### PR TITLE
M3: Wiki composition system — types, MCP CRUD, publishing, regen

### DIFF
--- a/core/drizzle/migrations/0002_content_storage.sql
+++ b/core/drizzle/migrations/0002_content_storage.sql
@@ -1,0 +1,42 @@
+-- Content storage: add content column to domain tables, source+diff to edits, update tsvector triggers
+
+ALTER TABLE "fragments" ADD COLUMN "content" text NOT NULL DEFAULT '';--> statement-breakpoint
+ALTER TABLE "wikis" ADD COLUMN "content" text NOT NULL DEFAULT '';--> statement-breakpoint
+ALTER TABLE "people" ADD COLUMN "content" text NOT NULL DEFAULT '';--> statement-breakpoint
+
+ALTER TABLE "edits"
+  ADD COLUMN "source" text NOT NULL DEFAULT 'user',
+  ADD COLUMN "diff" text NOT NULL DEFAULT '';--> statement-breakpoint
+
+-- Updated tsvector triggers to include content
+
+CREATE OR REPLACE FUNCTION wikis_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.prompt, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'C');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION fragments_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'B');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION people_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(array_to_string(NEW.aliases, ' '), '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.slug, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.relationship, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'C');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;

--- a/core/drizzle/migrations/0003_wiki_types.sql
+++ b/core/drizzle/migrations/0003_wiki_types.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "wiki_types" (
+  "slug" text PRIMARY KEY,
+  "name" text NOT NULL,
+  "short_descriptor" text NOT NULL DEFAULT '',
+  "descriptor" text NOT NULL DEFAULT '',
+  "prompt" text NOT NULL DEFAULT '',
+  "is_default" boolean NOT NULL DEFAULT false,
+  "user_modified" boolean NOT NULL DEFAULT false,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/core/drizzle/migrations/0004_public_wikis.sql
+++ b/core/drizzle/migrations/0004_public_wikis.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "wikis"
+  ADD COLUMN "published" boolean NOT NULL DEFAULT false,
+  ADD COLUMN "published_slug" text,
+  ADD COLUMN "published_at" timestamp,
+  ADD COLUMN "regenerate" boolean NOT NULL DEFAULT true;--> statement-breakpoint
+
+CREATE UNIQUE INDEX "wikis_published_slug_uidx" ON "wikis" ("published_slug")
+  WHERE "published_slug" IS NOT NULL;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781330400000,
       "tag": "0002_content_storage",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781416800000,
+      "tag": "0003_wiki_types",
+      "breakpoints": true
     }
   ]
 }

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775892107552,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781330400000,
+      "tag": "0002_content_storage",
+      "breakpoints": true
     }
   ]
 }

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781416800000,
       "tag": "0003_wiki_types",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781503200000,
+      "tag": "0004_public_wikis",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/__tests__/mcp-log-entry.test.ts
+++ b/core/src/__tests__/mcp-log-entry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 import { eq } from 'drizzle-orm'
 import { handleLogEntry, type McpServerDeps } from '../mcp/handlers.js'
 import { entries as entriesTable, vaults } from '../db/schema.js'
-import type { WriteJob } from '@robin/queue'
+import type { ExtractionJob } from '@robin/queue'
 import {
   ensureTestDatabase,
   pushTestSchema,
@@ -25,24 +25,17 @@ function makeDeps(overrides: Partial<McpServerDeps> = {}): McpServerDeps {
   return {
     db,
     producer: {
-      enqueueWrite: vi.fn().mockResolvedValue('job-id'),
-      enqueueReindex: vi.fn(),
-      enqueueProvision: vi.fn(),
-      enqueueExtraction: vi.fn(),
-      enqueueLinkJob: vi.fn(),
+      enqueueExtraction: vi.fn().mockResolvedValue('job-id'),
+      enqueueLink: vi.fn(),
       enqueueReclassify: vi.fn(),
-      enqueueSync: vi.fn(),
+      enqueueProvision: vi.fn(),
+      getQueue: vi.fn(),
+      close: vi.fn(),
     } as unknown as McpServerDeps['producer'],
-    gatewayClient: {
-      write: vi.fn().mockResolvedValue({ path: '', commitHash: 'abc', timestamp: '' }),
-      read: vi.fn(),
-      provision: vi.fn(),
-      search: vi.fn(),
-      reindex: vi.fn(),
-      batchWrite: vi.fn(),
-    } as unknown as McpServerDeps['gatewayClient'],
     spawnWriteWorker: vi.fn(),
     resolveDefaultVaultId: vi.fn().mockResolvedValue(testVaultId),
+    entityExtractCall: vi.fn().mockResolvedValue({ people: [] }),
+    loadUserPeople: vi.fn().mockResolvedValue([]),
     ...overrides,
   }
 }
@@ -68,7 +61,7 @@ beforeEach(async () => {
 // ─── Tests ───
 
 describe('handleLogEntry', () => {
-  it('inserts entry row in PENDING state before enqueuing write job', async () => {
+  it('inserts entry row in PENDING state before enqueuing extraction job', async () => {
     const deps = makeDeps()
     const result = await handleLogEntry(deps, { content: 'Hello world' }, testUserId)
 
@@ -76,7 +69,7 @@ describe('handleLogEntry', () => {
     expect(result.content[0].text).toContain('Entry queued: entry')
 
     // Verify entry row exists in DB
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows).toHaveLength(1)
     expect(rows[0].state).toBe('PENDING')
     expect(rows[0].content).toBe('Hello world')
@@ -86,58 +79,21 @@ describe('handleLogEntry', () => {
     expect(rows[0].vaultId).toBe(testVaultId)
 
     // Verify enqueue was called after insert
-    expect(deps.producer.enqueueWrite).toHaveBeenCalledTimes(1)
-    const job = (deps.producer.enqueueWrite as ReturnType<typeof vi.fn>).mock
-      .calls[0][1] as WriteJob
-    expect(job.payload.entryId).toBe(rows[0].lookupKey)
-    expect(job.payload.rawEntry.content).toBe('Hello world')
-    expect(job.payload.rawEntry.source).toBe('mcp')
+    expect(deps.producer.enqueueExtraction).toHaveBeenCalledTimes(1)
+    const job = (deps.producer.enqueueExtraction as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as ExtractionJob
+    expect(job.entryKey).toBe(rows[0].lookupKey)
+    expect(job.content).toBe('Hello world')
+    expect(job.source).toBe('mcp')
   })
 
-  it('writes verbatim note to git before inserting entry', async () => {
+  it('stores content in DB entry row', async () => {
     const deps = makeDeps()
     await handleLogEntry(deps, { content: 'My note content' }, testUserId)
 
-    expect(deps.gatewayClient.write).toHaveBeenCalledTimes(1)
-    const writeCall = (deps.gatewayClient.write as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(writeCall.userId).toBe(testUserId)
-    expect(writeCall.path).toMatch(/^var\/raw\/\d{4}-\d{2}-\d{2}-my-note-content\.entry.+\.md$/)
-    expect(writeCall.content).toContain('My note content')
-    expect(writeCall.content).toContain('source: mcp')
-    expect(writeCall.branch).toBe('main')
-
-    // Entry repoPath should reflect the note path
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
-    expect(rows[0].repoPath).toMatch(/^var\/raw\//)
-  })
-
-  it('sets repoPath to empty string when git write fails (best-effort)', async () => {
-    const deps = makeDeps({
-      gatewayClient: {
-        write: vi.fn().mockRejectedValue(new Error('gateway down')),
-      } as unknown as McpServerDeps['gatewayClient'],
-    })
-
-    const result = await handleLogEntry(deps, { content: 'Content here' }, testUserId)
-
-    expect(result.isError).toBeUndefined()
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
-    expect(rows[0].repoPath).toBe('')
-
-    // Job should still be enqueued
-    expect(deps.producer.enqueueWrite).toHaveBeenCalledTimes(1)
-    const job = (deps.producer.enqueueWrite as ReturnType<typeof vi.fn>).mock
-      .calls[0][1] as WriteJob
-    expect(job.payload.noteFilePath).toBeUndefined()
-  })
-
-  it('includes noteFilePath in job payload when git write succeeds', async () => {
-    const deps = makeDeps()
-    await handleLogEntry(deps, { content: 'A note' }, testUserId)
-
-    const job = (deps.producer.enqueueWrite as ReturnType<typeof vi.fn>).mock
-      .calls[0][1] as WriteJob
-    expect(job.payload.noteFilePath).toMatch(/^var\/raw\//)
+    const rows = await db.select().from(entriesTable)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].content).toBe('My note content')
   })
 
   it('sets title from first 80 chars of content', async () => {
@@ -145,7 +101,7 @@ describe('handleLogEntry', () => {
     const deps = makeDeps()
     await handleLogEntry(deps, { content: longContent }, testUserId)
 
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows[0].title).toBe('A'.repeat(80))
   })
 
@@ -153,7 +109,7 @@ describe('handleLogEntry', () => {
     const deps = makeDeps()
     await handleLogEntry(deps, { content: '  spaced content  ' }, testUserId)
 
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows[0].content).toBe('spaced content')
   })
 
@@ -163,7 +119,7 @@ describe('handleLogEntry', () => {
 
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain('content is required')
-    expect(deps.producer.enqueueWrite).not.toHaveBeenCalled()
+    expect(deps.producer.enqueueExtraction).not.toHaveBeenCalled()
   })
 
   it('returns error for whitespace-only content', async () => {
@@ -180,26 +136,26 @@ describe('handleLogEntry', () => {
 
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain('not authenticated')
-    expect(deps.producer.enqueueWrite).not.toHaveBeenCalled()
+    expect(deps.producer.enqueueExtraction).not.toHaveBeenCalled()
   })
 
   it('respects source parameter override', async () => {
     const deps = makeDeps()
     await handleLogEntry(deps, { content: 'From web', source: 'web' }, testUserId)
 
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows[0].source).toBe('web')
 
-    const job = (deps.producer.enqueueWrite as ReturnType<typeof vi.fn>).mock
-      .calls[0][1] as WriteJob
-    expect(job.payload.rawEntry.source).toBe('web')
+    const job = (deps.producer.enqueueExtraction as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as ExtractionJob
+    expect(job.source).toBe('web')
   })
 
   it('defaults source to mcp when not specified', async () => {
     const deps = makeDeps()
     await handleLogEntry(deps, { content: 'No source' }, testUserId)
 
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows[0].source).toBe('mcp')
   })
 
@@ -209,7 +165,7 @@ describe('handleLogEntry', () => {
     })
     await handleLogEntry(deps, { content: 'No vault' }, testUserId)
 
-    const rows = await db.select().from(entriesTable).where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     expect(rows[0].vaultId).toBeNull()
   })
 
@@ -224,13 +180,11 @@ describe('handleLogEntry', () => {
     // Insert an entry that will claim the slug 'hello'
     await db.insert(entriesTable).values({
       lookupKey: 'conflict-key',
-      userId: testUserId,
       slug: 'hello',
       title: 'Hello',
       content: 'Hello',
       type: 'thought',
       source: 'mcp',
-      repoPath: '',
     })
 
     // A second entry with the same content should get slug 'hello-2'
@@ -239,10 +193,7 @@ describe('handleLogEntry', () => {
 
     expect(result.isError).toBeUndefined()
 
-    const rows = await db
-      .select()
-      .from(entriesTable)
-      .where(eq(entriesTable.userId, testUserId))
+    const rows = await db.select().from(entriesTable)
     const slugs = rows.map((r) => r.slug).sort()
     expect(slugs).toContain('hello')
     expect(slugs).toContain('hello-2')

--- a/core/src/__tests__/mcp-log-fragment.test.ts
+++ b/core/src/__tests__/mcp-log-fragment.test.ts
@@ -32,22 +32,13 @@ function makeDeps(overrides: Partial<McpServerDeps> = {}): McpServerDeps {
   return {
     db,
     producer: {
-      enqueueWrite: vi.fn().mockResolvedValue('job-id'),
-      enqueueReindex: vi.fn(),
-      enqueueProvision: vi.fn(),
-      enqueueExtraction: vi.fn(),
-      enqueueLinkJob: vi.fn(),
+      enqueueExtraction: vi.fn().mockResolvedValue('job-id'),
+      enqueueLink: vi.fn(),
       enqueueReclassify: vi.fn(),
-      enqueueSync: vi.fn(),
+      enqueueProvision: vi.fn(),
+      getQueue: vi.fn(),
+      close: vi.fn(),
     } as unknown as McpServerDeps['producer'],
-    gatewayClient: {
-      write: vi.fn().mockResolvedValue({ path: '', commitHash: 'abc', timestamp: '' }),
-      read: vi.fn(),
-      provision: vi.fn(),
-      search: vi.fn(),
-      reindex: vi.fn(),
-      batchWrite: vi.fn().mockResolvedValue({ commitHash: 'abc123' }),
-    } as unknown as McpServerDeps['gatewayClient'],
     spawnWriteWorker: vi.fn(),
     resolveDefaultVaultId: vi.fn().mockResolvedValue(testVaultId),
     entityExtractCall: vi.fn().mockResolvedValue({ people: [] }),
@@ -61,13 +52,12 @@ async function createTestThread() {
     .insert(threadsTable)
     .values({
       lookupKey: TEST_THREAD_KEY,
-      userId: testUserId,
       slug: TEST_THREAD_SLUG,
       name: 'Fitness',
       type: 'log',
       state: 'RESOLVED',
       vaultId: testVaultId,
-    } as any)
+    })
     .onConflictDoNothing()
 }
 
@@ -107,7 +97,7 @@ describe('handleLogFragment', () => {
     expect(parsed.threadSlug).toBe(TEST_THREAD_SLUG)
     expect(parsed.wikiKey).toBe(TEST_THREAD_KEY)
 
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
+    const rows = await db.select().from(fragmentsTable)
     expect(rows).toHaveLength(1)
     expect(rows[0].state).toBe('RESOLVED')
     expect(rows[0].type).toBe('observation')
@@ -115,7 +105,7 @@ describe('handleLogFragment', () => {
     expect(rows[0].entryId).toBeNull()
   })
 
-  it('writes fragment file to gateway via batchWrite', async () => {
+  it('stores fragment content in DB', async () => {
     const deps = makeDeps()
     await handleLogFragment(
       deps,
@@ -123,14 +113,9 @@ describe('handleLogFragment', () => {
       testUserId
     )
 
-    expect(deps.gatewayClient.batchWrite).toHaveBeenCalledTimes(1)
-    const call = (deps.gatewayClient.batchWrite as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call.userId).toBe(testUserId)
-    expect(call.files[0].path).toMatch(/^fragments\/\d{8}-morning-run-notes-[a-z0-9]+\.frag.+\.md$/)
-    expect(call.files[0].content).toContain('Morning run notes')
-    expect(call.files[0].content).toContain('status: RESOLVED')
-    expect(call.files[0].content).toContain(TEST_THREAD_KEY)
-    expect(call.branch).toBe('main')
+    const rows = await db.select().from(fragmentsTable)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].content).toContain('Morning run notes')
   })
 
   it('inserts FRAGMENT_IN_WIKI edge', async () => {
@@ -163,7 +148,7 @@ describe('handleLogFragment', () => {
       .select()
       .from(threadsTable)
       .where(eq(threadsTable.lookupKey, TEST_THREAD_KEY))
-    expect(thread.state).toBe('DIRTY')
+    expect(thread.state).toBe('PENDING')
   })
 
   it('uses provided title when given', async () => {
@@ -178,7 +163,7 @@ describe('handleLogFragment', () => {
       testUserId
     )
 
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
+    const rows = await db.select().from(fragmentsTable)
     expect(rows[0].title).toBe('Custom Title')
   })
 
@@ -191,7 +176,7 @@ describe('handleLogFragment', () => {
       testUserId
     )
 
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
+    const rows = await db.select().from(fragmentsTable)
     expect(rows[0].title).toBe('A'.repeat(80))
   })
 
@@ -207,7 +192,7 @@ describe('handleLogFragment', () => {
       testUserId
     )
 
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
+    const rows = await db.select().from(fragmentsTable)
     expect(rows[0].tags).toEqual(['fitness', 'running'])
   })
 
@@ -250,27 +235,9 @@ describe('handleLogFragment', () => {
     )
 
     expect(result.isError).toBeUndefined()
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
+    const rows = await db.select().from(fragmentsTable)
     expect(rows).toHaveLength(1)
     expect(rows[0].state).toBe('RESOLVED')
-  })
-
-  it('sets repoPath to empty string when gateway write fails', async () => {
-    const deps = makeDeps({
-      gatewayClient: {
-        batchWrite: vi.fn().mockRejectedValue(new Error('gateway down')),
-      } as unknown as McpServerDeps['gatewayClient'],
-    })
-
-    const result = await handleLogFragment(
-      deps,
-      { content: 'Content here', threadSlug: TEST_THREAD_SLUG },
-      testUserId
-    )
-
-    expect(result.isError).toBeUndefined()
-    const rows = await db.select().from(fragmentsTable).where(eq(fragmentsTable.userId, testUserId))
-    expect(rows[0].repoPath).toBe('')
   })
 
   it('returns error when threadSlug not found', async () => {
@@ -337,21 +304,9 @@ describe('handleLogFragment', () => {
     )
 
     expect(result.isError).toBeUndefined()
-    const personRows = await db.select().from(peopleTable).where(eq(peopleTable.userId, testUserId))
+    const personRows = await db.select().from(peopleTable)
     expect(personRows).toHaveLength(1)
     expect(personRows[0].name).toBe('Sarah Connor')
     expect(personRows[0].state).toBe('RESOLVED')
-  })
-
-  it('frontmatter omits entryKey field', async () => {
-    const deps = makeDeps()
-    await handleLogFragment(
-      deps,
-      { content: 'No entry parent', threadSlug: TEST_THREAD_SLUG },
-      testUserId
-    )
-
-    const call = (deps.gatewayClient.batchWrite as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call.files[0].content).not.toContain('entryKey')
   })
 })

--- a/core/src/__tests__/mcp-resolvers.test.ts
+++ b/core/src/__tests__/mcp-resolvers.test.ts
@@ -80,11 +80,11 @@ describe('resolveSlug', () => {
   })
 })
 
-// ─── Resolver integration tests (real DB, mocked gateway) ───
+// ─── Resolver integration tests (real DB) ───
 
 import type postgres from 'postgres'
 import type { McpResolverDeps } from '../mcp/resolvers.js'
-import { listThreads, getThread, getFragment, getPerson } from '../mcp/resolvers.js'
+import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery } from '../mcp/resolvers.js'
 import { makeLookupKey, ObjectType } from '@robin/shared'
 import { entries, fragments, wikis, people, edges } from '../db/schema.js'
 import {
@@ -96,21 +96,6 @@ import {
   createTestVault,
   clearTestData,
 } from './test-setup.js'
-
-function mockGateway(readResults: Record<string, string> = {}): McpResolverDeps['gatewayClient'] {
-  return {
-    read: async (_userId: string, path: string) => {
-      const content = readResults[path]
-      if (content === undefined) throw new Error(`Not found: ${path}`)
-      return { path, content, commitHash: 'abc123' }
-    },
-    provision: async () => ({ status: 'ok', userId: '' }),
-    write: async () => ({ path: '', commitHash: '', timestamp: '' }),
-    search: async () => ({ results: [], count: 0 }),
-    reindex: async () => ({ status: 'ok' }),
-    batchWrite: async () => ({ commitHash: '', fileCount: 0, timestamp: '' }),
-  } as McpResolverDeps['gatewayClient']
-}
 
 describe('MCP resolvers (real DB)', () => {
   let db: ReturnType<typeof getTestDb>['db']
@@ -152,45 +137,40 @@ describe('MCP resolvers (real DB)', () => {
 
     await db.insert(entries).values({
       lookupKey: entryKey,
-      userId: testUserId,
       slug: 'mcp-test-entry',
       state: 'RESOLVED',
-      repoPath: 'entries/mcp-test-entry.md',
       title: 'MCP Test Entry',
       content: 'Some content',
     })
 
     await db.insert(wikis).values({
       lookupKey: wikiKey,
-      userId: testUserId,
       slug: 'ai-infrastructure',
       name: 'AI Infrastructure & Startups',
       type: 'log',
       state: 'RESOLVED',
-      repoPath: 'wikis/ai-infrastructure.md',
+      content: '---\ntitle: AI\n---\nWiki body about AI infra.',
       lastRebuiltAt: new Date('2025-06-01'),
     })
 
     await db.insert(fragments).values([
       {
         lookupKey: fragKey1,
-        userId: testUserId,
         slug: 'vector-db-note',
         title: 'Vector DB Note',
         type: 'observation',
         tags: ['ai', 'databases'],
-        repoPath: 'fragments/vector-db-note.md',
+        content: '---\ntitle: Vector DB Note\ntags: [ai, databases]\n---\nContent about vector DBs.',
         entryId: entryKey,
         state: 'RESOLVED',
       },
       {
         lookupKey: fragKey2,
-        userId: testUserId,
         slug: 'startup-pivot',
         title: 'Startup Pivot Discussion',
         type: 'observation',
         tags: ['startups'],
-        repoPath: 'fragments/startup-pivot.md',
+        content: '---\ntitle: Pivot\n---\nStartup pivot snippet.',
         entryId: entryKey,
         state: 'RESOLVED',
       },
@@ -199,22 +179,20 @@ describe('MCP resolvers (real DB)', () => {
     await db.insert(people).values([
       {
         lookupKey: personKey1,
-        userId: testUserId,
         slug: 'david-chen',
         name: 'David Chen',
         relationship: 'colleague',
-        sections: { aliases: ['Dave', 'D. Chen'] },
-        repoPath: 'people/david-chen.md',
+        aliases: ['Dave', 'D. Chen'],
+        content: '---\nname: David Chen\n---\nPerson body about David.',
         state: 'RESOLVED',
       },
       {
         lookupKey: personKey2,
-        userId: testUserId,
         slug: 'sarah-jones',
         name: 'Sarah Jones',
         relationship: 'friend',
-        sections: { aliases: [] },
-        repoPath: 'people/sarah-jones.md',
+        aliases: [],
+        content: '',
         state: 'RESOLVED',
       },
     ])
@@ -223,7 +201,6 @@ describe('MCP resolvers (real DB)', () => {
     await db.insert(edges).values([
       {
         id: crypto.randomUUID(),
-        userId: testUserId,
         srcType: 'frag',
         srcId: fragKey1,
         dstType: 'wiki',
@@ -232,7 +209,6 @@ describe('MCP resolvers (real DB)', () => {
       },
       {
         id: crypto.randomUUID(),
-        userId: testUserId,
         srcType: 'frag',
         srcId: fragKey2,
         dstType: 'wiki',
@@ -241,7 +217,6 @@ describe('MCP resolvers (real DB)', () => {
       },
       {
         id: crypto.randomUUID(),
-        userId: testUserId,
         srcType: 'frag',
         srcId: fragKey1,
         dstType: 'person',
@@ -251,15 +226,11 @@ describe('MCP resolvers (real DB)', () => {
     ])
   })
 
-  // ─── listThreads ───
+  // ─── listWikis ───
 
-  describe('listThreads', () => {
+  describe('listWikis', () => {
     it('returns wikis with correct fragment counts from edge joins', async () => {
-      const gw = mockGateway({
-        'wikis/ai-infrastructure.md': '---\ntitle: AI\n---\nWiki body about AI infra.',
-      })
-
-      const result = await listThreads({ db, gatewayClient: gw }, testUserId)
+      const result = await listWikis({ db })
 
       expect(result).toHaveLength(1)
       expect(result[0].slug).toBe('ai-infrastructure')
@@ -269,9 +240,10 @@ describe('MCP resolvers (real DB)', () => {
       expect(result[0].lastRebuiltAt).toBe('2025-06-01T00:00:00.000Z')
     })
 
-    it('returns empty array for user with no wikis', async () => {
-      const gw = mockGateway()
-      const result = await listThreads({ db, gatewayClient: gw }, 'nonexistent-user')
+    it('returns empty array when no wikis exist', async () => {
+      await db.delete(edges)
+      await db.delete(wikis)
+      const result = await listWikis({ db })
       expect(result).toEqual([])
     })
 
@@ -281,8 +253,7 @@ describe('MCP resolvers (real DB)', () => {
         .set({ deletedAt: new Date() })
         .where(eq(wikis.lookupKey, wikiKey))
 
-      const gw = mockGateway()
-      const result = await listThreads({ db, gatewayClient: gw }, testUserId)
+      const result = await listWikis({ db })
       expect(result).toEqual([])
     })
 
@@ -290,16 +261,13 @@ describe('MCP resolvers (real DB)', () => {
       // Soft-delete one edge
       await db.update(edges).set({ deletedAt: new Date() }).where(eq(edges.srcId, fragKey2))
 
-      const gw = mockGateway({
-        'wikis/ai-infrastructure.md': '---\n---\nBody.',
-      })
-      const result = await listThreads({ db, gatewayClient: gw }, testUserId)
+      const result = await listWikis({ db })
       expect(result[0].fragmentCount).toBe(1)
     })
 
-    it('returns empty preview when gateway read fails', async () => {
-      const gw = mockGateway({}) // no content → throws
-      const result = await listThreads({ db, gatewayClient: gw }, testUserId)
+    it('returns empty preview when content is empty', async () => {
+      await db.update(wikis).set({ content: '' }).where(eq(wikis.lookupKey, wikiKey))
+      const result = await listWikis({ db })
       expect(result[0].wikiPreview).toBe('')
     })
   })
@@ -308,19 +276,13 @@ describe('MCP resolvers (real DB)', () => {
 
   describe('getThread', () => {
     it('resolves exact slug and returns wiki body + linked fragments', async () => {
-      const gw = mockGateway({
-        'wikis/ai-infrastructure.md': '---\ntitle: AI\n---\nFull wiki body.',
-        'fragments/vector-db-note.md': '---\ntitle: VDB\n---\nVector DB snippet content.',
-        'fragments/startup-pivot.md': '---\ntitle: Pivot\n---\nStartup pivot snippet.',
-      })
+      const result = await getThread({ db }, 'ai-infrastructure')
 
-      const result = await getThread({ db, gatewayClient: gw }, testUserId, 'ai-infrastructure')
-
-      expect('wiki' in result).toBe(true)
-      if ('wiki' in result) {
+      expect('thread' in result).toBe(true)
+      if ('thread' in result) {
         expect(result.thread.slug).toBe('ai-infrastructure')
         expect(result.thread.state).toBe('RESOLVED')
-        expect(result.wikiBody).toBe('Full wiki body.')
+        expect(result.wikiBody).toBe('Wiki body about AI infra.')
         expect(result.fragments).toHaveLength(2)
 
         const slugs = result.fragments.map((f) => f.slug).sort()
@@ -329,22 +291,15 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('resolves fuzzy slug match', async () => {
-      const gw = mockGateway({
-        'wikis/ai-infrastructure.md': '---\n---\nBody.',
-        'fragments/vector-db-note.md': '---\n---\nSnippet.',
-        'fragments/startup-pivot.md': '---\n---\nSnippet.',
-      })
-
-      const result = await getThread({ db, gatewayClient: gw }, testUserId, 'ai-infra')
-      expect('wiki' in result).toBe(true)
-      if ('wiki' in result) {
+      const result = await getThread({ db }, 'ai-infra')
+      expect('thread' in result).toBe(true)
+      if ('thread' in result) {
         expect(result.thread.slug).toBe('ai-infrastructure')
       }
     })
 
     it('returns error for no match', async () => {
-      const gw = mockGateway()
-      const result = await getThread({ db, gatewayClient: gw }, testUserId, 'zzz-nonexistent')
+      const result = await getThread({ db }, 'zzz-nonexistent')
       expect('error' in result).toBe(true)
       if ('error' in result) {
         expect(result.suggestions).toContain('ai-infrastructure')
@@ -354,14 +309,9 @@ describe('MCP resolvers (real DB)', () => {
     it('excludes soft-deleted fragment edges', async () => {
       await db.update(edges).set({ deletedAt: new Date() }).where(eq(edges.srcId, fragKey2))
 
-      const gw = mockGateway({
-        'wikis/ai-infrastructure.md': '---\n---\nBody.',
-        'fragments/vector-db-note.md': '---\n---\nSnippet.',
-      })
-
-      const result = await getThread({ db, gatewayClient: gw }, testUserId, 'ai-infrastructure')
-      expect('wiki' in result).toBe(true)
-      if ('wiki' in result) {
+      const result = await getThread({ db }, 'ai-infrastructure')
+      expect('thread' in result).toBe(true)
+      if ('thread' in result) {
         expect(result.fragments).toHaveLength(1)
         expect(result.fragments[0].slug).toBe('vector-db-note')
       }
@@ -372,12 +322,7 @@ describe('MCP resolvers (real DB)', () => {
 
   describe('getFragment', () => {
     it('resolves exact slug and returns content + frontmatter', async () => {
-      const gw = mockGateway({
-        'fragments/vector-db-note.md':
-          '---\ntitle: Vector DB Note\ntags: [ai, databases]\n---\nContent about vector DBs.',
-      })
-
-      const result = await getFragment({ db, gatewayClient: gw }, testUserId, 'vector-db-note')
+      const result = await getFragment({ db }, 'vector-db-note')
 
       expect('slug' in result).toBe(true)
       if ('slug' in result) {
@@ -390,11 +335,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('resolves fuzzy slug match', async () => {
-      const gw = mockGateway({
-        'fragments/vector-db-note.md': '---\n---\nContent.',
-      })
-
-      const result = await getFragment({ db, gatewayClient: gw }, testUserId, 'vector-db')
+      const result = await getFragment({ db }, 'vector-db')
       expect('slug' in result).toBe(true)
       if ('slug' in result) {
         expect(result.slug).toBe('vector-db-note')
@@ -402,8 +343,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('returns error for unknown slug', async () => {
-      const gw = mockGateway()
-      const result = await getFragment({ db, gatewayClient: gw }, testUserId, 'zzz-missing')
+      const result = await getFragment({ db }, 'zzz-missing')
       expect('error' in result).toBe(true)
     })
 
@@ -413,22 +353,16 @@ describe('MCP resolvers (real DB)', () => {
         .set({ deletedAt: new Date() })
         .where(eq(fragments.lookupKey, fragKey1))
 
-      const gw = mockGateway()
-      const result = await getFragment({ db, gatewayClient: gw }, testUserId, 'vector-db-note')
+      const result = await getFragment({ db }, 'vector-db-note')
       expect('error' in result).toBe(true)
     })
   })
 
-  // ─── getPerson ───
+  // ─── findPersonByQuery ───
 
-  describe('getPerson', () => {
+  describe('findPersonByQuery', () => {
     it('resolves exact name and returns body + linked fragments', async () => {
-      const gw = mockGateway({
-        'people/david-chen.md': '---\nname: David Chen\n---\nPerson body about David.',
-        'fragments/vector-db-note.md': '---\ntitle: VDB\n---\nHad lunch with David.',
-      })
-
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'David Chen')
+      const result = await findPersonByQuery({ db }, 'David Chen')
 
       expect('person' in result).toBe(true)
       if ('person' in result) {
@@ -443,12 +377,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('resolves alias match', async () => {
-      const gw = mockGateway({
-        'people/david-chen.md': '---\n---\nBody.',
-        'fragments/vector-db-note.md': '---\n---\nSnippet.',
-      })
-
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'Dave')
+      const result = await findPersonByQuery({ db }, 'Dave')
       expect('person' in result).toBe(true)
       if ('person' in result) {
         expect(result.person.name).toBe('David Chen')
@@ -456,12 +385,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('resolves fuzzy name match', async () => {
-      const gw = mockGateway({
-        'people/david-chen.md': '---\n---\nBody.',
-        'fragments/vector-db-note.md': '---\n---\nSnippet.',
-      })
-
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'david')
+      const result = await findPersonByQuery({ db }, 'david')
       expect('person' in result).toBe(true)
       if ('person' in result) {
         expect(result.person.name).toBe('David Chen')
@@ -469,8 +393,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('returns error with suggestions for no match', async () => {
-      const gw = mockGateway()
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'Zzz Nonexistent')
+      const result = await findPersonByQuery({ db }, 'Zzz Nonexistent')
       expect('error' in result).toBe(true)
       if ('error' in result) {
         expect(result.suggestions).toContain('David Chen')
@@ -480,8 +403,7 @@ describe('MCP resolvers (real DB)', () => {
     it('excludes soft-deleted people', async () => {
       await db.update(people).set({ deletedAt: new Date() }).where(eq(people.lookupKey, personKey1))
 
-      const gw = mockGateway()
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'David Chen')
+      const result = await findPersonByQuery({ db }, 'David Chen')
       expect('error' in result).toBe(true)
     })
 
@@ -489,15 +411,56 @@ describe('MCP resolvers (real DB)', () => {
       // Soft-delete the mention edge
       await db.update(edges).set({ deletedAt: new Date() }).where(eq(edges.dstId, personKey1))
 
-      const gw = mockGateway({
-        'people/david-chen.md': '---\n---\nBody.',
-      })
-
-      const result = await getPerson({ db, gatewayClient: gw }, testUserId, 'David Chen')
+      const result = await findPersonByQuery({ db }, 'David Chen')
       expect('person' in result).toBe(true)
       if ('person' in result) {
         expect(result.fragments).toHaveLength(0)
       }
+    })
+  })
+
+  // ─── findPersonById ───
+
+  describe('findPersonById', () => {
+    it('returns person by exact lookupKey', async () => {
+      const result = await findPersonById({ db }, personKey1)
+      expect('person' in result).toBe(true)
+      if ('person' in result) {
+        expect(result.person.name).toBe('David Chen')
+        expect(result.person.slug).toBe('david-chen')
+        expect(typeof result.body).toBe('string')
+        expect(result.body).toBe('Person body about David.')
+      }
+    })
+
+    it('returns error for unknown id', async () => {
+      const result = await findPersonById({ db }, 'person01ZZZZZZZZZZZZZZZZZZZZZZZZZZ')
+      expect('error' in result).toBe(true)
+    })
+
+    it('returns linked fragments', async () => {
+      const result = await findPersonById({ db }, personKey1)
+      expect('person' in result).toBe(true)
+      if ('person' in result) {
+        expect(result.fragments).toHaveLength(1)
+        expect(result.fragments[0].slug).toBe('vector-db-note')
+      }
+    })
+
+    it('excludes soft-deleted people', async () => {
+      await db.update(people).set({ deletedAt: new Date() }).where(eq(people.lookupKey, personKey1))
+      const result = await findPersonById({ db }, personKey1)
+      expect('error' in result).toBe(true)
+    })
+  })
+
+  // ─── find_person routing ───
+
+  describe('find_person routing', () => {
+    it('detects lookupKey pattern correctly', () => {
+      expect(/^person[0-9A-Z]{26}$/i.test('person01ABCDEFGHIJKLMNOPQRSTUVWX')).toBe(true)
+      expect(/^person[0-9A-Z]{26}$/i.test('David Chen')).toBe(false)
+      expect(/^person[0-9A-Z]{26}$/i.test('david-chen')).toBe(false)
     })
   })
 })

--- a/core/src/__tests__/test-setup.ts
+++ b/core/src/__tests__/test-setup.ts
@@ -89,7 +89,6 @@ export async function createTestVault(
     .insert(schema.vaults)
     .values({
       id: TEST_VAULT_ID,
-      userId: TEST_USER_ID,
       name: 'Test Vault',
       slug: 'test-vault',
     })

--- a/core/src/bootstrap/seed-wiki-types.ts
+++ b/core/src/bootstrap/seed-wiki-types.ts
@@ -1,0 +1,35 @@
+import { db } from '../db/client.js'
+import { wikiTypes } from '../db/schema.js'
+import { loadWikiTypeConfigs } from '@robin/shared'
+import { logger } from '../lib/logger.js'
+
+const log = logger.child({ component: 'seed-wiki-types' })
+
+/**
+ * Seed default wiki types from YAML configs.
+ * Uses INSERT ... ON CONFLICT DO NOTHING -- safe to call multiple times,
+ * never overwrites user-modified rows.
+ */
+export async function seedWikiTypes(): Promise<{ seeded: number }> {
+  const configs = loadWikiTypeConfigs()
+
+  let seeded = 0
+  for (const config of configs) {
+    const result = await db
+      .insert(wikiTypes)
+      .values({
+        slug: config.slug,
+        name: config.name,
+        shortDescriptor: config.shortDescriptor,
+        descriptor: config.descriptor,
+        prompt: config.prompt,
+        isDefault: true,
+        userModified: false,
+      })
+      .onConflictDoNothing()
+    seeded += result.count ?? 0
+  }
+
+  log.info({ seeded, total: configs.length }, 'wiki types seeded')
+  return { seeded }
+}

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -123,6 +123,20 @@ export const configs = pgTable(
   ]
 )
 
+// ─── Wiki Types (first-class type registry — seeded from YAML, user-customizable) ───
+
+export const wikiTypes = pgTable('wiki_types', {
+  slug: text('slug').primaryKey(),
+  name: text('name').notNull(),
+  shortDescriptor: text('short_descriptor').notNull().default(''),
+  descriptor: text('descriptor').notNull().default(''),
+  prompt: text('prompt').notNull().default(''),
+  isDefault: boolean('is_default').notNull().default(false),
+  userModified: boolean('user_modified').notNull().default(false),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
 // ─── State Enum ───
 
 export const objectStateEnum = pgEnum('object_state', ['PENDING', 'LINKING', 'RESOLVED'])

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -134,6 +134,7 @@ function baseColumns() {
     lookupKey: text('lookup_key').primaryKey(),
     slug: text('slug').notNull(),
     state: objectStateEnum('state').notNull().default('PENDING'),
+    content: text('content').notNull().default(''),
     dedupHash: text('dedup_hash'),
     lockedBy: text('locked_by'),
     lockedAt: timestamp('locked_at'),
@@ -152,7 +153,6 @@ export const entries = pgTable(
   {
     ...baseColumns(),
     title: text('title').notNull().default(''),
-    content: text('content').notNull().default(''),
     type: text('type').notNull().default('thought'),
     source: text('source').notNull().default('api'),
     vaultId: text('vault_id').references(() => vaults.id, {
@@ -237,6 +237,8 @@ export const edits = pgTable(
     timestamp: timestamp('timestamp').defaultNow().notNull(),
     type: text('type').notNull().default('addition'),
     content: text('content').notNull(),
+    source: text('source').notNull().default('user'),
+    diff: text('diff').notNull().default(''),
   },
   (t) => [index('edits_object_idx').on(t.objectType, t.objectId)]
 )

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -213,10 +213,17 @@ export const wikis = pgTable(
       onDelete: 'set null',
     }),
     lastRebuiltAt: timestamp('last_rebuilt_at'),
+    published: boolean('published').notNull().default(false),
+    publishedSlug: text('published_slug'),
+    publishedAt: timestamp('published_at'),
+    regenerate: boolean('regenerate').notNull().default(true),
     embedding: vector('embedding', { dimensions: 1536 }),
     searchVector: tsvector('search_vector'),
   },
-  (t) => [uniqueIndex('wikis_slug_uidx').on(t.slug)]
+  (t) => [
+    uniqueIndex('wikis_slug_uidx').on(t.slug),
+    uniqueIndex('wikis_published_slug_uidx').on(t.publishedSlug),
+  ]
 )
 
 export const people = pgTable(

--- a/core/src/db/slug.ts
+++ b/core/src/db/slug.ts
@@ -1,7 +1,10 @@
 import { eq } from 'drizzle-orm'
-import { entries, fragments } from './schema.js'
+import { customAlphabet } from 'nanoid'
+import { entries, fragments, wikis } from './schema.js'
 import { checkSlugCollision } from '@robin/shared'
 import type { DB } from './client.js'
+
+const nanoid6 = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 6)
 
 /**
  * @summary Resolve a unique slug for an entry, appending -2, -3 etc. on collision.
@@ -37,4 +40,34 @@ export async function resolveFragmentSlug(database: DB, slug: string): Promise<s
       .limit(1)
     return !!existing
   })
+}
+
+/**
+ * @summary Resolve a unique slug for a wiki, appending a nanoid(6) suffix on collision.
+ *
+ * Unlike entry/fragment slug resolution (which appends -2, -3, etc.), wiki slugs
+ * use a random suffix to avoid predictable URLs.
+ *
+ * @param database - Drizzle db instance
+ * @param slug     - Candidate slug from generateSlug()
+ * @returns A slug guaranteed unique in the wikis table
+ */
+export async function resolveWikiSlug(database: DB, slug: string): Promise<string> {
+  const exists = async (candidate: string) => {
+    const [row] = await database
+      .select({ key: wikis.lookupKey })
+      .from(wikis)
+      .where(eq(wikis.slug, candidate))
+      .limit(1)
+    return !!row
+  }
+
+  if (!(await exists(slug))) return slug
+
+  for (let i = 0; i < 5; i++) {
+    const candidate = `${slug}-${nanoid6()}`
+    if (!(await exists(candidate))) return candidate
+  }
+
+  throw new Error(`Slug collision: could not disambiguate "${slug}" after 5 attempts`)
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -18,6 +18,7 @@ import { peopleRoutes } from './routes/people.js'
 import { graphRoutes } from './routes/graph.js'
 import { relationshipsRoutes } from './routes/relationships.js'
 import { contentRoutes } from './routes/content.js'
+import { wikiTypesRoutes } from './routes/wiki-types.js'
 // M2 dormant: internalRoutes is the git-sync webhook, preserved verbatim in
 // src/routes/internal.ts for M3/M4 refinement. Gateway is gone in M2 so the
 // route is not mounted. Restore when sync-back lands.
@@ -112,6 +113,7 @@ app.route('/people', peopleRoutes)
 app.route('/graph', graphRoutes)
 app.route('/relationships', relationshipsRoutes)
 app.route('/api/content', contentRoutes)
+app.route('/wiki-types', wikiTypesRoutes)
 
 /***********************************************************************
  * ## Boot

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -19,6 +19,7 @@ import { graphRoutes } from './routes/graph.js'
 import { relationshipsRoutes } from './routes/relationships.js'
 import { contentRoutes } from './routes/content.js'
 import { wikiTypesRoutes } from './routes/wiki-types.js'
+import { publishedRoutes } from './routes/published.js'
 // M2 dormant: internalRoutes is the git-sync webhook, preserved verbatim in
 // src/routes/internal.ts for M3/M4 refinement. Gateway is gone in M2 so the
 // route is not mounted. Restore when sync-back lands.
@@ -95,6 +96,7 @@ app.get('/openapi.json', (c) => c.json(openapiSpec))
 // M2 dormant: git-sync webhook. See import comment above.
 // app.route('/internal', internalRoutes)
 app.route('/admin', adminRoutes)
+app.route('/published', publishedRoutes)
 app.use('/api/auth/*', (c) => auth.handler(c.req.raw))
 app.route('/admin/queues', bullBoardApp)
 

--- a/core/src/lib/id.ts
+++ b/core/src/lib/id.ts
@@ -5,3 +5,9 @@ export const nanoid = customAlphabet(
   '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
   21
 )
+
+/** 24-char nanoid for published wiki slugs */
+export const nanoid24 = customAlphabet(
+  '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  24
+)

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -42,6 +42,7 @@ import {
   wikis as threadsTable,
   edges as edgesTable,
   people as peopleTable,
+  wikiTypes as wikiTypesTable,
 } from '../db/schema.js'
 import { resolveThreadBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
@@ -346,6 +347,97 @@ export async function handleLogFragment(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     log.error({ err, userId }, 'mcp log_fragment failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `create_wiki_type` MCP tool call.
+ *
+ * @summary Create a custom wiki type with guardrails for slug format,
+ * conflict detection, and required fields.
+ */
+export async function handleCreateWikiType(
+  deps: McpServerDeps,
+  input: {
+    slug: string
+    name: string
+    shortDescriptor: string
+    descriptor: string
+    prompt?: string
+  }
+) {
+  try {
+    // Normalize slug
+    const slug = input.slug
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '')
+
+    if (!slug) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: slug is required and must contain alphanumeric characters or hyphens' }],
+        isError: true as const,
+      }
+    }
+
+    if (!input.name?.trim()) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: name is required' }],
+        isError: true as const,
+      }
+    }
+
+    if (!input.shortDescriptor?.trim()) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: shortDescriptor is required' }],
+        isError: true as const,
+      }
+    }
+
+    if (!input.descriptor?.trim()) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: descriptor is required' }],
+        isError: true as const,
+      }
+    }
+
+    // Check for slug conflict
+    const [existing] = await deps.db
+      .select({ slug: wikiTypesTable.slug })
+      .from(wikiTypesTable)
+      .where(eq(wikiTypesTable.slug, slug))
+    if (existing) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: wiki type "${slug}" already exists` }],
+        isError: true as const,
+      }
+    }
+
+    const prompt = input.prompt?.trim() || `You are Quill. Generate a ${input.name.trim()} document.`
+
+    const [created] = await deps.db
+      .insert(wikiTypesTable)
+      .values({
+        slug,
+        name: input.name.trim(),
+        shortDescriptor: input.shortDescriptor.trim(),
+        descriptor: input.descriptor.trim(),
+        prompt,
+        isDefault: false,
+        userModified: true,
+      })
+      .returning()
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(created) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err }, 'mcp create_wiki_type failed')
     return {
       content: [{ type: 'text' as const, text: `Error: ${message}` }],
       isError: true as const,

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -33,7 +33,7 @@ import {
 } from '@robin/shared'
 import type { PeopleExtractionOutput } from '@robin/shared'
 import type { BullMQProducer, ExtractionJob } from '@robin/queue'
-import { resolveEntrySlug } from '../db/slug.js'
+import { resolveEntrySlug, resolveWikiSlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateEntry } from '../db/dedup.js'
 import type { DB } from '../db/client.js'
 import {
@@ -43,12 +43,15 @@ import {
   edges as edgesTable,
   people as peopleTable,
   wikiTypes as wikiTypesTable,
+  edits as editsTable,
 } from '../db/schema.js'
 import { resolveThreadBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
+import { inferWikiType } from './wiki-type-inference.js'
 import { resolvePerson, DEFAULT_RESOLUTION_CONFIG } from '@robin/agent'
 import type { KnownPerson } from '@robin/agent'
-import { eq } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
+import { nanoid } from '../lib/id.js'
 import { logger } from '../lib/logger.js'
 
 const log = logger.child({ component: 'mcp' })
@@ -438,6 +441,154 @@ export async function handleCreateWikiType(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     log.error({ err }, 'mcp create_wiki_type failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `create_wiki` MCP tool call.
+ *
+ * @summary Creates a new wiki with an inferred type based on description.
+ * Slug collisions are resolved with a nanoid(6) suffix.
+ */
+export async function handleCreateWiki(
+  deps: McpServerDeps,
+  input: { title: string; description?: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+
+  if (!input.title?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: title is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const slug = generateSlug(input.title.trim())
+    const finalSlug = await resolveWikiSlug(deps.db, slug)
+    const lookupKey = makeLookupKey('wiki')
+    const inferredType = inferWikiType(input.description ?? '')
+
+    await deps.db.insert(threadsTable).values({
+      lookupKey,
+      slug: finalSlug,
+      name: input.title.trim(),
+      type: inferredType,
+      state: 'PENDING',
+      prompt: '',
+    })
+
+    const result = { slug: finalSlug, lookupKey, inferredType }
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp create_wiki failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `edit_wiki` MCP tool call.
+ *
+ * @summary Updates a wiki's canonical content and stores the previous
+ * content as an edit record tagged `source: 'mcp'`.
+ */
+export async function handleEditWiki(
+  deps: McpServerDeps,
+  input: { wikiSlug: string; content: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+
+  if (!input.wikiSlug?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: wikiSlug is required' }],
+      isError: true as const,
+    }
+  }
+
+  if (!input.content?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: content is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    // Resolve wiki by exact slug match (exclude soft-deleted)
+    const [wiki] = await deps.db
+      .select({
+        lookupKey: threadsTable.lookupKey,
+        slug: threadsTable.slug,
+        content: threadsTable.content,
+      })
+      .from(threadsTable)
+      .where(and(eq(threadsTable.slug, input.wikiSlug.trim()), isNull(threadsTable.deletedAt)))
+      .limit(1)
+
+    if (!wiki) {
+      // Provide suggestions via resolveThreadBySlug
+      const resolverDeps: McpResolverDeps = { db: deps.db }
+      const resolved = await resolveThreadBySlug(resolverDeps, input.wikiSlug.trim())
+      if ('error' in resolved) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(resolved) }],
+          isError: true as const,
+        }
+      }
+      // Shouldn't reach here if resolveThreadBySlug returned an error
+      return {
+        content: [{ type: 'text' as const, text: `Error: wiki "${input.wikiSlug}" not found` }],
+        isError: true as const,
+      }
+    }
+
+    const previousContent = wiki.content || ''
+
+    // Update canonical content
+    await deps.db
+      .update(threadsTable)
+      .set({ content: input.content, updatedAt: new Date() })
+      .where(eq(threadsTable.lookupKey, wiki.lookupKey))
+
+    // Store previous content as edit record (diff computation deferred)
+    await deps.db.insert(editsTable).values({
+      id: nanoid(),
+      objectType: 'wiki',
+      objectId: wiki.lookupKey,
+      type: 'addition',
+      content: previousContent,
+      diff: '',
+      source: 'mcp',
+    })
+
+    const result = { wikiSlug: wiki.slug, lookupKey: wiki.lookupKey, recorded: true }
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp edit_wiki failed')
     return {
       content: [{ type: 'text' as const, text: `Error: ${message}` }],
       isError: true as const,

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -18,7 +18,6 @@
  *
  * **Fail-open semantics:**
  * - Entity extraction errors → fragment persisted without people edges.
- * - Git gateway down → DB row created with empty `repoPath`; sync reconciles.
  * - Thread marked DIRTY after insert → wiki regen picks it up next cycle.
  *
  * @see {@link handleLogEntry} — pipeline entry point
@@ -30,15 +29,12 @@ import {
   makeLookupKey,
   parseLookupKey,
   generateSlug,
-  composeFilename,
   loadPeopleExtractionSpec,
 } from '@robin/shared'
 import type { PeopleExtractionOutput } from '@robin/shared'
-import type { BullMQProducer } from '@robin/queue'
+import type { BullMQProducer, ExtractionJob } from '@robin/queue'
 import { resolveEntrySlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateEntry } from '../db/dedup.js'
-import type { WriteJob } from '@robin/queue'
-import type { gatewayClient as GatewayClient } from '../gateway/client.js'
 import type { DB } from '../db/client.js'
 import {
   entries as entriesTable,
@@ -49,7 +45,6 @@ import {
 } from '../db/schema.js'
 import { resolveThreadBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { assembleFragmentFrontmatter, assemblePersonFrontmatter } from '@robin/agent'
 import { resolvePerson, DEFAULT_RESOLUTION_CONFIG } from '@robin/agent'
 import type { KnownPerson } from '@robin/agent'
 import { eq } from 'drizzle-orm'
@@ -63,11 +58,10 @@ const log = logger.child({ component: 'mcp' })
  *
  * @remarks
  * Deliberately broader than {@link McpResolverDeps} — handlers need
- * write access (producer, gateway writes) plus LLM calls for entity
- * extraction, while resolvers only need reads.
+ * write access (producer) plus LLM calls for entity extraction, while
+ * resolvers only need reads.
  *
  * @property producer              - BullMQ producer for enqueuing pipeline jobs
- * @property gatewayClient         - Git gateway for reads/writes to user repos
  * @property db                    - Drizzle database instance
  * @property spawnWriteWorker      - Ensures a write worker exists for the user
  * @property resolveDefaultVaultId - Returns the user's inbox vault ID
@@ -76,7 +70,6 @@ const log = logger.child({ component: 'mcp' })
  */
 export interface McpServerDeps {
   producer: BullMQProducer
-  gatewayClient: typeof GatewayClient
   db: DB
   spawnWriteWorker: (userId: string) => void
   resolveDefaultVaultId: (userId: string) => Promise<string | null>
@@ -90,32 +83,18 @@ export interface McpServerDeps {
  * @summary Captures a raw thought and feeds it into the full AI
  * ingestion pipeline (6 stages via BullMQ).
  *
- * @remarks
- * This is the primary entry point for MCP clients that want Robin to
- * classify, fragment, and file their content automatically.
- *
- * @param deps   - Injected dependencies (db, gateway, producer, etc.)
+ * @param deps   - Injected dependencies (db, producer, etc.)
  * @param input  - The raw content and optional source tag
  * @param userId - Authenticated user ID (`undefined` = not authenticated)
  * @returns MCP-shaped response with entry key or error
  *
  * @throws Never — all errors are caught and returned as `{ isError: true }`
- *
- * @example
- * ```ts
- * const result = await handleLogEntry(deps,
- *   { content: 'Had coffee with Sarah' },
- *   userId
- * )
- * // → { content: [{ type: 'text', text: 'Entry queued: entry01...' }] }
- * ```
  */
 export async function handleLogEntry(
   deps: McpServerDeps,
   input: { content: string; source?: 'mcp' | 'api' | 'web' },
   userId: string | undefined
 ) {
-  /** @gate — Reject unauthenticated requests */
   if (!userId) {
     return {
       content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
@@ -123,7 +102,6 @@ export async function handleLogEntry(
     }
   }
 
-  /** @gate — Reject empty content */
   const trimmed = input.content?.trim()
   if (!trimmed) {
     return {
@@ -133,47 +111,24 @@ export async function handleLogEntry(
   }
 
   try {
-    /** @gate — Reject duplicate content */
     const hash = computeContentHash(trimmed)
-    const dup = await findDuplicateEntry(deps.db, userId, hash)
+    const dup = await findDuplicateEntry(deps.db, hash)
     if (dup) {
       return {
         content: [{ type: 'text' as const, text: `Duplicate: entry ${dup.lookupKey} already contains this content` }],
       }
     }
 
-    /** @step 1 — Generate entry identifiers and resolve default vault */
     const entryKey = makeLookupKey('entry')
     const { ulid: entryUlid } = parseLookupKey(entryKey)
     const defaultVaultId = await deps.resolveDefaultVaultId(userId)
     const title = trimmed.slice(0, 80)
-    const slug = await resolveEntrySlug(deps.db, userId, generateSlug(title))
+    const slug = await resolveEntrySlug(deps.db, generateSlug(title))
     const entrySource = input.source ?? 'mcp'
     const now = new Date()
-    const dateStr = now.toISOString().split('T')[0]
 
-    /** @step 2 — Write verbatim note to git (mirrors POST /entries) */
-    const noteFilePath = `var/raw/${dateStr}-${slug}.${entryKey}.md`
-    const noteContent = `---\ncreated_at: ${now.toISOString()}\nsource: ${entrySource}\nentry_id: ${entryKey}\n---\n\n${trimmed}`
-    let noteWriteOk = false
-    try {
-      await deps.gatewayClient.write({
-        userId,
-        path: noteFilePath,
-        content: noteContent,
-        message: `note: raw entry ${entryUlid.slice(0, 8)}`,
-        branch: 'main',
-      })
-      noteWriteOk = true
-    } catch (err) {
-      /** @fallback — Git down: entry row gets empty repoPath */
-      log.error({ err }, 'mcp note write failed')
-    }
-
-    /** @step 3 — Insert entry row (must exist before enqueue — worker reads it) */
     await deps.db.insert(entriesTable).values({
       lookupKey: entryKey,
-      userId,
       slug,
       vaultId: defaultVaultId,
       title,
@@ -181,31 +136,19 @@ export async function handleLogEntry(
       dedupHash: hash,
       type: 'thought',
       source: entrySource,
-      repoPath: noteWriteOk ? noteFilePath : '',
     })
 
-    /** @step 4 — Enqueue WriteJob for the 6-stage AI pipeline */
-    const job: WriteJob = {
-      type: 'write',
+    const job: ExtractionJob = {
+      type: 'extraction',
       jobId: entryUlid,
-      userId,
       enqueuedAt: now.toISOString(),
-      payload: {
-        userId,
-        rawEntry: {
-          content: trimmed,
-          source: entrySource,
-          metadata: defaultVaultId ? { vaultId: defaultVaultId } : undefined,
-        },
-        jobId: entryUlid,
-        entryId: entryKey,
-        enqueuedAt: now.toISOString(),
-        noteFilePath: noteWriteOk ? noteFilePath : undefined,
-      },
+      content: trimmed,
+      entryKey,
+      vaultId: defaultVaultId,
+      source: entrySource,
     }
-    await deps.producer.enqueueWrite(userId, job)
+    await deps.producer.enqueueExtraction(job)
 
-    /** @step 5 — Spawn write worker if not already running */
     deps.spawnWriteWorker(userId)
 
     return {
@@ -227,34 +170,12 @@ export async function handleLogEntry(
  * @summary Persist a fragment directly to a known thread, bypassing
  * the full AI ingestion pipeline.
  *
- * @remarks
- * The standard pipeline (`log_entry` → 6 stages) is optimized for
- * unstructured input where Robin decides classification. When the
- * caller already knows the thread, this handler skips vault classify,
- * fragmentation, and thread classify — going straight to persist.
- *
- * **Edge types created:**
- * - `FRAGMENT_IN_WIKI` — links fragment to its parent thread
- * - `FRAGMENT_MENTIONS_PERSON` — one per extracted person mention
- *
- * @param deps   - Injected dependencies (db, gateway, LLM calls, etc.)
+ * @param deps   - Injected dependencies (db, LLM calls, etc.)
  * @param input  - Fragment content, target thread slug, optional title/tags
  * @param userId - Authenticated user ID (`undefined` = not authenticated)
  * @returns MCP-shaped response with fragment/thread keys or error
  *
  * @throws Never — all errors caught and returned as `{ isError: true }`
- *
- * @see {@link resolveThreadBySlug} — strict slug resolution (no fuzzy auto-match)
- * @see {@link handleLogEntry} — full pipeline alternative
- *
- * @example
- * ```ts
- * const result = await handleLogFragment(deps,
- *   { content: 'Did a 5k run', threadSlug: 'fitness' },
- *   userId
- * )
- * // → { content: [{ text: '{"fragmentKey":"frag01...","threadSlug":"fitness"}' }] }
- * ```
  */
 export async function handleLogFragment(
   deps: McpServerDeps,
@@ -266,7 +187,6 @@ export async function handleLogFragment(
   },
   userId: string | undefined
 ) {
-  /** @gate — Reject unauthenticated requests */
   if (!userId) {
     return {
       content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
@@ -274,7 +194,6 @@ export async function handleLogFragment(
     }
   }
 
-  /** @gate — Reject empty content */
   const trimmed = input.content?.trim()
   if (!trimmed) {
     return {
@@ -283,7 +202,6 @@ export async function handleLogFragment(
     }
   }
 
-  /** @gate — Reject missing threadSlug */
   if (!input.threadSlug?.trim()) {
     return {
       content: [{ type: 'text' as const, text: 'Error: threadSlug is required' }],
@@ -294,13 +212,10 @@ export async function handleLogFragment(
   try {
     const resolverDeps: McpResolverDeps = {
       db: deps.db,
-      gatewayClient: deps.gatewayClient,
     }
 
-    /** @step 1 — Resolve thread by exact slug (no fuzzy auto-resolution) */
-    const threadResult = await resolveThreadBySlug(resolverDeps, userId, input.threadSlug.trim())
+    const threadResult = await resolveThreadBySlug(resolverDeps, input.threadSlug.trim())
 
-    /** @gate — Thread not found → return error with suggestions */
     if ('error' in threadResult) {
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(threadResult) }],
@@ -308,10 +223,9 @@ export async function handleLogFragment(
       }
     }
 
-    /** @step 2 — Entity extraction (fail-open) */
+    // Entity extraction (fail-open)
     let personKeys: string[] = []
     let newPeople: Array<{ personKey: string; canonicalName: string }> = []
-    let extractionStatus: 'completed' | 'failed' = 'failed'
     try {
       const knownPeople = await deps.loadUserPeople(userId)
       const knownPeopleJson =
@@ -347,155 +261,77 @@ export async function handleLogFragment(
           })
         }
       }
-      extractionStatus = 'completed'
     } catch (err) {
-      /** @fallback — LLM down: continue without people edges */
       log.warn({ err, userId }, 'log_fragment entity extraction failed (continuing)')
     }
 
-    /** @step 3 — Generate fragment identifiers (key, ULID, slug, filename) */
+    // Generate fragment identifiers
     const fragKey = makeLookupKey('frag')
     const { ulid: fragUlid } = parseLookupKey(fragKey)
     const title = input.title?.trim() || trimmed.slice(0, 80)
     const fragSlug = `${generateSlug(title)}-${fragUlid.slice(0, 6).toLowerCase()}`
     const now = new Date()
-    const today = now.toISOString().slice(0, 10).replace(/-/g, '')
-    const fragFilename = composeFilename({
-      date: today,
-      slug: fragSlug,
-      type: 'frag',
-      ulid: fragUlid,
-    })
-    const fragPath = `fragments/${fragFilename}`
 
-    /** @step 4 — Assemble fragment frontmatter (always RESOLVED observation) */
-    const frontmatter = assembleFragmentFrontmatter({
-      title,
-      type: 'observation',
-      date: today,
-      tags: input.tags ?? [],
-      wikiKeys: [threadResult.lookupKey],
-      personKeys,
-      relatedFragmentKeys: [],
-      status: 'RESOLVED',
-      confidence: 1,
-      sourceSpan: '',
-      suggestedSlug: fragSlug,
-      wikiLinks: [],
-      brokenLinks: [],
-      entityExtractionStatus: extractionStatus,
-    })
-
-    /** @step 5 — Build person markdown files for newly discovered people */
-    const personFiles: Array<{ path: string; content: string }> = []
-    for (const person of newPeople) {
-      const { ulid: personUlid } = parseLookupKey(person.personKey)
-      const personSlug = generateSlug(person.canonicalName)
-      const personFilename = composeFilename({
-        date: today,
-        slug: personSlug,
-        type: 'person',
-        ulid: personUlid,
-      })
-      const personFm = assemblePersonFrontmatter({
-        type: 'person',
-        state: 'RESOLVED',
-        verified: false,
-        canonicalName: person.canonicalName,
-        aliases: [],
-        fragmentKeys: [fragKey],
-        lastRebuiltAt: null,
-        wikiLinks: [],
-        brokenLinks: [],
-      })
-      personFiles.push({
-        path: `people/${personFilename}`,
-        content: personFm,
-      })
-    }
-
-    /** @step 6 — Write fragment + person files to git via batchWrite */
-    let repoPath = fragPath
-    try {
-      await deps.gatewayClient.batchWrite({
-        userId,
-        files: [{ path: fragPath, content: `${frontmatter}\n${trimmed}` }, ...personFiles],
-        message: `fragment: ${title}`,
-        branch: 'main',
-      })
-    } catch (err) {
-      /** @fallback — Gateway down: fragment row gets empty repoPath */
-      log.error({ err, userId }, 'log_fragment git write failed')
-      repoPath = ''
-    }
-
-    /** @step 7a — Insert fragment row */
+    // Insert fragment row
     await deps.db.insert(fragmentsTable).values({
       lookupKey: fragKey,
-      userId,
       slug: fragSlug,
       title,
       type: 'observation',
       tags: input.tags ?? [],
       entryId: null,
       state: 'RESOLVED',
-      repoPath,
+      content: trimmed,
     })
 
-    /** @step 7b — Insert FRAGMENT_IN_WIKI edge */
+    // Insert FRAGMENT_IN_WIKI edge
     await deps.db
       .insert(edgesTable)
       .values({
         id: crypto.randomUUID(),
-        userId,
         srcType: 'fragment',
         srcId: fragKey,
         dstType: 'wiki',
         dstId: threadResult.lookupKey,
         edgeType: 'FRAGMENT_IN_WIKI',
-      } as any)
+      })
       .onConflictDoNothing()
 
-    /** @step 7c — Insert FRAGMENT_MENTIONS_PERSON edges (one per person) */
+    // Insert FRAGMENT_MENTIONS_PERSON edges (one per person)
     for (const personKey of personKeys) {
       await deps.db
         .insert(edgesTable)
         .values({
           id: crypto.randomUUID(),
-          userId,
           srcType: 'fragment',
           srcId: fragKey,
           dstType: 'person',
           dstId: personKey,
           edgeType: 'FRAGMENT_MENTIONS_PERSON',
-        } as any)
+        })
         .onConflictDoNothing()
     }
 
-    /** @step 7d — Insert new people rows (for people not yet in DB) */
+    // Insert new people rows (for people not yet in DB)
     for (const person of newPeople) {
       await deps.db
         .insert(peopleTable)
         .values({
           lookupKey: person.personKey,
-          userId,
           slug: generateSlug(person.canonicalName),
           name: person.canonicalName,
+          canonicalName: person.canonicalName,
           state: 'RESOLVED',
-          sections: {
-            canonicalName: person.canonicalName,
-            aliases: [],
-            verified: false,
-            fragmentKeys: [fragKey],
-          },
-        } as any)
+          aliases: [],
+          verified: false,
+        })
         .onConflictDoNothing()
     }
 
-    /** @step 8 — Mark thread DIRTY for wiki regen (timeline + synthesis) */
+    // Mark thread for wiki regen (PENDING signals regen needed)
     await deps.db
       .update(threadsTable)
-      .set({ state: 'DIRTY', updatedAt: now } as any)
+      .set({ state: 'PENDING', updatedAt: now })
       .where(eq(threadsTable.lookupKey, threadResult.lookupKey))
 
     const result = {

--- a/core/src/mcp/resolvers.ts
+++ b/core/src/mcp/resolvers.ts
@@ -30,7 +30,7 @@
 
 import { eq, and, isNull, sql, inArray } from 'drizzle-orm'
 import type { DB } from '../db/client.js'
-import { wikis, fragments, people, edges } from '../db/schema.js'
+import { wikis, fragments, people, edges, wikiTypes } from '../db/schema.js'
 
 /***********************************************************************
  * ## Types
@@ -60,6 +60,8 @@ interface WikiSummary {
   fragmentCount: number
   lastRebuiltAt: string | null
   wikiPreview: string
+  shortDescriptor: string
+  descriptor: string
 }
 
 /** Full thread detail with wiki body and member fragment snippets. */
@@ -372,7 +374,12 @@ function resolvePerson(
  * @param deps - Database client
  * @returns Array of {@link WikiSummary} sorted by last update
  */
-export async function listWikis(deps: McpResolverDeps): Promise<WikiSummary[]> {
+export async function listWikis(
+  deps: McpResolverDeps,
+  opts: { includeDescriptors?: boolean } = {}
+): Promise<WikiSummary[]> {
+  const includeDescriptors = opts.includeDescriptors ?? true
+
   const rows = await deps.db
     .select({
       lookupKey: wikis.lookupKey,
@@ -383,8 +390,11 @@ export async function listWikis(deps: McpResolverDeps): Promise<WikiSummary[]> {
       content: wikis.content,
       lastRebuiltAt: wikis.lastRebuiltAt,
       fragmentCount: sql<number>`count(${edges.id})::int`,
+      shortDescriptor: wikiTypes.shortDescriptor,
+      descriptor: wikiTypes.descriptor,
     })
     .from(wikis)
+    .leftJoin(wikiTypes, eq(wikis.type, wikiTypes.slug))
     .leftJoin(
       edges,
       and(
@@ -394,7 +404,7 @@ export async function listWikis(deps: McpResolverDeps): Promise<WikiSummary[]> {
       )
     )
     .where(isNull(wikis.deletedAt))
-    .groupBy(wikis.lookupKey)
+    .groupBy(wikis.lookupKey, wikiTypes.shortDescriptor, wikiTypes.descriptor)
     .orderBy(sql`${wikis.updatedAt} DESC`)
     .limit(20)
 
@@ -410,6 +420,8 @@ export async function listWikis(deps: McpResolverDeps): Promise<WikiSummary[]> {
       fragmentCount: row.fragmentCount,
       lastRebuiltAt: row.lastRebuiltAt?.toISOString() ?? null,
       wikiPreview,
+      shortDescriptor: includeDescriptors ? (row.shortDescriptor ?? '') : '',
+      descriptor: includeDescriptors ? (row.descriptor ?? '') : '',
     }
   })
 }
@@ -769,4 +781,37 @@ export async function resolveThreadBySlug(
     error: `Thread not found: "${slugInput}"`,
     suggestions: scored.slice(0, 3).map((s) => s.slug),
   }
+}
+
+/***********************************************************************
+ * ## Wiki type resolvers
+ ***********************************************************************/
+
+export interface WikiTypeSummary {
+  slug: string
+  name: string
+  shortDescriptor: string
+  descriptor: string
+  isDefault: boolean
+  userModified: boolean
+}
+
+/**
+ * List all wiki types ordered by name.
+ * Global config -- no userId scoping needed.
+ */
+export async function listWikiTypes(deps: McpResolverDeps): Promise<WikiTypeSummary[]> {
+  const rows = await deps.db
+    .select({
+      slug: wikiTypes.slug,
+      name: wikiTypes.name,
+      shortDescriptor: wikiTypes.shortDescriptor,
+      descriptor: wikiTypes.descriptor,
+      isDefault: wikiTypes.isDefault,
+      userModified: wikiTypes.userModified,
+    })
+    .from(wikiTypes)
+    .orderBy(wikiTypes.name)
+
+  return rows
 }

--- a/core/src/mcp/resolvers.ts
+++ b/core/src/mcp/resolvers.ts
@@ -16,21 +16,21 @@
  * aliases, then fuzzy. When multiple candidates score within 5 points,
  * the response includes `alternatives` for disambiguation.
  *
- * **Git as source of truth:** wiki/fragment content is read from git
- * via gateway, not DB. Gateway down → empty content, not failure.
+ * **Content from DB:** wiki/fragment/person content is read from the
+ * `content` column on each domain table (populated by the ingest pipeline).
  *
  * @see {@link resolveSlug} — generic fuzzy slug matching (auto-resolve at 70+)
  * @see {@link resolveThreadBySlug} — strict exact-match for write paths
- * @see {@link listThreads} — thread listing with fragment counts
+ * @see {@link listWikis} — wiki listing with fragment counts
  * @see {@link getThread} — full thread detail with wiki body
  * @see {@link getFragment} — full fragment with content + frontmatter
- * @see {@link getPerson} — person detail with alias-aware matching
+ * @see {@link findPersonById} — exact PK lookup
+ * @see {@link findPersonByQuery} — fuzzy name/slug/alias search
  */
 
 import { eq, and, isNull, sql, inArray } from 'drizzle-orm'
 import type { DB } from '../db/client.js'
 import { wikis, fragments, people, edges } from '../db/schema.js'
-import type { gatewayClient as GatewayClient } from '../gateway/client.js'
 
 /***********************************************************************
  * ## Types
@@ -44,15 +44,14 @@ import type { gatewayClient as GatewayClient } from '../gateway/client.js'
  *
  * @remarks
  * Intentionally narrower than {@link McpServerDeps} — resolvers only
- * need read access to the database and gateway.
+ * need read access to the database.
  */
 export interface McpResolverDeps {
   db: DB
-  gatewayClient: typeof GatewayClient
 }
 
-/** Thread list item with fragment count and wiki preview. */
-interface ThreadSummary {
+/** Wiki list item with fragment count and wiki preview. */
+interface WikiSummary {
   lookupKey: string
   slug: string
   name: string
@@ -281,7 +280,7 @@ export function resolveSlug(
  * @remarks More aggressive than slug resolution — checks canonical
  * names, aliases, and fuzzy matches with ambiguity detection.
  *
- * @see {@link getPerson} — public resolver that uses this
+ * @see {@link findPersonByQuery} — public resolver that uses this
  ***********************************************************************/
 
 /**
@@ -291,22 +290,13 @@ export function resolveSlug(
  * **Resolution strategy:**
  * 1. Exact canonical name match (case-insensitive)
  * 2. Exact alias match (case-insensitive)
- * 3. Fuzzy match across names + aliases — best score wins if >= 70
+ * 3. Fuzzy match across names, aliases, AND slugs — best score wins if >= 70
  * 4. Ambiguity detection: multiple candidates within 5 points →
  *    `alternatives` returned so the MCP client can disambiguate
  *
  * @param nameInput  - The name to search for
  * @param candidates - All known people with their aliases
  * @returns Matched person (possibly with `alternatives`) or error
- *
- * @example
- * ```ts
- * resolvePerson('Sarah', [
- *   { name: 'Sarah Connor', slug: 'sarah-connor', aliases: [] },
- *   { name: 'Sarah Chen', slug: 'sarah-chen', aliases: ['SC'] },
- * ])
- * // → { match: { name: 'Sarah Connor', ... }, alternatives: ['Sarah Chen'] }
- * ```
  */
 function resolvePerson(
   nameInput: string,
@@ -328,10 +318,14 @@ function resolvePerson(
         ratio(lower, c.name.toLowerCase()),
         partialRatio(lower, c.name.toLowerCase())
       )
+      const slugScore = Math.max(
+        ratio(lower, c.slug.toLowerCase()),
+        partialRatio(lower, c.slug.toLowerCase())
+      )
       const aliasScores = c.aliases.map((a) =>
         Math.max(ratio(lower, a.toLowerCase()), partialRatio(lower, a.toLowerCase()))
       )
-      const best = Math.max(nameScore, ...aliasScores, 0)
+      const best = Math.max(nameScore, slugScore, ...aliasScores, 0)
       return { candidate: c, score: best }
     })
     .sort((a, b) => b.score - a.score)
@@ -368,18 +362,17 @@ function resolvePerson(
  ***********************************************************************/
 
 /**
- * List all wikis for a user with fragment counts and wiki previews.
+ * List all wikis with fragment counts and wiki previews.
  *
  * @remarks
  * Returns the 20 most recently updated wikis. Fragment counts are
  * computed via a LEFT JOIN on `FRAGMENT_IN_WIKI` edges. Wiki previews
- * are read from git (first 200 chars after frontmatter).
+ * are read from the `content` column (first 200 chars after frontmatter).
  *
- * @param deps   - Database and gateway client
- * @param userId - Authenticated user ID
- * @returns Array of {@link ThreadSummary} sorted by last update
+ * @param deps - Database client
+ * @returns Array of {@link WikiSummary} sorted by last update
  */
-export async function listThreads(deps: McpResolverDeps, userId: string): Promise<ThreadSummary[]> {
+export async function listWikis(deps: McpResolverDeps): Promise<WikiSummary[]> {
   const rows = await deps.db
     .select({
       lookupKey: wikis.lookupKey,
@@ -387,7 +380,7 @@ export async function listThreads(deps: McpResolverDeps, userId: string): Promis
       name: wikis.name,
       type: wikis.type,
       state: wikis.state,
-      repoPath: wikis.repoPath,
+      content: wikis.content,
       lastRebuiltAt: wikis.lastRebuiltAt,
       fragmentCount: sql<number>`count(${edges.id})::int`,
     })
@@ -400,55 +393,40 @@ export async function listThreads(deps: McpResolverDeps, userId: string): Promis
         isNull(edges.deletedAt)
       )
     )
-    .where(and(eq(wikis.userId, userId), isNull(wikis.deletedAt)))
+    .where(isNull(wikis.deletedAt))
     .groupBy(wikis.lookupKey)
     .orderBy(sql`${wikis.updatedAt} DESC`)
     .limit(20)
 
-  const results: ThreadSummary[] = await Promise.all(
-    rows.map(async (row) => {
-      let wikiPreview = ''
-      const path = row.repoPath || `wikis/${row.slug}.md`
-      try {
-        const file = await deps.gatewayClient.read(userId, path)
-        const body = stripFrontmatter(file.content)
-        wikiPreview = body.slice(0, 200).trim()
-      } catch {
-        // Gateway read failure or file doesn't exist
-      }
-      return {
-        lookupKey: row.lookupKey,
-        slug: row.slug,
-        name: row.name,
-        type: row.type,
-        state: row.state,
-        fragmentCount: row.fragmentCount,
-        lastRebuiltAt: row.lastRebuiltAt?.toISOString() ?? null,
-        wikiPreview,
-      }
-    })
-  )
-
-  return results
+  return rows.map((row) => {
+    const body = stripFrontmatter(row.content || '')
+    const wikiPreview = body.slice(0, 200).trim()
+    return {
+      lookupKey: row.lookupKey,
+      slug: row.slug,
+      name: row.name,
+      type: row.type,
+      state: row.state,
+      fragmentCount: row.fragmentCount,
+      lastRebuiltAt: row.lastRebuiltAt?.toISOString() ?? null,
+      wikiPreview,
+    }
+  })
 }
 
 /**
  * Get full thread detail by slug with fuzzy matching.
  *
  * @remarks
- * Reads the thread's wiki body from git (source of truth) and fetches
+ * Reads the thread's wiki body from the `content` column and fetches
  * all member fragments via `FRAGMENT_IN_WIKI` edges with 300-char snippets.
  *
- * @param deps      - Database and gateway client
- * @param userId    - Authenticated user ID
+ * @param deps      - Database client
  * @param slugInput - Thread slug (exact or fuzzy)
  * @returns {@link ThreadDetail} with wiki body and fragments, or {@link ErrorResult}
- *
- * @see {@link resolveSlug} — fuzzy matching strategy used here
  */
 export async function getThread(
   deps: McpResolverDeps,
-  userId: string,
   slugInput: string
 ): Promise<ThreadDetail | ErrorResult> {
   const allThreads = await deps.db
@@ -458,11 +436,11 @@ export async function getThread(
       name: wikis.name,
       type: wikis.type,
       state: wikis.state,
-      repoPath: wikis.repoPath,
+      content: wikis.content,
       lastRebuiltAt: wikis.lastRebuiltAt,
     })
     .from(wikis)
-    .where(and(eq(wikis.userId, userId), isNull(wikis.deletedAt)))
+    .where(isNull(wikis.deletedAt))
 
   const resolved = resolveSlug(
     slugInput,
@@ -473,15 +451,7 @@ export async function getThread(
   const thread = allThreads.find((t) => t.slug === resolved.match.slug)
   if (!thread) return { error: 'Thread not found', suggestions: [] }
 
-  // Read wiki body from git (source of truth, not DB)
-  let wikiBody = ''
-  const wikiPath = thread.repoPath || `wikis/${thread.slug}.md`
-  try {
-    const file = await deps.gatewayClient.read(userId, wikiPath)
-    wikiBody = stripFrontmatter(file.content)
-  } catch {
-    // Gateway read failure or file doesn't exist
-  }
+  const wikiBody = stripFrontmatter(thread.content || '')
 
   // Fetch member fragments via edge graph
   const fragEdges = await deps.db
@@ -489,7 +459,6 @@ export async function getThread(
     .from(edges)
     .where(
       and(
-        eq(edges.userId, userId),
         eq(edges.dstId, thread.lookupKey),
         eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
         isNull(edges.deletedAt)
@@ -504,26 +473,16 @@ export async function getThread(
             slug: fragments.slug,
             type: fragments.type,
             title: fragments.title,
-            repoPath: fragments.repoPath,
+            content: fragments.content,
           })
           .from(fragments)
           .where(and(inArray(fragments.lookupKey, fragKeys), isNull(fragments.deletedAt)))
       : []
 
-  const fragmentSnippets: FragmentSnippet[] = await Promise.all(
-    frags.map(async (f) => {
-      let snippet = ''
-      if (f.repoPath) {
-        try {
-          const file = await deps.gatewayClient.read(userId, f.repoPath)
-          snippet = stripFrontmatter(file.content).slice(0, 300).trim()
-        } catch {
-          // Gateway read failure
-        }
-      }
-      return { slug: f.slug, type: f.type, title: f.title, snippet }
-    })
-  )
+  const fragmentSnippets: FragmentSnippet[] = frags.map((f) => {
+    const snippet = stripFrontmatter(f.content || '').slice(0, 300).trim()
+    return { slug: f.slug, type: f.type, title: f.title, snippet }
+  })
 
   return {
     thread: {
@@ -543,20 +502,16 @@ export async function getThread(
  * Get full fragment detail by slug with fuzzy matching.
  *
  * @remarks
- * Returns the complete markdown content and raw frontmatter from git.
- * The `content` field has frontmatter stripped; the `frontmatter` field
- * has just the YAML block for structured parsing by MCP clients.
+ * Returns the complete markdown content and raw frontmatter from the
+ * `content` column. The `content` field has frontmatter stripped; the
+ * `frontmatter` field has just the YAML block for structured parsing.
  *
- * @param deps      - Database and gateway client
- * @param userId    - Authenticated user ID
+ * @param deps      - Database client
  * @param slugInput - Fragment slug (exact or fuzzy)
  * @returns {@link FragmentDetail} with content and frontmatter, or {@link ErrorResult}
- *
- * @see {@link resolveSlug} — fuzzy matching strategy used here
  */
 export async function getFragment(
   deps: McpResolverDeps,
-  userId: string,
   slugInput: string
 ): Promise<FragmentDetail | ErrorResult> {
   const allFrags = await deps.db
@@ -565,10 +520,10 @@ export async function getFragment(
       type: fragments.type,
       title: fragments.title,
       tags: fragments.tags,
-      repoPath: fragments.repoPath,
+      content: fragments.content,
     })
     .from(fragments)
-    .where(and(eq(fragments.userId, userId), isNull(fragments.deletedAt)))
+    .where(isNull(fragments.deletedAt))
 
   const resolved = resolveSlug(
     slugInput,
@@ -579,17 +534,8 @@ export async function getFragment(
   const frag = allFrags.find((f) => f.slug === resolved.match.slug)
   if (!frag) return { error: 'Fragment not found', suggestions: [] }
 
-  let content = ''
-  let frontmatter = ''
-  if (frag.repoPath) {
-    try {
-      const file = await deps.gatewayClient.read(userId, frag.repoPath)
-      content = stripFrontmatter(file.content)
-      frontmatter = extractFrontmatter(file.content)
-    } catch {
-      // Gateway read failure
-    }
-  }
+  const content = stripFrontmatter(frag.content || '')
+  const frontmatter = extractFrontmatter(frag.content || '')
 
   return {
     slug: frag.slug,
@@ -602,62 +548,32 @@ export async function getFragment(
 }
 
 /**
- * Get person detail by name with alias-aware fuzzy matching.
+ * Find a person by exact lookupKey (PK lookup).
  *
- * @remarks
- * Reads the person's profile body from git and fetches all fragments
- * that mention them via `FRAGMENT_MENTIONS_PERSON` edges. If multiple
- * people match closely, the response includes `alternatives` for
- * disambiguation.
- *
- * @param deps      - Database and gateway client
- * @param userId    - Authenticated user ID
- * @param nameInput - Person name to search for (exact or fuzzy)
- * @returns {@link PersonDetail} with profile and fragments, or {@link ErrorResult}
- *
- * @see {@link resolvePerson} — alias-aware matching strategy used here
+ * @param deps - Database client
+ * @param id   - Exact lookupKey (e.g. "person01ABCDEFGHIJKLMNOPQRSTUV")
+ * @returns {@link PersonDetail} with body and linked fragments, or {@link ErrorResult}
  */
-export async function getPerson(
+export async function findPersonById(
   deps: McpResolverDeps,
-  userId: string,
-  nameInput: string
+  id: string
 ): Promise<PersonDetail | ErrorResult> {
-  const allPeople = await deps.db
+  const [person] = await deps.db
     .select({
       lookupKey: people.lookupKey,
       slug: people.slug,
       name: people.name,
       relationship: people.relationship,
-      sections: people.sections,
-      repoPath: people.repoPath,
+      aliases: people.aliases,
+      content: people.content,
     })
     .from(people)
-    .where(and(eq(people.userId, userId), isNull(people.deletedAt)))
+    .where(and(eq(people.lookupKey, id), isNull(people.deletedAt)))
+    .limit(1)
 
-  const candidates = allPeople.map((p) => ({
-    name: p.name,
-    slug: p.slug,
-    aliases: Array.isArray((p.sections as Record<string, unknown>)?.aliases)
-      ? ((p.sections as Record<string, unknown>).aliases as string[])
-      : [],
-  }))
-
-  const resolved = resolvePerson(nameInput, candidates)
-  if ('error' in resolved) return resolved
-
-  const person = allPeople.find((p) => p.slug === resolved.match.slug)
   if (!person) return { error: 'Person not found', suggestions: [] }
 
-  // Read person profile from git
-  let body = ''
-  if (person.repoPath) {
-    try {
-      const file = await deps.gatewayClient.read(userId, person.repoPath)
-      body = stripFrontmatter(file.content)
-    } catch {
-      // Gateway read failure
-    }
-  }
+  const body = stripFrontmatter(person.content || '')
 
   // Fetch linked fragments via FRAGMENT_MENTIONS_PERSON edges
   const fragEdges = await deps.db
@@ -665,7 +581,6 @@ export async function getPerson(
     .from(edges)
     .where(
       and(
-        eq(edges.userId, userId),
         eq(edges.dstId, person.lookupKey),
         eq(edges.edgeType, 'FRAGMENT_MENTIONS_PERSON'),
         isNull(edges.deletedAt)
@@ -680,26 +595,102 @@ export async function getPerson(
             slug: fragments.slug,
             type: fragments.type,
             title: fragments.title,
-            repoPath: fragments.repoPath,
+            content: fragments.content,
           })
           .from(fragments)
           .where(and(inArray(fragments.lookupKey, fragKeys), isNull(fragments.deletedAt)))
       : []
 
-  const fragmentSnippets: FragmentSnippet[] = await Promise.all(
-    frags.map(async (f) => {
-      let snippet = ''
-      if (f.repoPath) {
-        try {
-          const file = await deps.gatewayClient.read(userId, f.repoPath)
-          snippet = stripFrontmatter(file.content).slice(0, 300).trim()
-        } catch {
-          // Gateway read failure
-        }
-      }
-      return { slug: f.slug, type: f.type, title: f.title, snippet }
+  const fragmentSnippets: FragmentSnippet[] = frags.map((f) => {
+    const snippet = stripFrontmatter(f.content || '').slice(0, 300).trim()
+    return { slug: f.slug, type: f.type, title: f.title, snippet }
+  })
+
+  return {
+    person: {
+      name: person.name,
+      slug: person.slug,
+      aliases: person.aliases ?? [],
+      relationship: person.relationship,
+    },
+    body,
+    fragments: fragmentSnippets,
+  }
+}
+
+/**
+ * Find a person by fuzzy name/slug/alias search.
+ *
+ * @remarks
+ * Reads all non-deleted people, scores against name, slug, and aliases
+ * using Levenshtein fuzzy matching. Returns the best match with optional
+ * alternatives when multiple candidates score within 5 points.
+ * Max 5 results.
+ *
+ * @param deps  - Database client
+ * @param query - Person name, slug, or alias to search for
+ * @returns {@link PersonDetail} with body and linked fragments, or {@link ErrorResult}
+ */
+export async function findPersonByQuery(
+  deps: McpResolverDeps,
+  query: string
+): Promise<PersonDetail | ErrorResult> {
+  const allPeople = await deps.db
+    .select({
+      lookupKey: people.lookupKey,
+      slug: people.slug,
+      name: people.name,
+      relationship: people.relationship,
+      aliases: people.aliases,
+      content: people.content,
     })
-  )
+    .from(people)
+    .where(isNull(people.deletedAt))
+
+  const candidates = allPeople.map((p) => ({
+    name: p.name,
+    slug: p.slug,
+    aliases: p.aliases ?? [],
+  }))
+
+  const resolved = resolvePerson(query, candidates)
+  if ('error' in resolved) return resolved
+
+  const person = allPeople.find((p) => p.slug === resolved.match.slug)
+  if (!person) return { error: 'Person not found', suggestions: [] }
+
+  const body = stripFrontmatter(person.content || '')
+
+  // Fetch linked fragments via FRAGMENT_MENTIONS_PERSON edges
+  const fragEdges = await deps.db
+    .select({ srcId: edges.srcId })
+    .from(edges)
+    .where(
+      and(
+        eq(edges.dstId, person.lookupKey),
+        eq(edges.edgeType, 'FRAGMENT_MENTIONS_PERSON'),
+        isNull(edges.deletedAt)
+      )
+    )
+
+  const fragKeys = fragEdges.map((e) => e.srcId)
+  const frags =
+    fragKeys.length > 0
+      ? await deps.db
+          .select({
+            slug: fragments.slug,
+            type: fragments.type,
+            title: fragments.title,
+            content: fragments.content,
+          })
+          .from(fragments)
+          .where(and(inArray(fragments.lookupKey, fragKeys), isNull(fragments.deletedAt)))
+      : []
+
+  const fragmentSnippets: FragmentSnippet[] = frags.map((f) => {
+    const snippet = stripFrontmatter(f.content || '').slice(0, 300).trim()
+    return { slug: f.slug, type: f.type, title: f.title, snippet }
+  })
 
   const result: PersonDetail = {
     person: {
@@ -737,16 +728,12 @@ export async function getPerson(
  * On miss, returns scored suggestions so the MCP client can present
  * "did you mean?" options without auto-resolving.
  *
- * @param deps      - Database and gateway client
- * @param userId    - Authenticated user ID
+ * @param deps      - Database client
  * @param slugInput - Exact thread slug to match
  * @returns Thread metadata or {@link ErrorResult} with suggestions
- *
- * @see {@link resolveSlug} — fuzzy alternative used by read-only resolvers
  */
 export async function resolveThreadBySlug(
   deps: McpResolverDeps,
-  userId: string,
   slugInput: string
 ): Promise<
   | { lookupKey: string; slug: string; name: string; state: string }
@@ -760,7 +747,7 @@ export async function resolveThreadBySlug(
       state: wikis.state,
     })
     .from(wikis)
-    .where(and(eq(wikis.userId, userId), isNull(wikis.deletedAt)))
+    .where(isNull(wikis.deletedAt))
 
   // Exact match only — log_fragment requires precision
   const exact = allThreads.find((t) => t.slug === slugInput)

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -19,9 +19,9 @@
 
 import { z } from 'zod/v4'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery } from './resolvers.js'
+import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery, listWikiTypes } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 
 export type { McpServerDeps }
@@ -90,37 +90,30 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
   )
 
   /***********************************************************************
-   * ## Resources
+   * ## Wiki listing
    ***********************************************************************/
 
-  server.registerResource(
-    'list_threads',
-    'robin://wikis',
+  server.registerTool(
+    'list_wikis',
     {
-      description: 'All wikis with fragment counts and wiki previews',
+      description: 'List all wikis with fragment counts, previews, and type descriptors',
+      inputSchema: {
+        includeDescriptors: z.boolean().optional().describe(
+          'Include type descriptors in the response (default: true). Set false for compact output.'
+        ),
+      },
     },
-    async () => {
+    async ({ includeDescriptors }) => {
       try {
-        const data = await listWikis(resolverDeps)
+        const data = await listWikis(resolverDeps, { includeDescriptors })
         return {
-          contents: [
-            {
-              uri: 'robin://wikis',
-              mimeType: 'application/json',
-              text: JSON.stringify(data),
-            },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify(data) }],
         }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         return {
-          contents: [
-            {
-              uri: 'robin://wikis',
-              mimeType: 'application/json',
-              text: JSON.stringify({ error: message }),
-            },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
         }
       }
     }
@@ -230,6 +223,54 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
           isError: true as const,
         }
       }
+    }
+  )
+
+  /***********************************************************************
+   * ## Wiki type tools
+   ***********************************************************************/
+
+  server.registerTool(
+    'get_wiki_types',
+    {
+      description:
+        'List all available wiki types with their descriptors. ' +
+        'Use this to understand what types are available before classifying or creating wikis.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const data = await listWikiTypes(resolverDeps)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(data) }],
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
+        }
+      }
+    }
+  )
+
+  server.registerTool(
+    'create_wiki_type',
+    {
+      description:
+        'Create a custom wiki type. Use this intentionally — only when the existing types ' +
+        'do not fit the content. Requires a unique slug, a display name, a short descriptor ' +
+        '(3-5 words), and a full descriptor sentence.',
+      inputSchema: {
+        slug: z.string().describe('Unique slug: lowercase alphanumeric + hyphens only'),
+        name: z.string().describe('Display name (e.g. "Research Notes")'),
+        shortDescriptor: z.string().describe('3-5 word label for pills/badges'),
+        descriptor: z.string().describe('One sentence describing what this wiki type contains'),
+        prompt: z.string().optional().describe('Optional: custom Quill generation instruction'),
+      },
+    },
+    async ({ slug, name, shortDescriptor, descriptor, prompt }) => {
+      return handleCreateWikiType(deps, { slug, name, shortDescriptor, descriptor, prompt })
     }
   )
 

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -19,7 +19,7 @@
 
 import { z } from 'zod/v4'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { listThreads, getThread, getFragment, getPerson } from './resolvers.js'
+import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
 import { handleLogEntry, handleLogFragment } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
@@ -44,14 +44,10 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
 
   const resolverDeps: McpResolverDeps = {
     db: deps.db,
-    gatewayClient: deps.gatewayClient,
   }
 
   /***********************************************************************
    * ## Tools — Write operations
-   *
-   * @remarks Mutating tools that create entries, fragments, or search.
-   * Business logic in {@link handleLogEntry} and {@link handleLogFragment}.
    ***********************************************************************/
 
   server.registerTool(
@@ -93,53 +89,19 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     }
   )
 
-  server.registerTool(
-    'search',
-    {
-      description: 'Search your Robin knowledge base',
-      inputSchema: {
-        query: z.string().describe('Search query'),
-        limit: z.number().optional().describe('Max results to return (default 10)'),
-      },
-    },
-    async ({ query, limit }, extra) => {
-      const userId = extra.authInfo?.clientId as string
-      try {
-        const results = await deps.gatewayClient.search(userId, query, limit ?? 10)
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(results) }],
-        }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err)
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ error: message }),
-            },
-          ],
-        }
-      }
-    }
-  )
-
   /***********************************************************************
    * ## Resources
-   *
-   * @remarks Static MCP resources exposed via `robin://` URIs.
-   * @see {@link listThreads} — resolver backing this resource
    ***********************************************************************/
 
   server.registerResource(
     'list_threads',
     'robin://wikis',
     {
-      description: 'All wikis for the authenticated user with fragment counts and wiki previews',
+      description: 'All wikis with fragment counts and wiki previews',
     },
-    async (_uri, extra) => {
-      const userId = extra.authInfo?.clientId as string
+    async () => {
       try {
-        const data = await listThreads(resolverDeps, userId)
+        const data = await listWikis(resolverDeps)
         return {
           contents: [
             {
@@ -166,11 +128,6 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
 
   /***********************************************************************
    * ## Read tools
-   *
-   * @remarks Non-mutating tools with fuzzy slug/name matching.
-   * @see {@link getThread} — thread detail resolver
-   * @see {@link getFragment} — fragment detail resolver
-   * @see {@link getPerson} — person detail resolver
    ***********************************************************************/
 
   server.registerTool(
@@ -181,10 +138,9 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         slug: z.string().describe('Thread slug or partial slug for fuzzy matching'),
       },
     },
-    async ({ slug }, extra) => {
-      const userId = extra.authInfo?.clientId as string
+    async ({ slug }) => {
       try {
-        const result = await getThread(resolverDeps, userId, slug)
+        const result = await getThread(resolverDeps, slug)
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         }
@@ -210,10 +166,9 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         slug: z.string().describe('Fragment slug or partial slug'),
       },
     },
-    async ({ slug }, extra) => {
-      const userId = extra.authInfo?.clientId as string
+    async ({ slug }) => {
       try {
-        const result = await getFragment(resolverDeps, userId, slug)
+        const result = await getFragment(resolverDeps, slug)
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         }
@@ -232,29 +187,47 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
   )
 
   server.registerTool(
-    'get_person',
+    'find_person',
     {
-      description: 'Find a person by name with fuzzy matching on canonical name and aliases',
+      description:
+        'Find a person by ID or name. ' +
+        'If the input matches the pattern person{ULID} (e.g. "person01ABC..."), it routes to an exact ID lookup. ' +
+        'Otherwise it performs fuzzy search across slug, name, and aliases. ' +
+        'Pass id for guaranteed exact lookup; pass query for name-based search.',
       inputSchema: {
-        name: z.string().describe('Person name to search for'),
+        id: z.string().optional().describe(
+          'Exact person lookupKey (e.g. "person01ABCDEFGHIJKLMNOPQRS"). Use for precise lookup when you have the ID.'
+        ),
+        query: z.string().optional().describe(
+          'Person name, slug, or alias to search for. Fuzzy-matched across all three fields.'
+        ),
       },
     },
-    async ({ name }, extra) => {
-      const userId = extra.authInfo?.clientId as string
+    async ({ id, query }) => {
       try {
-        const result = await getPerson(resolverDeps, userId, name)
+        // Auto-detect: if input looks like a lookupKey, route to id lookup
+        const input = id ?? query ?? ''
+        const isLookupKey = /^person[0-9A-Z]{26}$/i.test(input)
+
+        if (isLookupKey) {
+          const result = await findPersonById(resolverDeps, input)
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] }
+        }
+
+        if (query) {
+          const result = await findPersonByQuery(resolverDeps, query)
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] }
+        }
+
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Provide id or query' }) }],
+          isError: true as const,
         }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ error: message }),
-            },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
         }
       }
     }

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -21,7 +21,7 @@ import { z } from 'zod/v4'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery, listWikiTypes } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 
 export type { McpServerDeps }
@@ -86,6 +86,42 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         { content, threadSlug, title, tags },
         extra.authInfo?.clientId as string
       )
+    }
+  )
+
+  server.registerTool(
+    'create_wiki',
+    {
+      description:
+        'Create a new wiki in the knowledge base. Robin infers the wiki type from the description.',
+      inputSchema: {
+        title: z.string().describe('Wiki title (becomes the slug)'),
+        description: z
+          .string()
+          .optional()
+          .describe('What this wiki is for — used to infer the wiki type'),
+      },
+    },
+    async ({ title, description }, extra) => {
+      return handleCreateWiki(deps, { title, description }, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'edit_wiki',
+    {
+      description:
+        'Write content to a wiki. The full content is stored as an edit record and will be ' +
+        'incorporated during the next regeneration cycle. Use list_wikis to get valid slugs.',
+      inputSchema: {
+        wikiSlug: z.string().describe('Exact wiki slug (from list_wikis)'),
+        content: z
+          .string()
+          .describe('The content to add or replace. Full text is preserved for regen context.'),
+      },
+    },
+    async ({ wikiSlug, content }, extra) => {
+      return handleEditWiki(deps, { wikiSlug, content }, extra.authInfo?.clientId as string)
     }
   )
 

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -18,11 +18,14 @@
  ***********************************************************************/
 
 import { z } from 'zod/v4'
+import { eq } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery, listWikiTypes } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
 import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
+import { wikis } from '../db/schema.js'
+import { nanoid24 } from '../lib/id.js'
 
 export type { McpServerDeps }
 
@@ -307,6 +310,122 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     },
     async ({ slug, name, shortDescriptor, descriptor, prompt }) => {
       return handleCreateWikiType(deps, { slug, name, shortDescriptor, descriptor, prompt })
+    }
+  )
+
+  /***********************************************************************
+   * ## Publish tools
+   ***********************************************************************/
+
+  server.registerTool(
+    'publish_wiki',
+    {
+      description:
+        'Publish a wiki with a stable public URL. Generates a nanoid slug on first publish. ' +
+        'Wiki must have content before publishing.',
+      inputSchema: {
+        wikiKey: z.string().describe('Wiki lookupKey or slug'),
+      },
+    },
+    async ({ wikiKey }) => {
+      try {
+        const [wiki] = await deps.db
+          .select()
+          .from(wikis)
+          .where(eq(wikis.lookupKey, wikiKey))
+
+        if (!wiki) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Wiki not found' }) }],
+            isError: true as const,
+          }
+        }
+
+        if (!wiki.content) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Cannot publish a wiki with no content' }) }],
+            isError: true as const,
+          }
+        }
+
+        const slug = wiki.publishedSlug ?? nanoid24()
+        const [updated] = await deps.db
+          .update(wikis)
+          .set({
+            published: true,
+            publishedSlug: slug,
+            publishedAt: wiki.publishedAt ?? new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(wikis.lookupKey, wikiKey))
+          .returning()
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              published: updated.published,
+              publishedSlug: updated.publishedSlug,
+              publishedAt: updated.publishedAt,
+            }),
+          }],
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
+        }
+      }
+    }
+  )
+
+  server.registerTool(
+    'unpublish_wiki',
+    {
+      description:
+        'Unpublish a wiki. The slug is preserved so re-publishing restores the same URL.',
+      inputSchema: {
+        wikiKey: z.string().describe('Wiki lookupKey or slug'),
+      },
+    },
+    async ({ wikiKey }) => {
+      try {
+        const [wiki] = await deps.db
+          .select()
+          .from(wikis)
+          .where(eq(wikis.lookupKey, wikiKey))
+
+        if (!wiki) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Wiki not found' }) }],
+            isError: true as const,
+          }
+        }
+
+        const [updated] = await deps.db
+          .update(wikis)
+          .set({ published: false, updatedAt: new Date() })
+          .where(eq(wikis.lookupKey, wikiKey))
+          .returning()
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              published: updated.published,
+              publishedSlug: updated.publishedSlug,
+              publishedAt: updated.publishedAt,
+            }),
+          }],
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
+        }
+      }
     }
   )
 

--- a/core/src/mcp/wiki-type-inference.ts
+++ b/core/src/mcp/wiki-type-inference.ts
@@ -1,0 +1,52 @@
+import type { WikiType } from '@robin/shared'
+
+/**
+ * Static descriptor map for wiki type inference.
+ * Sourced from the YAML-backed wiki-type-configs — kept inline so
+ * inference works without loading YAML specs at runtime.
+ */
+const WIKI_TYPE_DESCRIPTORS: Record<WikiType, string> = {
+  log:        'a chronological synthesis of events and observations',
+  collection: 'a curated library of related items',
+  belief:     'a synthesis of a held position or mental model',
+  decision:   'a record of a discrete choice and its reasoning',
+  project:    'a living document of an active initiative',
+  goal:       'a high-level goal with measurable direction',
+  skill:      'a knowledge base for a capability being built',
+  agent:      'documentation for a configured AI assistant',
+  voice:      'a style guide for communication',
+  principles: 'a document of operating rules and commitments',
+}
+
+/**
+ * Infer the best-matching WikiType from a user-provided description.
+ *
+ * Scores each type by counting how many tokens in the descriptor appear
+ * in the lowercased description. Returns the highest-scoring type.
+ * Defaults to 'log' on tie or empty input.
+ */
+export function inferWikiType(description: string): WikiType {
+  if (!description.trim()) return 'log'
+
+  const lower = description.toLowerCase()
+  const inputTokens = new Set(lower.split(/\s+/).filter(Boolean))
+
+  let bestType: WikiType = 'log'
+  let bestScore = 0
+
+  for (const [type, descriptor] of Object.entries(WIKI_TYPE_DESCRIPTORS) as [WikiType, string][]) {
+    const descriptorTokens = descriptor.toLowerCase().split(/\s+/)
+    let score = 0
+    for (const token of descriptorTokens) {
+      if (inputTokens.has(token)) score++
+      // Also check substring match for partial overlaps
+      if (token.length > 3 && lower.includes(token)) score++
+    }
+    if (score > bestScore) {
+      bestScore = score
+      bestType = type
+    }
+  }
+
+  return bestType
+}

--- a/core/src/routes/content.ts
+++ b/core/src/routes/content.ts
@@ -60,8 +60,7 @@ contentRoutes.get('/:type/:key', async (c) => {
     return c.json({ error: 'Not found' }, 404)
   }
 
-  // Only entry rows currently store the source content directly.
-  const raw = type === 'entry' ? ((row as { content?: string }).content ?? '') : ''
+  const raw = (row as { content?: string }).content ?? ''
   const format = c.req.query('format')
 
   if (format === 'structured') {
@@ -130,6 +129,7 @@ contentRoutes.put('/:type/:key', async (c) => {
       .set({
         title: data.frontmatter.title as string,
         tags: (data.frontmatter.tags as string[]) ?? [],
+        content: body,
         updatedAt: now,
       })
       .where(eq(fragments.lookupKey, key))
@@ -142,24 +142,33 @@ contentRoutes.put('/:type/:key', async (c) => {
       })
       .where(eq(entries.lookupKey, key))
   } else if (type === 'wiki') {
+    const [currentWiki] = await db
+      .select({ content: wikis.content })
+      .from(wikis)
+      .where(eq(wikis.lookupKey, key))
+      .limit(1)
+    const previousContent = currentWiki?.content ?? ''
+
     await db
       .update(wikis)
       .set({
         name: data.frontmatter.name as string,
         type: (data.frontmatter.type as string) ?? 'log',
         prompt: (data.frontmatter.prompt as string) ?? '',
+        content: body,
         updatedAt: now,
       })
       .where(eq(wikis.lookupKey, key))
 
-    // Log thread body edit as a single addition (no diff vs git anymore)
-    if (body) {
+    if (body && body !== previousContent) {
       await db.insert(edits).values({
         id: nanoid(),
         objectType: 'wiki',
         objectId: key,
         type: 'addition',
-        content: body,
+        content: previousContent,
+        source: 'user',
+        diff: '',
       })
       log.info({ wikiKey: key }, 'logged wiki edit')
     }
@@ -169,6 +178,7 @@ contentRoutes.put('/:type/:key', async (c) => {
       .set({
         name: data.frontmatter.name as string,
         relationship: (data.frontmatter.relationship as string) ?? '',
+        content: body,
         updatedAt: now,
       })
       .where(eq(people.lookupKey, key))

--- a/core/src/routes/mcp.ts
+++ b/core/src/routes/mcp.ts
@@ -1,21 +1,24 @@
 /***********************************************************************
  * @module routes/mcp
  *
- * @summary MCP HTTP bridge.
+ * @summary MCP HTTP bridge — routes MCP JSON-RPC over Streamable HTTP.
  *
  * @remarks
- * M2 disables the MCP tool surface — no log_entry/log_fragment/search tools
- * during the ingest pipeline rebuild. The endpoint stays mounted so clients
- * receive a structured 503 instead of a connection error, and so the JWT
- * auth path keeps marking onboardedAt on first connect.
+ * Each request creates a fresh stateless transport + MCP server,
+ * authenticates via JWT query param, and delegates to the transport.
+ * The transport uses Web Standard Request/Response (works with Hono).
  ***********************************************************************/
 
 import { Hono } from 'hono'
 import { eq, and, isNull } from 'drizzle-orm'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import { verifyMcpToken } from '../mcp/jwt.js'
+import { createMcpServer } from '../mcp/server.js'
+import type { McpServerDeps } from '../mcp/server.js'
 import { db } from '../db/client.js'
 import { users } from '../db/schema.js'
 import { logger } from '../lib/logger.js'
+import { producer } from '../queue/producer.js'
 
 const log = logger.child({ component: 'mcp' })
 
@@ -40,8 +43,34 @@ mcp.use('*', async (c, next) => {
   }
 })
 
-mcp.all('/', (c) =>
-  c.json({ error: 'MCP tools are disabled during M2 ingest pipeline rebuild' }, 503)
-)
+mcp.all('/', async (c) => {
+  const userId = c.get('userId')
+
+  const deps: McpServerDeps = {
+    db,
+    producer,
+    spawnWriteWorker: () => {},
+    resolveDefaultVaultId: async () => null,
+    entityExtractCall: async () => ({ people: [] }),
+    loadUserPeople: async () => [],
+  }
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  })
+
+  const server = createMcpServer(deps)
+  await server.connect(transport)
+
+  try {
+    const response = await transport.handleRequest(c.req.raw, {
+      authInfo: { clientId: userId, token: '', scopes: [] },
+    })
+    return response
+  } finally {
+    await transport.close()
+    await server.close()
+  }
+})
 
 export { mcp }

--- a/core/src/routes/published.ts
+++ b/core/src/routes/published.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import { db } from '../db/client.js'
+import { wikis } from '../db/schema.js'
+import { publicWikiResponseSchema } from '../schemas/wikis.schema.js'
+
+const publishedRoutes = new Hono()
+
+publishedRoutes.get('/wiki/:nanoid', async (c) => {
+  const nanoid = c.req.param('nanoid')
+
+  const [wiki] = await db
+    .select({
+      name: wikis.name,
+      type: wikis.type,
+      publishedAt: wikis.publishedAt,
+      content: wikis.content,
+      published: wikis.published,
+    })
+    .from(wikis)
+    .where(and(eq(wikis.publishedSlug, nanoid), eq(wikis.published, true)))
+    .limit(1)
+
+  if (!wiki || !wiki.content) {
+    return c.json({ error: 'Not found' }, 404)
+  }
+
+  c.header('Cache-Control', 'no-store')
+
+  if (c.req.query('raw') !== undefined) {
+    return c.text(wiki.content)
+  }
+
+  return c.json(
+    publicWikiResponseSchema.parse({
+      name: wiki.name,
+      type: wiki.type,
+      publishedAt: wiki.publishedAt,
+      content: wiki.content,
+    })
+  )
+})
+
+export { publishedRoutes }

--- a/core/src/routes/vaults.ts
+++ b/core/src/routes/vaults.ts
@@ -10,7 +10,7 @@ import type { ReclassifyJob } from '@robin/queue'
 import { nanoid } from '../lib/id.js'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { vaults, wikis, edges } from '../db/schema.js'
+import { vaults, wikis, edges, wikiTypes } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
@@ -122,9 +122,27 @@ vaultsRouter.put('/:id/profile', zValidator('json', updateVaultProfileBodySchema
 vaultsRouter.get('/:vaultId/wikis', async (c) => {
   const vaultId = c.req.param('vaultId')
 
-  const rows = await db.select().from(wikis).where(eq(wikis.vaultId, vaultId))
+  const rows = await db
+    .select({
+      wiki: wikis,
+      shortDescriptor: wikiTypes.shortDescriptor,
+      descriptor: wikiTypes.descriptor,
+    })
+    .from(wikis)
+    .leftJoin(wikiTypes, eq(wikis.type, wikiTypes.slug))
+    .where(eq(wikis.vaultId, vaultId))
 
-  return c.json({ wikis: rows.map((r) => threadResponseSchema.parse(prepareThread(r))) })
+  return c.json({
+    wikis: rows.map((r) =>
+      threadResponseSchema.parse(
+        prepareThread({
+          ...r.wiki,
+          shortDescriptor: r.shortDescriptor ?? '',
+          descriptor: r.descriptor ?? '',
+        })
+      )
+    ),
+  })
 })
 
 // POST /vaults/:vaultId/wikis — create thread

--- a/core/src/routes/wiki-types.ts
+++ b/core/src/routes/wiki-types.ts
@@ -1,0 +1,108 @@
+import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
+import { zValidator } from '@hono/zod-validator'
+import { sessionMiddleware } from '../middleware/session.js'
+import { db } from '../db/client.js'
+import { wikiTypes } from '../db/schema.js'
+import { logger } from '../lib/logger.js'
+import { validationHook } from '../lib/validation.js'
+import { seedWikiTypes } from '../bootstrap/seed-wiki-types.js'
+import {
+  wikiTypeResponseSchema,
+  wikiTypeListResponseSchema,
+  createWikiTypeBodySchema,
+  updateWikiTypeBodySchema,
+} from '../schemas/wiki-types.schema.js'
+
+const log = logger.child({ component: 'wiki-types' })
+
+const wikiTypesRouter = new Hono()
+wikiTypesRouter.use('*', sessionMiddleware)
+
+// POST /wiki-types/setup -- seed defaults from YAML configs (idempotent)
+wikiTypesRouter.post('/setup', async (c) => {
+  try {
+    const result = await seedWikiTypes()
+    return c.json(result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err }, 'wiki-types setup failed')
+    return c.json({ error: message }, 500)
+  }
+})
+
+// GET /wiki-types -- list all wiki types
+wikiTypesRouter.get('/', async (c) => {
+  const rows = await db.select().from(wikiTypes).orderBy(wikiTypes.name)
+  return c.json(wikiTypeListResponseSchema.parse({ wikiTypes: rows }))
+})
+
+// GET /wiki-types/:slug -- get single wiki type
+wikiTypesRouter.get('/:slug', async (c) => {
+  const slug = c.req.param('slug')
+  const [row] = await db.select().from(wikiTypes).where(eq(wikiTypes.slug, slug))
+  if (!row) return c.json({ error: 'Not found' }, 404)
+  return c.json(wikiTypeResponseSchema.parse(row))
+})
+
+// PUT /wiki-types/:slug -- update a wiki type (sets userModified = true)
+wikiTypesRouter.put(
+  '/:slug',
+  zValidator('json', updateWikiTypeBodySchema, validationHook),
+  async (c) => {
+    const slug = c.req.param('slug')
+    const body = c.req.valid('json')
+
+    const [existing] = await db.select().from(wikiTypes).where(eq(wikiTypes.slug, slug))
+    if (!existing) return c.json({ error: 'Not found' }, 404)
+
+    const updates: Record<string, unknown> = {
+      userModified: true,
+      updatedAt: new Date(),
+    }
+    if (body.name != null) updates.name = body.name
+    if (body.shortDescriptor != null) updates.shortDescriptor = body.shortDescriptor
+    if (body.descriptor != null) updates.descriptor = body.descriptor
+    if (body.prompt != null) updates.prompt = body.prompt
+
+    const [updated] = await db
+      .update(wikiTypes)
+      .set(updates)
+      .where(eq(wikiTypes.slug, slug))
+      .returning()
+
+    return c.json(wikiTypeResponseSchema.parse(updated))
+  }
+)
+
+// POST /wiki-types -- create a new user-defined wiki type
+wikiTypesRouter.post(
+  '/',
+  zValidator('json', createWikiTypeBodySchema, validationHook),
+  async (c) => {
+    const body = c.req.valid('json')
+
+    // Check for conflict with existing slug
+    const [existing] = await db.select().from(wikiTypes).where(eq(wikiTypes.slug, body.slug))
+    if (existing) {
+      return c.json({ error: `Wiki type "${body.slug}" already exists` }, 409)
+    }
+
+    const [created] = await db
+      .insert(wikiTypes)
+      .values({
+        slug: body.slug,
+        name: body.name,
+        shortDescriptor: body.shortDescriptor,
+        descriptor: body.descriptor,
+        prompt: body.prompt,
+        isDefault: false,
+        userModified: true,
+      })
+      .returning()
+
+    return c.json(wikiTypeResponseSchema.parse(created), 201)
+  }
+)
+
+export { wikiTypesRouter as wikiTypesRoutes }

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -17,13 +17,20 @@ const log = logger.child({ component: 'wikis' })
 
 /** Prepare a thread row for schema parsing (add id alias + computed defaults) */
 function prepareThread(
-  t: typeof wikis.$inferSelect & { noteCount?: number; lastUpdated?: string }
+  t: typeof wikis.$inferSelect & {
+    noteCount?: number
+    lastUpdated?: string
+    shortDescriptor?: string
+    descriptor?: string
+  }
 ) {
   return {
     ...t,
     id: t.lookupKey,
     noteCount: t.noteCount ?? 0,
     lastUpdated: t.lastUpdated ?? t.updatedAt.toISOString(),
+    shortDescriptor: t.shortDescriptor ?? '',
+    descriptor: t.descriptor ?? '',
   }
 }
 

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -1,13 +1,16 @@
 import { Hono } from 'hono'
-import { eq } from 'drizzle-orm'
+import { eq, and, inArray, desc, isNull } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
-import { generateSlug } from '@robin/shared'
+import { generateSlug, loadWikiGenerationSpec } from '@robin/shared'
+import type { WikiType } from '@robin/shared'
+import { createIngestAgents, createStringCaller, NoOpenRouterKeyError } from '@robin/agent'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { wikis } from '../db/schema.js'
+import { wikis, edges, fragments, edits } from '../db/schema.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
-import { nanoid24 } from '../lib/id.js'
+import { nanoid24, nanoid } from '../lib/id.js'
+import { loadOpenRouterConfigFromDb } from '../lib/openrouter-config.js'
 import {
   threadResponseSchema,
   threadWithWikiResponseSchema,
@@ -127,22 +130,100 @@ wikisRouter.post('/:id/regenerate', async (c) => {
     return c.json({ error: 'Regeneration is disabled for this wiki' }, 400)
   }
 
-  // TODO(regen): Insert LLM generation call here — load wiki generation spec,
-  // gather linked fragments, assemble prompt, call LLM, write output to
-  // wikis.content, and log the regen as an edit with source: 'regen'.
+  const previousContent = wiki.content
 
-  const [updated] = await db
-    .update(wikis)
-    .set({ lastRebuiltAt: new Date(), updatedAt: new Date() })
-    .where(eq(wikis.lookupKey, id))
-    .returning()
+  try {
+    const orConfig = await loadOpenRouterConfigFromDb(db)
+    const agents = createIngestAgents(orConfig)
+    const callLlm = createStringCaller(agents.wikiClassifier)
 
-  return c.json({
-    ok: true,
-    lookupKey: updated.lookupKey,
-    stub: true,
-    message: 'Regen endpoint wired — LLM call integration pending',
-  })
+    // Gather linked fragments via FRAGMENT_IN_WIKI edges
+    const fragmentEdges = await db
+      .select({ srcId: edges.srcId })
+      .from(edges)
+      .where(
+        and(
+          eq(edges.dstId, id),
+          eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+          isNull(edges.deletedAt)
+        )
+      )
+
+    const fragmentKeys = fragmentEdges.map((e) => e.srcId)
+    let fragmentsText = ''
+    let fragmentCount = 0
+
+    if (fragmentKeys.length > 0) {
+      const fragRows = await db
+        .select({ title: fragments.title, content: fragments.content })
+        .from(fragments)
+        .where(and(inArray(fragments.lookupKey, fragmentKeys), isNull(fragments.deletedAt)))
+
+      fragmentCount = fragRows.length
+      fragmentsText = fragRows
+        .map((f) => `### ${f.title}\n${f.content}`)
+        .join('\n\n')
+    }
+
+    // Gather recent user edits for the {{edits}} template variable
+    const userEdits = await db
+      .select({ content: edits.content })
+      .from(edits)
+      .where(
+        and(
+          eq(edits.objectType, 'wiki'),
+          eq(edits.objectId, id),
+          eq(edits.source, 'user')
+        )
+      )
+      .orderBy(desc(edits.timestamp))
+      .limit(10)
+
+    const editsSummary = userEdits.length > 0
+      ? userEdits.map((e) => e.content).join('\n---\n')
+      : undefined
+
+    // Load prompt spec and call LLM
+    const spec = loadWikiGenerationSpec(wiki.type as WikiType, {
+      fragments: fragmentsText,
+      title: wiki.name,
+      date: new Date().toISOString().split('T')[0],
+      count: fragmentCount,
+      existingWiki: previousContent || undefined,
+      edits: editsSummary,
+    })
+
+    const markdown = await callLlm(spec.system, spec.user)
+
+    // Update wiki content and log edit
+    const now = new Date()
+    const [updated] = await db
+      .update(wikis)
+      .set({ content: markdown, lastRebuiltAt: now, updatedAt: now })
+      .where(eq(wikis.lookupKey, id))
+      .returning()
+
+    await db.insert(edits).values({
+      id: nanoid(),
+      objectType: 'wiki',
+      objectId: id,
+      type: 'addition',
+      content: previousContent,
+      source: 'regen',
+      diff: '',
+    })
+
+    log.info({ wikiKey: id, fragmentCount }, 'wiki regenerated via Quill')
+
+    return c.json({ ok: true, lookupKey: updated.lookupKey, lastRebuiltAt: updated.lastRebuiltAt })
+  } catch (err) {
+    if (err instanceof NoOpenRouterKeyError) {
+      return c.json({ error: 'OpenRouter API key not configured' }, 500)
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ wikiKey: id, error: message }, 'wiki regen failed')
+    return c.json({ error: 'Regeneration failed', detail: message }, 500)
+  }
 })
 
 // POST /wikis/:targetId/merge — merge source thread into target

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -7,10 +7,12 @@ import { db } from '../db/client.js'
 import { wikis } from '../db/schema.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
+import { nanoid24 } from '../lib/id.js'
 import {
   threadResponseSchema,
   threadWithWikiResponseSchema,
   updateThreadBodySchema,
+  publishWikiResponseSchema,
 } from '../schemas/wikis.schema.js'
 
 const log = logger.child({ component: 'wikis' })
@@ -75,11 +77,72 @@ wikisRouter.put('/:id', zValidator('json', updateThreadBodySchema, validationHoo
   return c.json(threadResponseSchema.parse(prepareThread(thread)))
 })
 
-// POST /wikis/:id/regenerate — manual wiki regen
-// TODO(M3): regen worker is dormant in M2. Restore when regen pipeline lands.
+// POST /wikis/:id/publish — publish wiki with stable nanoid slug
+wikisRouter.post('/:id/publish', async (c) => {
+  const id = c.req.param('id')
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
+  if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+  if (!wiki.content) {
+    return c.json({ error: 'Cannot publish a wiki with no content' }, 400)
+  }
+
+  const slug = wiki.publishedSlug ?? nanoid24()
+  const [updated] = await db
+    .update(wikis)
+    .set({
+      published: true,
+      publishedSlug: slug,
+      publishedAt: wiki.publishedAt ?? new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(wikis.lookupKey, id))
+    .returning()
+
+  return c.json(publishWikiResponseSchema.parse(updated))
+})
+
+// POST /wikis/:id/unpublish — unpublish wiki (preserves slug for re-publish)
+wikisRouter.post('/:id/unpublish', async (c) => {
+  const id = c.req.param('id')
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
+  if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+  const [updated] = await db
+    .update(wikis)
+    .set({ published: false, updatedAt: new Date() })
+    .where(eq(wikis.lookupKey, id))
+    .returning()
+
+  return c.json(publishWikiResponseSchema.parse(updated))
+})
+
+// POST /wikis/:id/regenerate — on-demand wiki regen
 wikisRouter.post('/:id/regenerate', async (c) => {
-  log.warn('wiki regen requested but disabled in M2')
-  return c.json({ error: 'Wiki regen disabled in M2 — will be restored in M3' }, 503)
+  const id = c.req.param('id')
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
+  if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+  if (!wiki.regenerate) {
+    return c.json({ error: 'Regeneration is disabled for this wiki' }, 400)
+  }
+
+  // TODO(regen): Insert LLM generation call here — load wiki generation spec,
+  // gather linked fragments, assemble prompt, call LLM, write output to
+  // wikis.content, and log the regen as an edit with source: 'regen'.
+
+  const [updated] = await db
+    .update(wikis)
+    .set({ lastRebuiltAt: new Date(), updatedAt: new Date() })
+    .where(eq(wikis.lookupKey, id))
+    .returning()
+
+  return c.json({
+    ok: true,
+    lookupKey: updated.lookupKey,
+    stub: true,
+    message: 'Regen endpoint wired — LLM call integration pending',
+  })
 })
 
 // POST /wikis/:targetId/merge — merge source thread into target

--- a/core/src/schemas/wiki-types.schema.ts
+++ b/core/src/schemas/wiki-types.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const wikiTypeResponseSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  shortDescriptor: z.string(),
+  descriptor: z.string(),
+  prompt: z.string(),
+  isDefault: z.boolean(),
+  userModified: z.boolean(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+})
+
+export const wikiTypeListResponseSchema = z.object({
+  wikiTypes: z.array(wikiTypeResponseSchema),
+})
+
+export const createWikiTypeBodySchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]+$/, 'slug must be lowercase alphanumeric with hyphens'),
+  name: z.string().min(1),
+  shortDescriptor: z.string().min(1),
+  descriptor: z.string().min(1),
+  prompt: z.string().default(''),
+})
+
+export const updateWikiTypeBodySchema = z.object({
+  name: z.string().optional(),
+  shortDescriptor: z.string().optional(),
+  descriptor: z.string().optional(),
+  prompt: z.string().optional(),
+})

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -17,6 +17,8 @@ export const threadResponseSchema = z.object({
   updatedAt: z.coerce.date(),
   noteCount: z.number().default(0),
   lastUpdated: z.string(),
+  shortDescriptor: z.string().default(''),
+  descriptor: z.string().default(''),
 })
 
 export const threadWithWikiResponseSchema = threadResponseSchema.extend({

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -44,3 +44,19 @@ export const updateThreadBodySchema = z.object({
 })
 
 export { queuedResponseSchema as threadRegenerateResponseSchema }
+
+// ── Publish schemas ────────────────────────────────────────────────────────
+
+export const publishWikiResponseSchema = z.object({
+  published: z.boolean(),
+  publishedSlug: z.string().nullable(),
+  publishedAt: z.coerce.date().nullable(),
+  regenerate: z.boolean(),
+})
+
+export const publicWikiResponseSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  publishedAt: z.coerce.date(),
+  content: z.string(),
+})

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -21,9 +21,6 @@
     "src/__tests__",
     "**/*.test.ts",
     "**/*.spec.ts",
-    "src/mcp/server.ts",
-    "src/mcp/handlers.ts",
-    "src/mcp/resolvers.ts",
     "src/routes/internal.ts"
   ]
 }

--- a/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
+++ b/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { loadWikiGenerationSpec } from '../../prompts/index'
-import type { ThreadWikiType } from '../../prompts/index'
+import type { WikiType } from '../../types/wiki'
 
 const wikiFixtures = {
   fragments: 'Fragment 1: I went running today.\nFragment 2: Hit a new personal best on the 5k.',
@@ -9,13 +9,13 @@ const wikiFixtures = {
   count: 3,
 }
 
-const allTypes: ThreadWikiType[] = [
+const allTypes: WikiType[] = [
   'log',
   'collection',
   'belief',
   'decision',
   'project',
-  'objective',
+  'goal',
   'skill',
   'agent',
   'voice',

--- a/packages/shared/src/prompts/index.ts
+++ b/packages/shared/src/prompts/index.ts
@@ -33,3 +33,7 @@ export * from './loaders/fragment-relevance.js'
 export { loadWikiGenerationSpec } from './loaders/wiki-generation.js'
 export { loadPersonSummarySpec } from './loaders/person-summary.js'
 export { personSummaryInputSchema } from './specs/person-summary/person-summary.schema.js'
+
+// Wiki type configs
+export { loadWikiTypeConfigs } from './loaders/wiki-type-configs.js'
+export type { WikiTypeConfig } from './loaders/wiki-type-configs.js'

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -7,7 +7,7 @@ import { collectionWikiSchema } from '../specs/wiki-types/collection.schema.js'
 import { beliefWikiSchema } from '../specs/wiki-types/belief.schema.js'
 import { decisionWikiSchema } from '../specs/wiki-types/decision.schema.js'
 import { projectWikiSchema } from '../specs/wiki-types/project.schema.js'
-import { objectiveWikiSchema } from '../specs/wiki-types/objective.schema.js'
+import { goalWikiSchema } from '../specs/wiki-types/goal.schema.js'
 import { skillWikiSchema } from '../specs/wiki-types/skill.schema.js'
 import { agentWikiSchema } from '../specs/wiki-types/agent.schema.js'
 import { voiceWikiSchema } from '../specs/wiki-types/voice.schema.js'
@@ -30,7 +30,7 @@ const schemaMap: Record<WikiType, z.ZodType> = {
   belief: beliefWikiSchema,
   decision: decisionWikiSchema,
   project: projectWikiSchema,
-  objective: objectiveWikiSchema,
+  goal: goalWikiSchema,
   skill: skillWikiSchema,
   agent: agentWikiSchema,
   voice: voiceWikiSchema,

--- a/packages/shared/src/prompts/loaders/wiki-type-configs.ts
+++ b/packages/shared/src/prompts/loaders/wiki-type-configs.ts
@@ -1,0 +1,34 @@
+import { loadSpec } from '../loader.js'
+import type { WikiType } from '../../types/wiki.js'
+
+export interface WikiTypeConfig {
+  slug: WikiType
+  name: string
+  shortDescriptor: string
+  descriptor: string
+  prompt: string
+}
+
+const WIKI_TYPE_META: Record<WikiType, { name: string; shortDescriptor: string; descriptor: string }> = {
+  log:        { name: 'Log',        shortDescriptor: 'Chronological record',      descriptor: 'A chronological synthesis of events, observations, and activities over time' },
+  collection: { name: 'Collection', shortDescriptor: 'Curated item library',      descriptor: 'A curated library organizing related bookmarks, references, or resources' },
+  belief:     { name: 'Belief',     shortDescriptor: 'Held position or model',    descriptor: 'A synthesis of a held position, mental model, or worldview with supporting evidence' },
+  decision:   { name: 'Decision',   shortDescriptor: 'Choice and reasoning',      descriptor: 'A record of a discrete choice, its context, alternatives considered, and reasoning' },
+  project:    { name: 'Project',    shortDescriptor: 'Active initiative tracker',  descriptor: 'A living document tracking an active initiative, its goals, progress, and status' },
+  goal:       { name: 'Goal',       shortDescriptor: 'Goal with direction',        descriptor: 'A high-level goal with measurable milestones and progress tracking' },
+  skill:      { name: 'Skill',      shortDescriptor: 'Capability knowledge base', descriptor: 'A knowledge base documenting a capability being developed or maintained' },
+  agent:      { name: 'Agent',      shortDescriptor: 'AI assistant docs',         descriptor: 'Documentation for a configured AI assistant\'s purpose, behavior, and capabilities' },
+  voice:      { name: 'Voice',      shortDescriptor: 'Communication style guide', descriptor: 'A style guide capturing communication patterns, tone preferences, and voice identity' },
+  principles: { name: 'Principles', shortDescriptor: 'Operating rules',           descriptor: 'A document of operating rules, values, and commitments that guide behavior' },
+}
+
+export function loadWikiTypeConfigs(): WikiTypeConfig[] {
+  return (Object.keys(WIKI_TYPE_META) as WikiType[]).map((slug) => {
+    const spec = loadSpec(`${slug}.yaml`, 'wiki-types')
+    return {
+      slug,
+      ...WIKI_TYPE_META[slug],
+      prompt: spec.system_message,
+    }
+  })
+}

--- a/packages/shared/src/prompts/specs/wiki-types/goal.schema.ts
+++ b/packages/shared/src/prompts/specs/wiki-types/goal.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const goalWikiSchema = z.object({
+  markdown: z.string(),
+})
+
+export type GoalWikiOutput = z.infer<typeof goalWikiSchema>

--- a/packages/shared/src/prompts/specs/wiki-types/goal.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/goal.yaml
@@ -1,8 +1,8 @@
 name: QuillTheWriter
 version: 1
 category: generation
-task: thread_wiki_objective
-description: Generates an objective wiki — a high-level goal with measurable direction.
+task: thread_wiki_goal
+description: Generates a goal wiki — a high-level goal with measurable direction.
 temperature: 0.3
 
 system_message: |
@@ -14,20 +14,20 @@ system_message: |
 
 template: |
   [MOCK ACKNOWLEDGMENT]
-  Understood. I am Quill, writing an objective wiki. I track goals and
+  Understood. I am Quill, writing a goal wiki. I track goals and
   their progress. I include only what the fragments contain. I preserve
   attribution, hedging, and uncertainty. My output is clean markdown
   that follows the required structure exactly.
 
   [TASK]
-  Generate an objective wiki document for the thread "{{title}}" from the
+  Generate a goal wiki document for the thread "{{title}}" from the
   following {{count}} fragments.
 
   [DOCUMENT STRUCTURE]
   Use this exact structure:
-  # Objective: {{title}}
+  # Goal: {{title}}
 
-  ## The Objective
+  ## The Goal
   What the desired outcome is and why it matters.
 
   ## Key Results

--- a/packages/shared/src/prompts/specs/wiki-types/objective.schema.ts
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.schema.ts
@@ -1,7 +1,0 @@
-import { z } from 'zod'
-
-export const objectiveWikiSchema = z.object({
-  markdown: z.string(),
-})
-
-export type ObjectiveWikiOutput = z.infer<typeof objectiveWikiSchema>

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -12,7 +12,7 @@ export type WikiGuideKey =
   | 'wiki-guide-belief'
   | 'wiki-guide-decision'
   | 'wiki-guide-project'
-  | 'wiki-guide-objective'
+  | 'wiki-guide-goal'
   | 'wiki-guide-skill'
   | 'wiki-guide-agent'
   | 'wiki-guide-voice'
@@ -24,7 +24,7 @@ export const WIKI_TYPE_TO_GUIDE_KEY: Record<WikiType, WikiGuideKey> = {
   belief: 'wiki-guide-belief',
   decision: 'wiki-guide-decision',
   project: 'wiki-guide-project',
-  objective: 'wiki-guide-objective',
+  goal: 'wiki-guide-goal',
   skill: 'wiki-guide-skill',
   agent: 'wiki-guide-agent',
   voice: 'wiki-guide-voice',

--- a/packages/shared/src/types/wiki.ts
+++ b/packages/shared/src/types/wiki.ts
@@ -4,7 +4,7 @@ export type WikiType =
   | 'belief'
   | 'decision'
   | 'project'
-  | 'objective'
+  | 'goal'
   | 'skill'
   | 'agent'
   | 'voice'
@@ -22,9 +22,21 @@ export const DEFAULT_WIKIS: DefaultWiki[] = [
   { name: 'Beliefs', slug: 'beliefs', type: 'belief' },
   { name: 'Decisions', slug: 'decisions', type: 'decision' },
   { name: 'Projects', slug: 'projects', type: 'project' },
-  { name: 'Objectives', slug: 'objectives', type: 'objective' },
+  { name: 'Goals', slug: 'goals', type: 'goal' },
   { name: 'Skills', slug: 'skills', type: 'skill' },
   { name: 'Agents', slug: 'agents', type: 'agent' },
   { name: 'Voice', slug: 'voice', type: 'voice' },
   { name: 'Principles', slug: 'principles', type: 'principles' },
 ]
+
+export interface WikiTypeRecord {
+  slug: string
+  name: string
+  shortDescriptor: string
+  descriptor: string
+  prompt: string
+  isDefault: boolean
+  userModified: boolean
+  createdAt: Date
+  updatedAt: Date
+}


### PR DESCRIPTION
## Summary

Complete wiki composition system implementing the M3 milestone. Built as 6 sequential commits, each verified with `tsc --noEmit`.

### Commits

- **`6c08708` feat(db): content storage prerequisite** — `content` column in `baseColumns()` for all domain tables, `source` + `diff` columns on `edits`, updated tsvector triggers to index body text
- **`3ffa541` feat(mcp): reactivate MCP + find_person** — Fix M2 schema drift in all 4 resolvers, remove gateway client, re-enable MCP route with `StreamableHTTPServerTransport`, `find_person` with dual resolvers (ID + fuzzy query)
- **`bb5ec1e` feat(wiki-types): wiki type system** — Rename `objective` → `goal`, `wiki_types` DB table, YAML config loader, setup API (`POST /wiki-types/setup`), `get_wiki_types` + `create_wiki_type` MCP tools, descriptors in `list_wikis`
- **`e8d921f` feat(mcp): create_wiki + edit_wiki** — `create_wiki` with nanoid slug collision, `edit_wiki` with content update + audit logging, `inferWikiType` for type detection
- **`b5affd0` feat(publish): public wiki publishing** — `published`, `published_slug`, `regenerate` columns, `POST /wikis/:id/publish` + `/unpublish`, `GET /published/wiki/:nanoid` (unauthenticated, JSON + `?raw`), MCP tools
- **`37ea7cd` feat(regen): on-demand wiki regeneration** — Full LLM call via Quill: gathers fragments + edits, loads type-specific prompt, calls OpenRouter, writes to `wikis.content`, logs edit with `source: 'regen'`

### Issues closed

Closes #14, closes #15, closes #16, closes #17, closes #18, closes #19

### New MCP tools

| Tool | Description |
|------|-------------|
| `list_wikis` | List wikis with type descriptors, pagination |
| `create_wiki` | Create wiki with type inference |
| `edit_wiki` | Update wiki content with audit trail |
| `find_person` | Dual resolver: ID lookup or fuzzy search (slug, name, aliases) |
| `get_wiki_types` | List available wiki types |
| `create_wiki_type` | Create custom wiki type with guardrails |
| `publish_wiki` | Publish wiki with stable nanoid URL |
| `unpublish_wiki` | Unpublish (preserves slug) |

### New API endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/wiki-types/setup` | Yes | One-shot seed of default wiki types from YAML |
| GET | `/wiki-types` | Yes | List all wiki types |
| POST | `/wiki-types` | Yes | Create custom wiki type |
| PUT | `/wiki-types/:slug` | Yes | Update wiki type |
| POST | `/wikis/:id/publish` | Yes | Publish wiki |
| POST | `/wikis/:id/unpublish` | Yes | Unpublish wiki |
| POST | `/wikis/:id/regenerate` | Yes | On-demand Quill regen |
| GET | `/published/wiki/:nanoid` | No | Public wiki (JSON or `?raw` markdown) |

### Schema changes

- `content text NOT NULL DEFAULT ''` added to `baseColumns()` (fragments, wikis, people)
- `source text`, `diff text` added to `edits`
- `wiki_types` table (slug PK, name, descriptors, prompt, is_default, user_modified)
- `published`, `published_slug`, `published_at`, `regenerate` added to `wikis`
- tsvector triggers updated to index content + aliases + slug

## Test plan

- [ ] `npx tsc --noEmit` in `core/` and `packages/shared/` — zero errors
- [ ] `npx vitest run` — all tests pass (60+ tests)
- [ ] `POST /wiki-types/setup` seeds 10 default types
- [ ] `create_wiki` via MCP creates wiki with inferred type
- [ ] `edit_wiki` via MCP updates content and logs edit with `source: 'mcp'`
- [ ] `POST /wikis/:id/publish` returns nanoid slug, `GET /published/wiki/:nanoid` serves content
- [ ] `POST /wikis/:id/regenerate` calls Quill and writes generated content
- [ ] `find_person` routes ULID to ID lookup, names to fuzzy search

🤖 Generated with [Claude Code](https://claude.com/claude-code)