### PR TITLE
M3-M6 gap closure: search, regen worker, API surface

### DIFF
--- a/core/drizzle/migrations/0005_bouncer_mode.sql
+++ b/core/drizzle/migrations/0005_bouncer_mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wikis" ADD COLUMN "bouncer_mode" text NOT NULL DEFAULT 'auto';

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781503200000,
       "tag": "0004_public_wikis",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781589600000,
+      "tag": "0005_bouncer_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/core/scripts/generate-openapi-manifest.ts
+++ b/core/scripts/generate-openapi-manifest.ts
@@ -179,7 +179,7 @@ const routes: RouteSpec[] = [
   { method: 'POST', path: '/people/{id}/regenerate', operationId: 'regeneratePerson', summary: 'Trigger person body regeneration', tags: ['People'], auth: 'session', request: { params: { id: 'lookupKey' } }, responses: { '202': { description: 'Job queued', schemaName: 'queuedResponseSchema' }, '404': { description: 'Not found', schemaName: 'errorResponseSchema' } } },
 
   // Search
-  { method: 'GET', path: '/search', operationId: 'search', summary: 'Search fragments (BM25 + vector)', tags: ['Search'], auth: 'session', request: { query: { schemaName: 'searchQuerySchema' } }, responses: { '200': { description: 'Search results', schemaName: 'searchResponseSchema' }, '400': { description: 'Missing query', schemaName: 'errorResponseSchema' } } },
+  { method: 'GET', path: '/search', operationId: 'search', summary: 'Hybrid search across fragments, wikis, and people', tags: ['Search'], auth: 'session', request: { query: { schemaName: 'searchQuerySchema' } }, responses: { '200': { description: 'Search results', schemaName: 'searchResponseSchema' }, '400': { description: 'Missing query', schemaName: 'errorResponseSchema' } } },
 
   // Graph
   { method: 'GET', path: '/graph', operationId: 'getGraph', summary: 'Get the knowledge graph', tags: ['Graph'], auth: 'session', responses: { '200': { description: 'Graph nodes and edges', schemaName: 'graphResponseSchema' } } },

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -217,6 +217,7 @@ export const wikis = pgTable(
     publishedSlug: text('published_slug'),
     publishedAt: timestamp('published_at'),
     regenerate: boolean('regenerate').notNull().default(true),
+    bouncerMode: text('bouncer_mode').notNull().default('auto'), // 'auto' | 'review'
     embedding: vector('embedding', { dimensions: 1536 }),
     searchVector: tsvector('search_vector'),
   },

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -1,0 +1,141 @@
+import { eq, ne, and, inArray, desc, isNull } from 'drizzle-orm'
+import { createIngestAgents, createStringCaller, embedText } from '@robin/agent'
+import { loadWikiGenerationSpec } from '@robin/shared'
+import type { WikiType } from '@robin/shared'
+import { db as defaultDb, type DB } from '../db/client.js'
+import { wikis, edges, fragments, edits } from '../db/schema.js'
+import { loadOpenRouterConfigFromDb } from './openrouter-config.js'
+import { nanoid } from './id.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ component: 'regen' })
+
+export interface RegenResult {
+  content: string
+  fragmentCount: number
+  hasEmbedding: boolean
+}
+
+/**
+ * Shared wiki regeneration logic used by both the on-demand route handler
+ * and the background regen worker.
+ */
+export async function regenerateWiki(
+  database: DB = defaultDb,
+  wikiKey: string,
+  opts?: { skipEmbedding?: boolean }
+): Promise<RegenResult> {
+  const [wiki] = await database.select().from(wikis).where(eq(wikis.lookupKey, wikiKey))
+  if (!wiki) throw new Error(`Wiki not found: ${wikiKey}`)
+
+  const previousContent = wiki.content
+
+  const orConfig = await loadOpenRouterConfigFromDb(database)
+  const agents = createIngestAgents(orConfig)
+  const callLlm = createStringCaller(agents.wikiClassifier)
+
+  // Gather linked fragments via FRAGMENT_IN_WIKI edges
+  const fragmentEdges = await database
+    .select({ srcId: edges.srcId })
+    .from(edges)
+    .where(
+      and(
+        eq(edges.dstId, wikiKey),
+        eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+        isNull(edges.deletedAt)
+      )
+    )
+
+  const fragmentKeys = fragmentEdges.map((e) => e.srcId)
+  let fragmentsText = ''
+  let fragmentCount = 0
+
+  if (fragmentKeys.length > 0) {
+    const fragRows = await database
+      .select({ title: fragments.title, content: fragments.content })
+      .from(fragments)
+      .where(and(inArray(fragments.lookupKey, fragmentKeys), isNull(fragments.deletedAt)))
+
+    fragmentCount = fragRows.length
+    fragmentsText = fragRows
+      .map((f) => `### ${f.title}\n${f.content}`)
+      .join('\n\n')
+  }
+
+  // Gather recent user edits for the {{edits}} template variable
+  const userEdits = await database
+    .select({ content: edits.content })
+    .from(edits)
+    .where(
+      and(
+        eq(edits.objectType, 'wiki'),
+        eq(edits.objectId, wikiKey),
+        eq(edits.source, 'user')
+      )
+    )
+    .orderBy(desc(edits.timestamp))
+    .limit(10)
+
+  const editsSummary = userEdits.length > 0
+    ? userEdits.map((e) => e.content).join('\n---\n')
+    : undefined
+
+  // Gather related wikis for cross-linking context
+  const otherWikis = await database
+    .select({ name: wikis.name, slug: wikis.slug, type: wikis.type })
+    .from(wikis)
+    .where(and(ne(wikis.lookupKey, wikiKey), isNull(wikis.deletedAt)))
+    .limit(20)
+
+  const relatedWikisText = otherWikis.length > 0
+    ? otherWikis.map((w) => `- ${w.slug} (${w.type}): ${w.name}`).join('\n')
+    : undefined
+
+  // Load prompt spec and call LLM
+  const spec = loadWikiGenerationSpec(wiki.type as WikiType, {
+    fragments: fragmentsText,
+    title: wiki.name,
+    date: new Date().toISOString().split('T')[0],
+    count: fragmentCount,
+    existingWiki: previousContent || undefined,
+    edits: editsSummary,
+    relatedWikis: relatedWikisText,
+  })
+
+  const markdown = await callLlm(spec.system, spec.user)
+
+  // Update wiki content
+  const now = new Date()
+  await database
+    .update(wikis)
+    .set({ content: markdown, lastRebuiltAt: now, updatedAt: now })
+    .where(eq(wikis.lookupKey, wikiKey))
+
+  // Compute and store embedding for the new content
+  let hasEmbedding = false
+  if (!opts?.skipEmbedding) {
+    const vec = await embedText(markdown, {
+      apiKey: orConfig.apiKey,
+      model: orConfig.embeddingModel,
+    })
+    if (vec) {
+      await database.update(wikis).set({ embedding: vec }).where(eq(wikis.lookupKey, wikiKey))
+      hasEmbedding = true
+    }
+  }
+
+  // Log edit with source: 'regen'
+  await database.insert(edits).values({
+    id: nanoid(),
+    objectType: 'wiki',
+    objectId: wikiKey,
+    type: 'addition',
+    content: previousContent,
+    source: 'regen',
+    diff: '',
+  })
+
+  log.info({ wikiKey, fragmentCount, hasEmbedding }, 'wiki regenerated')
+
+  return { content: markdown, fragmentCount, hasEmbedding }
+}

--- a/core/src/lib/search.ts
+++ b/core/src/lib/search.ts
@@ -1,0 +1,208 @@
+import { sql } from 'drizzle-orm'
+import { embedText, type EmbedConfig } from '@robin/agent'
+import type { DB } from '../db/client.js'
+import { fragments, wikis, people } from '../db/schema.js'
+
+export interface SearchResult {
+  id: string
+  type: 'fragment' | 'wiki' | 'person'
+  title: string
+  snippet: string
+  score: number
+}
+
+type SearchTable = 'fragment' | 'wiki' | 'person'
+
+// Reciprocal Rank Fusion: score = sum(1 / (k + rank)) across all lists
+function rrfFuse(lists: SearchResult[][], k = 60): SearchResult[] {
+  const scores = new Map<string, { result: SearchResult; score: number }>()
+
+  for (const list of lists) {
+    for (let rank = 0; rank < list.length; rank++) {
+      const item = list[rank]
+      const key = `${item.type}:${item.id}`
+      const existing = scores.get(key)
+      const rrfScore = 1 / (k + rank + 1)
+      if (existing) {
+        existing.score += rrfScore
+      } else {
+        scores.set(key, { result: item, score: rrfScore })
+      }
+    }
+  }
+
+  return Array.from(scores.values())
+    .sort((a, b) => b.score - a.score)
+    .map(({ result, score }) => ({ ...result, score }))
+}
+
+function snippet(text: string | null | undefined, len = 200): string {
+  if (!text) return ''
+  return text.length > len ? text.slice(0, len) : text
+}
+
+// Table metadata for building queries
+const tableMeta = {
+  fragment: {
+    table: fragments,
+    idCol: fragments.lookupKey,
+    titleCol: fragments.title,
+    contentCol: fragments.content,
+    searchVectorCol: fragments.searchVector,
+    embeddingCol: fragments.embedding,
+    deletedAtCol: fragments.deletedAt,
+  },
+  wiki: {
+    table: wikis,
+    idCol: wikis.lookupKey,
+    titleCol: wikis.name,
+    contentCol: wikis.content,
+    searchVectorCol: wikis.searchVector,
+    embeddingCol: wikis.embedding,
+    deletedAtCol: wikis.deletedAt,
+  },
+  person: {
+    table: people,
+    idCol: people.lookupKey,
+    titleCol: people.name,
+    contentCol: people.content,
+    searchVectorCol: people.searchVector,
+    embeddingCol: people.embedding,
+    deletedAtCol: people.deletedAt,
+  },
+} as const
+
+async function bm25SearchTable(
+  database: DB,
+  query: string,
+  tableType: SearchTable,
+  limit: number
+): Promise<SearchResult[]> {
+  const meta = tableMeta[tableType]
+  const tsQuery = sql`plainto_tsquery('english', ${query})`
+
+  const rows = await database
+    .select({
+      id: meta.idCol,
+      title: meta.titleCol,
+      content: meta.contentCol,
+      score: sql<number>`ts_rank(${meta.searchVectorCol}, ${tsQuery})`,
+    })
+    .from(meta.table)
+    .where(
+      sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery}`
+    )
+    .orderBy(sql`ts_rank(${meta.searchVectorCol}, ${tsQuery}) DESC`)
+    .limit(limit)
+
+  return rows.map((r) => ({
+    id: r.id,
+    type: tableType,
+    title: r.title ?? '',
+    snippet: snippet(r.content),
+    score: Number(r.score ?? 0),
+  }))
+}
+
+async function bm25Search(
+  database: DB,
+  query: string,
+  opts: { limit?: number; tables?: SearchTable[] } = {}
+): Promise<SearchResult[]> {
+  const limit = opts.limit ?? 20
+  const tables = opts.tables ?? ['fragment', 'wiki', 'person']
+
+  const results = await Promise.all(
+    tables.map((t) => bm25SearchTable(database, query, t, limit))
+  )
+
+  return results
+    .flat()
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
+
+async function vectorSearchTable(
+  database: DB,
+  queryEmbedding: number[],
+  tableType: SearchTable,
+  limit: number
+): Promise<SearchResult[]> {
+  const meta = tableMeta[tableType]
+  const vecLiteral = JSON.stringify(queryEmbedding)
+
+  const rows = await database
+    .select({
+      id: meta.idCol,
+      title: meta.titleCol,
+      content: meta.contentCol,
+      distance: sql<number>`${meta.embeddingCol} <=> ${sql.raw(`'${vecLiteral}'::vector`)}`,
+    })
+    .from(meta.table)
+    .where(
+      sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL`
+    )
+    .orderBy(sql`${meta.embeddingCol} <=> ${sql.raw(`'${vecLiteral}'::vector`)}`)
+    .limit(limit)
+
+  return rows.map((r) => ({
+    id: r.id,
+    type: tableType,
+    title: r.title ?? '',
+    snippet: snippet(r.content),
+    score: 1 - Number(r.distance ?? 1) / 2,
+  }))
+}
+
+async function vectorSearch(
+  database: DB,
+  queryEmbedding: number[],
+  opts: { limit?: number; tables?: SearchTable[] } = {}
+): Promise<SearchResult[]> {
+  const limit = opts.limit ?? 20
+  const tables = opts.tables ?? ['fragment', 'wiki', 'person']
+
+  const results = await Promise.all(
+    tables.map((t) => vectorSearchTable(database, queryEmbedding, t, limit))
+  )
+
+  return results
+    .flat()
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
+
+export async function hybridSearch(
+  database: DB,
+  query: string,
+  opts: {
+    limit?: number
+    tables?: SearchTable[]
+    mode?: 'hybrid' | 'bm25' | 'vector'
+    embedConfig?: EmbedConfig
+  } = {}
+): Promise<SearchResult[]> {
+  const limit = opts.limit ?? 20
+  const tables = opts.tables ?? ['fragment', 'wiki', 'person']
+  const mode = opts.mode ?? 'hybrid'
+
+  const lists: SearchResult[][] = []
+
+  if (mode === 'bm25' || mode === 'hybrid') {
+    lists.push(await bm25Search(database, query, { limit, tables }))
+  }
+
+  if (mode === 'vector' || mode === 'hybrid') {
+    if (opts.embedConfig) {
+      const vec = await embedText(query, opts.embedConfig)
+      if (vec) {
+        lists.push(await vectorSearch(database, vec, { limit, tables }))
+      }
+    }
+  }
+
+  if (lists.length === 0) return []
+  if (lists.length === 1) return lists[0].slice(0, limit)
+
+  return rrfFuse(lists).slice(0, limit)
+}

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -26,6 +26,8 @@ import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWi
 import type { McpServerDeps } from './handlers.js'
 import { wikis } from '../db/schema.js'
 import { nanoid24 } from '../lib/id.js'
+import { hybridSearch } from '../lib/search.js'
+import { loadOpenRouterConfigFromDb } from '../lib/openrouter-config.js'
 
 export type { McpServerDeps }
 
@@ -254,6 +256,68 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Provide id or query' }) }],
           isError: true as const,
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
+        }
+      }
+    }
+  )
+
+  /***********************************************************************
+   * ## Search
+   ***********************************************************************/
+
+  server.registerTool(
+    'search',
+    {
+      description:
+        'Search the knowledge base across wikis, fragments, and people. ' +
+        'Returns ranked results using hybrid BM25 + semantic search with RRF fusion. ' +
+        'Use mode=bm25 for keyword search, mode=vector for semantic, mode=hybrid (default) for both.',
+      inputSchema: {
+        query: z.string().describe('Search query text'),
+        tables: z.string().optional().describe('Comma-separated: fragments,wikis,people (default: all)'),
+        mode: z.enum(['hybrid', 'bm25', 'vector']).optional().describe('Search mode (default: hybrid)'),
+        limit: z.number().optional().describe('Max results (default: 10)'),
+      },
+    },
+    async ({ query, tables, mode, limit }) => {
+      try {
+        const parsedTables = tables
+          ? (tables.split(',').map((t) => t.trim()).filter(Boolean) as ('fragment' | 'wiki' | 'person')[])
+          : undefined
+
+        let embedConfig: { apiKey: string; model: string } | undefined
+        if (mode !== 'bm25') {
+          try {
+            const orConfig = await loadOpenRouterConfigFromDb(deps.db)
+            embedConfig = { apiKey: orConfig.apiKey, model: orConfig.embeddingModel }
+          } catch {
+            // No OpenRouter key — fall back to BM25-only
+            if (mode === 'vector') {
+              return {
+                content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Vector search requires an OpenRouter API key' }) }],
+                isError: true as const,
+              }
+            }
+          }
+        }
+
+        const effectiveMode = (!embedConfig && mode !== 'bm25') ? 'bm25' : (mode ?? 'hybrid')
+
+        const results = await hybridSearch(deps.db, query, {
+          limit: limit ?? 10,
+          tables: parsedTables,
+          mode: effectiveMode,
+          embedConfig,
+        })
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(results) }],
         }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)

--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -1,13 +1,109 @@
-// TODO(M3): restore regen pipeline. Wave 2 deleted the regen agent and
-// frontmatter assembly modules; this stub keeps the type surface alive so
-// callers can compile while the worker is dormant.
-
 import type { JobResult, RegenJob, RegenBatchJob } from '@robin/queue'
+import { eq, and, isNull, lt, sql } from 'drizzle-orm'
+import { db } from '../db/client.js'
+import { wikis, edges } from '../db/schema.js'
+import { regenerateWiki } from '../lib/regen.js'
+import { logger } from '../lib/logger.js'
 
-export async function processRegenJob(_job: RegenJob): Promise<JobResult> {
-  throw new Error('regen disabled in M2 — will be restored in M3')
+const log = logger.child({ component: 'regen-worker' })
+
+/** Max wikis to process in a single batch job */
+const BATCH_LIMIT = 5
+
+/** Wikis older than this many hours are candidates for batch regen */
+const STALE_HOURS = 24
+
+export async function processRegenJob(job: RegenJob): Promise<JobResult> {
+  log.info({ jobId: job.jobId, wikiKey: job.objectKey }, 'processing regen job')
+
+  try {
+    const result = await regenerateWiki(db, job.objectKey)
+    log.info(
+      { jobId: job.jobId, wikiKey: job.objectKey, fragmentCount: result.fragmentCount },
+      'regen job completed'
+    )
+    return {
+      jobId: job.jobId,
+      success: true,
+      processedAt: new Date().toISOString(),
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ jobId: job.jobId, wikiKey: job.objectKey, error: message }, 'regen job failed')
+    return {
+      jobId: job.jobId,
+      success: false,
+      error: message,
+      processedAt: new Date().toISOString(),
+    }
+  }
 }
 
-export async function processRegenBatchJob(_job: RegenBatchJob): Promise<JobResult> {
-  throw new Error('regen disabled in M2 — will be restored in M3')
+export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResult> {
+  log.info({ jobId: job.jobId }, 'processing regen batch job')
+
+  try {
+    const cutoff = new Date(Date.now() - STALE_HOURS * 60 * 60 * 1000)
+
+    // Find wikis with lastRebuiltAt older than the cutoff that have linked fragments
+    const staleWikis = await db
+      .select({ lookupKey: wikis.lookupKey })
+      .from(wikis)
+      .where(
+        and(
+          isNull(wikis.deletedAt),
+          eq(wikis.regenerate, true),
+          lt(wikis.lastRebuiltAt, cutoff)
+        )
+      )
+      .limit(BATCH_LIMIT)
+
+    // Filter to wikis that actually have fragments linked since last rebuild
+    const toRegen: string[] = []
+    for (const wiki of staleWikis) {
+      const [hasEdge] = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(edges)
+        .where(
+          and(
+            eq(edges.dstId, wiki.lookupKey),
+            eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+            isNull(edges.deletedAt)
+          )
+        )
+      if (hasEdge && hasEdge.count > 0) {
+        toRegen.push(wiki.lookupKey)
+      }
+    }
+
+    let succeeded = 0
+    let failed = 0
+    for (const wikiKey of toRegen) {
+      try {
+        await regenerateWiki(db, wikiKey)
+        succeeded++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        log.warn({ wikiKey, error: message }, 'batch regen failed for wiki')
+        failed++
+      }
+    }
+
+    log.info({ jobId: job.jobId, succeeded, failed, total: toRegen.length }, 'regen batch completed')
+
+    return {
+      jobId: job.jobId,
+      success: failed === 0,
+      processedAt: new Date().toISOString(),
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ jobId: job.jobId, error: message }, 'regen batch job failed')
+    return {
+      jobId: job.jobId,
+      success: false,
+      error: message,
+      processedAt: new Date().toISOString(),
+    }
+  }
 }

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -1,13 +1,11 @@
 /**
- * BullMQ workers for the M2 ingest pipeline.
+ * BullMQ workers for the ingest + regen pipeline.
  *
- * Two long-lived workers run for the single user: extraction and link.
+ * Three long-lived workers run for the single user: extraction, link, and regen.
  * Extraction loads OpenRouter creds per-call, builds fresh Mastra agents,
  * and dispatches to runExtraction. Link does the same for runLinking.
+ * Regen rebuilds wiki content when new fragments are linked.
  * Retries, backoff, and DLQ are handled by BullMQ via RETRY_CONFIG.
- *
- * Regen, reclassify, and provision are dormant or stubbed in M2. See the
- * TODO(M3) comments in startWorkers().
  */
 
 import {
@@ -53,6 +51,7 @@ import { resolveFragmentSlug } from '../db/slug.js'
 import { computeContentHash } from '../db/dedup.js'
 import { emitPipelineEvent } from '../db/pipeline-events.js'
 import { producer } from './producer.js'
+import { processRegenJob } from './regen-worker.js'
 import { loadOpenRouterConfigFromDb } from '../lib/openrouter-config.js'
 import { logger } from '../lib/logger.js'
 
@@ -391,7 +390,29 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
       llmCall: createTypedCaller(agents.fragScorer, fragmentRelevanceSchema),
       emitEvent,
     },
-    insertEdge: insertEdgeRow,
+    insertEdge: async (edge: Record<string, unknown>) => {
+      await insertEdgeRow(edge)
+
+      // After creating a FRAGMENT_IN_WIKI edge, enqueue a regen job for the
+      // target wiki. BullMQ deduplicates by jobId (`regen-<wikiKey>`), so
+      // rapid fragment links to the same wiki collapse into a single regen.
+      if (edge.edgeType === 'FRAGMENT_IN_WIKI' && typeof edge.dstId === 'string') {
+        try {
+          await producer.enqueueRegen({
+            type: 'regen',
+            jobId: crypto.randomUUID(),
+            objectKey: edge.dstId,
+            objectType: 'wiki',
+            triggeredBy: 'scheduler',
+            enqueuedAt: new Date().toISOString(),
+          })
+          log.info({ wikiKey: edge.dstId }, 'regen job enqueued for wiki')
+        } catch (err) {
+          // Non-fatal: wiki will be picked up by the next batch scan
+          log.warn({ wikiKey: edge.dstId, err }, 'failed to enqueue regen job')
+        }
+      }
+    },
   }
 
   await runLinking(deps, {
@@ -412,12 +433,12 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
 
 let extractionWorker: ReturnType<typeof bullWorker.startExtractionWorker> | null = null
 let linkWorker: ReturnType<typeof bullWorker.startLinkWorker> | null = null
+let regenWorker: ReturnType<typeof bullWorker.startRegenWorker> | null = null
 
 /**
  * Start global ingest workers. Single-user — one worker per queue, no per-user fan-out.
- *
- * TODO(M3): re-register the regen worker, regen scheduler, and reclassify worker
- * once those pipelines come back online.
+ * Extraction and link workers handle ingest; regen worker rebuilds wikis when
+ * new fragments are linked via FRAGMENT_IN_WIKI edges.
  */
 export function startWorkers(): void {
   if (extractionWorker || linkWorker) {
@@ -434,6 +455,10 @@ export function startWorkers(): void {
   linkWorker = bullWorker.startLinkWorker(processLinkJob)
   linkWorker.on('completed', (job) => log.info({ jobId: job.id }, 'link completed'))
   linkWorker.on('failed', (job, err) => log.error({ jobId: job?.id, err }, 'link failed'))
+
+  regenWorker = bullWorker.startRegenWorker(processRegenJob)
+  regenWorker.on('completed', (job) => log.info({ jobId: job.id }, 'regen completed'))
+  regenWorker.on('failed', (job, err) => log.error({ jobId: job?.id, err }, 'regen failed'))
 
   log.info('ingest workers started')
 }

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -1,50 +1,103 @@
 import { Hono } from 'hono'
-import { eq, desc } from 'drizzle-orm'
+import { eq, and, desc, isNull, inArray } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
 import { makeLookupKey, generateSlug } from '@robin/shared'
 import { resolveFragmentSlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateFragment } from '../db/dedup.js'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { fragments, entries } from '../db/schema.js'
+import { fragments, entries, edges, wikis, people } from '../db/schema.js'
 import { validationHook } from '../lib/validation.js'
 import {
   fragmentResponseSchema,
   fragmentWithContentResponseSchema,
+  fragmentDetailResponseSchema,
   fragmentListResponseSchema,
   createFragmentBodySchema,
   updateFragmentBodySchema,
   fragmentListQuerySchema,
+  fragmentReviewBodySchema,
 } from '../schemas/fragments.schema.js'
 
 const fragmentsRouter = new Hono()
 fragmentsRouter.use('*', sessionMiddleware)
 
-// GET /fragments — list fragments (metadata only)
+// GET /fragments — list fragments (metadata only, no content)
 fragmentsRouter.get('/', async (c) => {
-  const query = fragmentListQuerySchema.safeParse({ limit: c.req.query('limit') })
+  const query = fragmentListQuerySchema.safeParse({
+    limit: c.req.query('limit'),
+    offset: c.req.query('offset'),
+    vaultId: c.req.query('vaultId'),
+  })
   const limit = query.success ? query.data.limit : 50
+  const offset = query.success ? query.data.offset : 0
+  const vaultId = query.success ? query.data.vaultId : undefined
 
+  const condition = vaultId ? eq(fragments.vaultId, vaultId) : undefined
   const rows = await db
     .select()
     .from(fragments)
+    .where(condition)
     .orderBy(desc(fragments.updatedAt))
     .limit(limit)
+    .offset(offset)
 
   return c.json(
     fragmentListResponseSchema.parse({ fragments: rows.map((r) => ({ ...r, id: r.lookupKey })) })
   )
 })
 
-// GET /fragments/:id — get fragment metadata (content lives in DB only post-M2)
+// GET /fragments/:id — detail with content and backlinks
 fragmentsRouter.get('/:id', async (c) => {
   const id = c.req.param('id')
 
   const [fragment] = await db.select().from(fragments).where(eq(fragments.lookupKey, id))
   if (!fragment) return c.json({ error: 'Not found' }, 404)
 
+  // Resolve backlinks: edges where this fragment is srcId
+  const outEdges = await db
+    .select()
+    .from(edges)
+    .where(and(eq(edges.srcId, id), isNull(edges.deletedAt)))
+
+  // Batch-resolve destination names
+  const backlinks: { id: string; name: string; type: string }[] = []
+  const dstByType: Record<string, string[]> = {}
+  for (const e of outEdges) {
+    const t = e.dstType === 'frag' ? 'fragment' : e.dstType
+    if (!dstByType[t]) dstByType[t] = []
+    dstByType[t].push(e.dstId)
+  }
+
+  if (dstByType.wiki?.length) {
+    const rows = await db
+      .select({ key: wikis.lookupKey, name: wikis.name })
+      .from(wikis)
+      .where(inArray(wikis.lookupKey, dstByType.wiki))
+    for (const r of rows) backlinks.push({ id: r.key, name: r.name, type: 'wiki' })
+  }
+  if (dstByType.person?.length) {
+    const rows = await db
+      .select({ key: people.lookupKey, name: people.name })
+      .from(people)
+      .where(inArray(people.lookupKey, dstByType.person))
+    for (const r of rows) backlinks.push({ id: r.key, name: r.name, type: 'person' })
+  }
+  if (dstByType.fragment?.length) {
+    const rows = await db
+      .select({ key: fragments.lookupKey, title: fragments.title })
+      .from(fragments)
+      .where(inArray(fragments.lookupKey, dstByType.fragment))
+    for (const r of rows) backlinks.push({ id: r.key, name: r.title, type: 'fragment' })
+  }
+
   return c.json(
-    fragmentWithContentResponseSchema.parse({ ...fragment, id: fragment.lookupKey, content: '' })
+    fragmentDetailResponseSchema.parse({
+      ...fragment,
+      id: fragment.lookupKey,
+      content: fragment.content ?? '',
+      backlinks,
+    })
   )
 })
 
@@ -139,6 +192,82 @@ fragmentsRouter.get('/:id/links', async (c) => {
 // TODO(phase-5): rewrite to use edges table
 fragmentsRouter.get('/:id/backlinks', async (c) => {
   return c.json({ backlinks: [] })
+})
+
+// POST /fragments/:id/accept — accept fragment into a review-mode wiki
+fragmentsRouter.post('/:id/accept', zValidator('json', fragmentReviewBodySchema, validationHook), async (c) => {
+  const id = c.req.param('id')
+  const { wikiId } = c.req.valid('json')
+
+  // Verify fragment exists
+  const [fragment] = await db.select().from(fragments).where(eq(fragments.lookupKey, id))
+  if (!fragment) return c.json({ error: 'Fragment not found' }, 404)
+
+  // Verify wiki exists and is in review mode
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, wikiId))
+  if (!wiki) return c.json({ error: 'Wiki not found' }, 404)
+  if (wiki.bouncerMode !== 'review') {
+    return c.json({ error: 'Wiki is not in review mode' }, 400)
+  }
+
+  // Find the FRAGMENT_IN_WIKI edge
+  const [edge] = await db
+    .select()
+    .from(edges)
+    .where(
+      and(
+        eq(edges.srcId, id),
+        eq(edges.dstId, wikiId),
+        eq(edges.edgeType, 'FRAGMENT_IN_WIKI')
+      )
+    )
+  if (!edge) return c.json({ error: 'No edge between fragment and wiki' }, 404)
+
+  // Accept: clear deletedAt to activate the edge
+  await db
+    .update(edges)
+    .set({ deletedAt: null })
+    .where(eq(edges.id, edge.id))
+
+  return c.json({ ok: true, fragmentId: id, wikiId })
+})
+
+// POST /fragments/:id/reject — reject fragment from a review-mode wiki
+fragmentsRouter.post('/:id/reject', zValidator('json', fragmentReviewBodySchema, validationHook), async (c) => {
+  const id = c.req.param('id')
+  const { wikiId } = c.req.valid('json')
+
+  // Verify fragment exists
+  const [fragment] = await db.select().from(fragments).where(eq(fragments.lookupKey, id))
+  if (!fragment) return c.json({ error: 'Fragment not found' }, 404)
+
+  // Verify wiki exists and is in review mode
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, wikiId))
+  if (!wiki) return c.json({ error: 'Wiki not found' }, 404)
+  if (wiki.bouncerMode !== 'review') {
+    return c.json({ error: 'Wiki is not in review mode' }, 400)
+  }
+
+  // Find the FRAGMENT_IN_WIKI edge
+  const [edge] = await db
+    .select()
+    .from(edges)
+    .where(
+      and(
+        eq(edges.srcId, id),
+        eq(edges.dstId, wikiId),
+        eq(edges.edgeType, 'FRAGMENT_IN_WIKI')
+      )
+    )
+  if (!edge) return c.json({ error: 'No edge between fragment and wiki' }, 404)
+
+  // Reject: soft-delete the edge
+  await db
+    .update(edges)
+    .set({ deletedAt: new Date() })
+    .where(eq(edges.id, edge.id))
+
+  return c.json({ ok: true, fragmentId: id, wikiId })
 })
 
 export { fragmentsRouter as fragmentsRoutes }

--- a/core/src/routes/graph.ts
+++ b/core/src/routes/graph.ts
@@ -22,12 +22,29 @@ graphRouter.use('*', sessionMiddleware)
 // GET /graph — build graph nodes and edges from the edges table
 graphRouter.get('/', async (c) => {
   const vaultId = c.req.query('vaultId')
+  const wikiId = c.req.query('wikiId')
 
   // 1. Query all edges
   let edgeRows = await db.select().from(edges).where(isNull(edges.deletedAt))
 
-  // 2. If vaultId filter, find entries/fragments in that vault, then filter edges
-  if (vaultId) {
+  // 2a. If wikiId filter, return only subgraph for that wiki (its fragments + their people)
+  if (wikiId) {
+    // Find FRAGMENT_IN_WIKI edges for this wiki
+    const wikiFragEdges = edgeRows.filter(
+      (e) => e.edgeType === 'FRAGMENT_IN_WIKI' && e.dstId === wikiId
+    )
+    const fragIds = new Set(wikiFragEdges.map((e) => e.srcId))
+
+    // Include: wiki-fragment edges + any edges from those fragments (e.g. mentions)
+    edgeRows = edgeRows.filter(
+      (e) =>
+        (e.edgeType === 'FRAGMENT_IN_WIKI' && e.dstId === wikiId) ||
+        (fragIds.has(e.srcId) && e.srcId !== wikiId)
+    )
+  }
+
+  // 2b. If vaultId filter, find entries/fragments in that vault, then filter edges
+  if (vaultId && !wikiId) {
     const vaultEntryKeys = await db
       .select({ key: entries.lookupKey })
       .from(entries)
@@ -80,7 +97,7 @@ graphRouter.get('/', async (c) => {
     idsByType[n.type].push(n.id)
   }
 
-  const labelMap: Record<string, { label: string; vaultId: string }> = {}
+  const labelMap: Record<string, { label: string; vaultId: string; snippet: string }> = {}
 
   if (idsByType.entry?.length) {
     const rows = await db
@@ -88,6 +105,7 @@ graphRouter.get('/', async (c) => {
         key: entries.lookupKey,
         title: entries.title,
         vaultId: entries.vaultId,
+        content: entries.content,
       })
       .from(entries)
       .where(inArray(entries.lookupKey, idsByType.entry))
@@ -95,6 +113,7 @@ graphRouter.get('/', async (c) => {
       labelMap[`entry:${r.key}`] = {
         label: r.title || 'Untitled Entry',
         vaultId: r.vaultId ?? '',
+        snippet: (r.content ?? '').slice(0, 100),
       }
   }
   if (idsByType.fragment?.length) {
@@ -103,6 +122,7 @@ graphRouter.get('/', async (c) => {
         key: fragments.lookupKey,
         title: fragments.title,
         entryId: fragments.entryId,
+        content: fragments.content,
       })
       .from(fragments)
       .where(inArray(fragments.lookupKey, idsByType.fragment))
@@ -120,28 +140,52 @@ graphRouter.get('/', async (c) => {
       labelMap[`fragment:${r.key}`] = {
         label: r.title || 'Untitled Fragment',
         vaultId: entryVaults[r.entryId] ?? '',
+        snippet: (r.content ?? '').slice(0, 100),
       }
   }
   if (idsByType.thread?.length) {
     const rows = await db
-      .select({ key: wikis.lookupKey, name: wikis.name })
+      .select({ key: wikis.lookupKey, name: wikis.name, content: wikis.content })
       .from(wikis)
       .where(inArray(wikis.lookupKey, idsByType.thread))
-    for (const r of rows) labelMap[`thread:${r.key}`] = { label: r.name, vaultId: '' }
+    for (const r of rows)
+      labelMap[`thread:${r.key}`] = {
+        label: r.name,
+        vaultId: '',
+        snippet: (r.content ?? '').slice(0, 100),
+      }
+  }
+  if (idsByType.wiki?.length) {
+    const rows = await db
+      .select({ key: wikis.lookupKey, name: wikis.name, content: wikis.content })
+      .from(wikis)
+      .where(inArray(wikis.lookupKey, idsByType.wiki))
+    for (const r of rows)
+      labelMap[`wiki:${r.key}`] = {
+        label: r.name,
+        vaultId: '',
+        snippet: (r.content ?? '').slice(0, 100),
+      }
   }
   if (idsByType.vault?.length) {
     const rows = await db
       .select({ id: vaults.id, name: vaults.name })
       .from(vaults)
       .where(inArray(vaults.id, idsByType.vault))
-    for (const r of rows) labelMap[`vault:${r.id}`] = { label: r.name, vaultId: r.id }
+    for (const r of rows)
+      labelMap[`vault:${r.id}`] = { label: r.name, vaultId: r.id, snippet: '' }
   }
   if (idsByType.person?.length) {
     const rows = await db
-      .select({ key: people.lookupKey, name: people.name })
+      .select({ key: people.lookupKey, name: people.name, content: people.content })
       .from(people)
       .where(inArray(people.lookupKey, idsByType.person))
-    for (const r of rows) labelMap[`person:${r.key}`] = { label: r.name, vaultId: '' }
+    for (const r of rows)
+      labelMap[`person:${r.key}`] = {
+        label: r.name,
+        vaultId: '',
+        snippet: (r.content ?? '').slice(0, 100),
+      }
   }
 
   // 5. Build nodes array
@@ -153,6 +197,7 @@ graphRouter.get('/', async (c) => {
       type: n.type as 'wiki' | 'fragment' | 'person' | 'entry' | 'vault',
       vaultId: resolved?.vaultId ?? '',
       size: n.edgeCount,
+      snippet: resolved?.snippet ?? '',
     }
   })
 

--- a/core/src/routes/people.ts
+++ b/core/src/routes/people.ts
@@ -1,12 +1,16 @@
 import { Hono } from 'hono'
-import { eq } from 'drizzle-orm'
+import { eq, and, isNull, inArray } from 'drizzle-orm'
+import { zValidator } from '@hono/zod-validator'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { people } from '../db/schema.js'
+import { people, edges, fragments } from '../db/schema.js'
 import { logger } from '../lib/logger.js'
+import { validationHook } from '../lib/validation.js'
 import {
-  personWithBacklinksResponseSchema,
+  personDetailResponseSchema,
   personListResponseSchema,
+  updatePersonBodySchema,
+  personListQuerySchema,
 } from '../schemas/people.schema.js'
 
 const log = logger.child({ component: 'people' })
@@ -14,33 +18,92 @@ const log = logger.child({ component: 'people' })
 const peopleRouter = new Hono()
 peopleRouter.use('*', sessionMiddleware)
 
-// GET /people — list all people
+// GET /people — list all people with pagination
 peopleRouter.get('/', async (c) => {
-  const rows = await db.select().from(people).orderBy(people.name)
+  const query = personListQuerySchema.safeParse({
+    limit: c.req.query('limit'),
+    offset: c.req.query('offset'),
+  })
+  const limit = query.success ? query.data.limit : 50
+  const offset = query.success ? query.data.offset : 0
+
+  const rows = await db
+    .select()
+    .from(people)
+    .orderBy(people.name)
+    .limit(limit)
+    .offset(offset)
 
   return c.json(
     personListResponseSchema.parse({ people: rows.map((r) => ({ ...r, id: r.lookupKey })) })
   )
 })
 
-// GET /people/:id — get person with backlinks
-// TODO(phase-6): query backlinks via edges table (FRAGMENT_MENTIONS_PERSON)
+// GET /people/:id — detail with content and backlinks (fragments mentioning this person)
 peopleRouter.get('/:id', async (c) => {
   const id = c.req.param('id')
 
   const [person] = await db.select().from(people).where(eq(people.lookupKey, id))
   if (!person) return c.json({ error: 'Not found' }, 404)
 
-  // TODO(phase-6): query via edges table
-  const backlinkFragmentIds: string[] = []
-  const backlinkThreadIds: string[] = []
+  // Query backlinks: edges where dstId = this person and edgeType = FRAGMENT_MENTIONS_PERSON
+  const mentionEdges = await db
+    .select()
+    .from(edges)
+    .where(
+      and(
+        eq(edges.dstId, id),
+        eq(edges.edgeType, 'FRAGMENT_MENTIONS_PERSON'),
+        isNull(edges.deletedAt)
+      )
+    )
+
+  const backlinks: { id: string; title: string }[] = []
+  const srcIds = mentionEdges.map((e) => e.srcId)
+  if (srcIds.length) {
+    const rows = await db
+      .select({ key: fragments.lookupKey, title: fragments.title })
+      .from(fragments)
+      .where(inArray(fragments.lookupKey, srcIds))
+    for (const r of rows) backlinks.push({ id: r.key, title: r.title })
+  }
 
   return c.json(
-    personWithBacklinksResponseSchema.parse({
+    personDetailResponseSchema.parse({
       ...person,
       id: person.lookupKey,
-      backlinkFragmentIds,
-      backlinkThreadIds,
+      content: person.content ?? '',
+      backlinks,
+    })
+  )
+})
+
+// PUT /people/:id — update person
+peopleRouter.put('/:id', zValidator('json', updatePersonBodySchema, validationHook), async (c) => {
+  const id = c.req.param('id')
+  const body = c.req.valid('json')
+
+  const [existing] = await db.select().from(people).where(eq(people.lookupKey, id))
+  if (!existing) return c.json({ error: 'Not found' }, 404)
+
+  const updates: Record<string, unknown> = { updatedAt: new Date() }
+  if (body.name != null) updates.name = body.name
+  if (body.relationship != null) updates.relationship = body.relationship
+  if (body.aliases != null) updates.aliases = body.aliases
+  if (body.content != null) updates.content = body.content
+
+  const [person] = await db
+    .update(people)
+    .set(updates)
+    .where(eq(people.lookupKey, id))
+    .returning()
+
+  return c.json(
+    personDetailResponseSchema.parse({
+      ...person,
+      id: person.lookupKey,
+      content: person.content ?? '',
+      backlinks: [],
     })
   )
 })

--- a/core/src/routes/search.ts
+++ b/core/src/routes/search.ts
@@ -1,55 +1,40 @@
 import { Hono } from 'hono'
-import { and, eq, sql } from 'drizzle-orm'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { fragments } from '../db/schema.js'
 import { searchQuerySchema, searchResponseSchema } from '../schemas/search.schema.js'
+import { hybridSearch } from '../lib/search.js'
+import { loadOpenRouterConfigFromDb } from '../lib/openrouter-config.js'
 
 const search = new Hono()
 search.use('*', sessionMiddleware)
 
-// GET /search — Postgres-backed full-text search over fragments
-// TODO(phase-5): score with hybrid BM25 + pgvector reranking
+// GET /search — hybrid BM25 + pgvector search across fragments, wikis, people
 search.get('/', async (c) => {
   const parsed = searchQuerySchema.safeParse({
     q: c.req.query('q'),
     limit: c.req.query('limit'),
-    minScore: c.req.query('minScore'),
+    tables: c.req.query('tables'),
+    mode: c.req.query('mode'),
     vaultId: c.req.query('vaultId'),
   })
   if (!parsed.success)
     return c.json({ error: 'Validation failed', fields: parsed.error.flatten() }, 400)
 
-  const { q, limit, vaultId } = parsed.data
+  const { q, limit, tables, mode } = parsed.data
 
-  const tsQuery = sql`plainto_tsquery('english', ${q})`
-  const conditions = [sql`${fragments.searchVector} @@ ${tsQuery}`]
-  if (vaultId) conditions.push(eq(fragments.vaultId, vaultId))
+  let embedConfig: { apiKey: string; model: string } | undefined
+  if (mode === 'hybrid' || mode === 'vector') {
+    try {
+      const orConfig = await loadOpenRouterConfigFromDb(db)
+      embedConfig = { apiKey: orConfig.apiKey, model: orConfig.embeddingModel }
+    } catch {
+      // No OpenRouter key configured — fall back to BM25 only
+    }
+  }
 
-  const rows = await db
-    .select({
-      lookupKey: fragments.lookupKey,
-      title: fragments.title,
-      tags: fragments.tags,
-      vaultId: fragments.vaultId,
-      score: sql<number>`ts_rank(${fragments.searchVector}, ${tsQuery})`,
-    })
-    .from(fragments)
-    .where(and(...conditions))
-    .orderBy(sql`ts_rank(${fragments.searchVector}, ${tsQuery}) DESC`)
-    .limit(limit)
+  const results = await hybridSearch(db, q, { limit, tables, mode, embedConfig })
 
-  const enriched = rows.map((r) => ({
-    score: Number(r.score ?? 0),
-    fragmentId: r.lookupKey,
-    title: r.title,
-    fragment: '',
-    tags: r.tags,
-    vaultId: r.vaultId ?? undefined,
-    threadId: undefined,
-  }))
-
-  return c.json(searchResponseSchema.parse({ results: enriched }))
+  return c.json(searchResponseSchema.parse({ results }))
 })
 
 export { search }

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -15,6 +15,8 @@ import {
   threadWithWikiResponseSchema,
   updateThreadBodySchema,
   publishWikiResponseSchema,
+  bouncerModeBodySchema,
+  bouncerModeResponseSchema,
 } from '../schemas/wikis.schema.js'
 
 const log = logger.child({ component: 'wikis' })
@@ -141,6 +143,22 @@ wikisRouter.post('/:id/regenerate', async (c) => {
     log.error({ wikiKey: id, error: message }, 'wiki regen failed')
     return c.json({ error: 'Regeneration failed', detail: message }, 500)
   }
+})
+
+// PATCH /wikis/:id/bouncer — toggle bouncer mode (auto/review)
+wikisRouter.patch('/:id/bouncer', zValidator('json', bouncerModeBodySchema, validationHook), async (c) => {
+  const id = c.req.param('id')
+  const { mode } = c.req.valid('json')
+
+  const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
+  if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+  await db
+    .update(wikis)
+    .set({ bouncerMode: mode, updatedAt: new Date() })
+    .where(eq(wikis.lookupKey, id))
+
+  return c.json(bouncerModeResponseSchema.parse({ id, bouncerMode: mode }))
 })
 
 // POST /wikis/:targetId/merge — merge source thread into target

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -1,16 +1,15 @@
 import { Hono } from 'hono'
-import { eq, ne, and, inArray, desc, isNull } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
-import { generateSlug, loadWikiGenerationSpec } from '@robin/shared'
-import type { WikiType } from '@robin/shared'
-import { createIngestAgents, createStringCaller, NoOpenRouterKeyError, embedText } from '@robin/agent'
+import { generateSlug } from '@robin/shared'
+import { NoOpenRouterKeyError } from '@robin/agent'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { wikis, edges, fragments, edits } from '../db/schema.js'
+import { wikis } from '../db/schema.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
-import { nanoid24, nanoid } from '../lib/id.js'
-import { loadOpenRouterConfigFromDb } from '../lib/openrouter-config.js'
+import { nanoid24 } from '../lib/id.js'
+import { regenerateWiki } from '../lib/regen.js'
 import {
   threadResponseSchema,
   threadWithWikiResponseSchema,
@@ -130,113 +129,10 @@ wikisRouter.post('/:id/regenerate', async (c) => {
     return c.json({ error: 'Regeneration is disabled for this wiki' }, 400)
   }
 
-  const previousContent = wiki.content
-
   try {
-    const orConfig = await loadOpenRouterConfigFromDb(db)
-    const agents = createIngestAgents(orConfig)
-    const callLlm = createStringCaller(agents.wikiClassifier)
-
-    // Gather linked fragments via FRAGMENT_IN_WIKI edges
-    const fragmentEdges = await db
-      .select({ srcId: edges.srcId })
-      .from(edges)
-      .where(
-        and(
-          eq(edges.dstId, id),
-          eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
-          isNull(edges.deletedAt)
-        )
-      )
-
-    const fragmentKeys = fragmentEdges.map((e) => e.srcId)
-    let fragmentsText = ''
-    let fragmentCount = 0
-
-    if (fragmentKeys.length > 0) {
-      const fragRows = await db
-        .select({ title: fragments.title, content: fragments.content })
-        .from(fragments)
-        .where(and(inArray(fragments.lookupKey, fragmentKeys), isNull(fragments.deletedAt)))
-
-      fragmentCount = fragRows.length
-      fragmentsText = fragRows
-        .map((f) => `### ${f.title}\n${f.content}`)
-        .join('\n\n')
-    }
-
-    // Gather recent user edits for the {{edits}} template variable
-    const userEdits = await db
-      .select({ content: edits.content })
-      .from(edits)
-      .where(
-        and(
-          eq(edits.objectType, 'wiki'),
-          eq(edits.objectId, id),
-          eq(edits.source, 'user')
-        )
-      )
-      .orderBy(desc(edits.timestamp))
-      .limit(10)
-
-    const editsSummary = userEdits.length > 0
-      ? userEdits.map((e) => e.content).join('\n---\n')
-      : undefined
-
-    // Gather related wikis for cross-linking context
-    const otherWikis = await db
-      .select({ name: wikis.name, slug: wikis.slug, type: wikis.type })
-      .from(wikis)
-      .where(and(ne(wikis.lookupKey, id), isNull(wikis.deletedAt)))
-      .limit(20)
-
-    const relatedWikisText = otherWikis.length > 0
-      ? otherWikis.map((w) => `- ${w.slug} (${w.type}): ${w.name}`).join('\n')
-      : undefined
-
-    // Load prompt spec and call LLM
-    const spec = loadWikiGenerationSpec(wiki.type as WikiType, {
-      fragments: fragmentsText,
-      title: wiki.name,
-      date: new Date().toISOString().split('T')[0],
-      count: fragmentCount,
-      existingWiki: previousContent || undefined,
-      edits: editsSummary,
-      relatedWikis: relatedWikisText,
-    })
-
-    const markdown = await callLlm(spec.system, spec.user)
-
-    // Update wiki content and log edit
-    const now = new Date()
-    const [updated] = await db
-      .update(wikis)
-      .set({ content: markdown, lastRebuiltAt: now, updatedAt: now })
-      .where(eq(wikis.lookupKey, id))
-      .returning()
-
-    // Compute and store embedding for the new content
-    const vec = await embedText(markdown, {
-      apiKey: orConfig.apiKey,
-      model: orConfig.embeddingModel,
-    })
-    if (vec) {
-      await db.update(wikis).set({ embedding: vec }).where(eq(wikis.lookupKey, id))
-    }
-
-    await db.insert(edits).values({
-      id: nanoid(),
-      objectType: 'wiki',
-      objectId: id,
-      type: 'addition',
-      content: previousContent,
-      source: 'regen',
-      diff: '',
-    })
-
-    log.info({ wikiKey: id, fragmentCount, hasEmbedding: !!vec }, 'wiki regenerated via Quill')
-
-    return c.json({ ok: true, lookupKey: updated.lookupKey, lastRebuiltAt: updated.lastRebuiltAt })
+    const result = await regenerateWiki(db, id)
+    log.info({ wikiKey: id, ...result }, 'wiki regenerated via on-demand endpoint')
+    return c.json({ ok: true, lookupKey: id, fragmentCount: result.fragmentCount })
   } catch (err) {
     if (err instanceof NoOpenRouterKeyError) {
       return c.json({ error: 'OpenRouter API key not configured' }, 500)

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono'
-import { eq, and, inArray, desc, isNull } from 'drizzle-orm'
+import { eq, ne, and, inArray, desc, isNull } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
 import { generateSlug, loadWikiGenerationSpec } from '@robin/shared'
 import type { WikiType } from '@robin/shared'
-import { createIngestAgents, createStringCaller, NoOpenRouterKeyError } from '@robin/agent'
+import { createIngestAgents, createStringCaller, NoOpenRouterKeyError, embedText } from '@robin/agent'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
 import { wikis, edges, fragments, edits } from '../db/schema.js'
@@ -183,6 +183,17 @@ wikisRouter.post('/:id/regenerate', async (c) => {
       ? userEdits.map((e) => e.content).join('\n---\n')
       : undefined
 
+    // Gather related wikis for cross-linking context
+    const otherWikis = await db
+      .select({ name: wikis.name, slug: wikis.slug, type: wikis.type })
+      .from(wikis)
+      .where(and(ne(wikis.lookupKey, id), isNull(wikis.deletedAt)))
+      .limit(20)
+
+    const relatedWikisText = otherWikis.length > 0
+      ? otherWikis.map((w) => `- ${w.slug} (${w.type}): ${w.name}`).join('\n')
+      : undefined
+
     // Load prompt spec and call LLM
     const spec = loadWikiGenerationSpec(wiki.type as WikiType, {
       fragments: fragmentsText,
@@ -191,6 +202,7 @@ wikisRouter.post('/:id/regenerate', async (c) => {
       count: fragmentCount,
       existingWiki: previousContent || undefined,
       edits: editsSummary,
+      relatedWikis: relatedWikisText,
     })
 
     const markdown = await callLlm(spec.system, spec.user)
@@ -203,6 +215,15 @@ wikisRouter.post('/:id/regenerate', async (c) => {
       .where(eq(wikis.lookupKey, id))
       .returning()
 
+    // Compute and store embedding for the new content
+    const vec = await embedText(markdown, {
+      apiKey: orConfig.apiKey,
+      model: orConfig.embeddingModel,
+    })
+    if (vec) {
+      await db.update(wikis).set({ embedding: vec }).where(eq(wikis.lookupKey, id))
+    }
+
     await db.insert(edits).values({
       id: nanoid(),
       objectType: 'wiki',
@@ -213,7 +234,7 @@ wikisRouter.post('/:id/regenerate', async (c) => {
       diff: '',
     })
 
-    log.info({ wikiKey: id, fragmentCount }, 'wiki regenerated via Quill')
+    log.info({ wikiKey: id, fragmentCount, hasEmbedding: !!vec }, 'wiki regenerated via Quill')
 
     return c.json({ ok: true, lookupKey: updated.lookupKey, lastRebuiltAt: updated.lastRebuiltAt })
   } catch (err) {

--- a/core/src/schemas/fragments.schema.ts
+++ b/core/src/schemas/fragments.schema.ts
@@ -21,6 +21,17 @@ export const fragmentWithContentResponseSchema = fragmentResponseSchema.extend({
   content: z.string(),
 })
 
+/** Fragment detail with backlinks resolved from edges table */
+export const fragmentDetailResponseSchema = fragmentWithContentResponseSchema.extend({
+  backlinks: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      type: z.string(),
+    })
+  ),
+})
+
 export const fragmentListResponseSchema = z.object({
   fragments: z.array(fragmentResponseSchema),
 })
@@ -40,6 +51,14 @@ export const updateFragmentBodySchema = z.object({
   tags: z.array(z.string()).optional(),
 })
 
+/** Body for accept/reject review endpoints */
+export const fragmentReviewBodySchema = z.object({
+  wikiId: z.string().min(1, 'wikiId is required'),
+})
+
 // ── Query schemas ───────────────────────────────────────────────────────────
 
-export const fragmentListQuerySchema = paginationQuerySchema
+export const fragmentListQuerySchema = paginationQuerySchema.extend({
+  offset: z.coerce.number().int().min(0).default(0),
+  vaultId: z.string().optional(),
+})

--- a/core/src/schemas/graph.schema.ts
+++ b/core/src/schemas/graph.schema.ts
@@ -9,6 +9,7 @@ export const graphNodeSchema = z.object({
   type: z.enum(['wiki', 'fragment', 'person', 'entry', 'vault']),
   vaultId: z.string(),
   size: z.number(),
+  snippet: z.string().default(''),
 })
 
 export const graphEdgeSchema = z.object({

--- a/core/src/schemas/people.schema.ts
+++ b/core/src/schemas/people.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { lookupKeySchema, objectStateSchema, queuedResponseSchema } from './base.schema.js'
+import { lookupKeySchema, objectStateSchema, paginationQuerySchema, queuedResponseSchema } from './base.schema.js'
 
 // ── Response schemas ────────────────────────────────────────────────────────
 
@@ -18,6 +18,17 @@ export const personResponseSchema = z.object({
   updatedAt: z.coerce.date(),
 })
 
+/** Person detail with content and backlinks from edges table */
+export const personDetailResponseSchema = personResponseSchema.extend({
+  content: z.string(),
+  backlinks: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+    })
+  ),
+})
+
 export const personWithBacklinksResponseSchema = personResponseSchema.extend({
   backlinkFragmentIds: z.array(z.string()),
   backlinkThreadIds: z.array(z.string()),
@@ -25,6 +36,21 @@ export const personWithBacklinksResponseSchema = personResponseSchema.extend({
 
 export const personListResponseSchema = z.object({
   people: z.array(personResponseSchema),
+})
+
+// ── Request schemas ─────────────────────────────────────────────────────────
+
+export const updatePersonBodySchema = z.object({
+  name: z.string().optional(),
+  relationship: z.string().optional(),
+  aliases: z.array(z.string()).optional(),
+  content: z.string().optional(),
+})
+
+// ── Query schemas ───────────────────────────────────────────────────────────
+
+export const personListQuerySchema = paginationQuerySchema.extend({
+  offset: z.coerce.number().int().min(0).default(0),
 })
 
 export { queuedResponseSchema as personRegenerateResponseSchema }

--- a/core/src/schemas/search.schema.ts
+++ b/core/src/schemas/search.schema.ts
@@ -2,23 +2,32 @@ import { z } from 'zod'
 
 // ── Query schemas ───────────────────────────────────────────────────────────
 
+const searchTableEnum = z.enum(['fragment', 'wiki', 'person'])
+const searchModeEnum = z.enum(['hybrid', 'bm25', 'vector'])
+
 export const searchQuerySchema = z.object({
   q: z.string().min(1, 'q is required'),
   limit: z.coerce.number().int().min(1).max(100).default(10),
-  minScore: z.coerce.number().optional(),
+  tables: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (!v) return ['fragment', 'wiki', 'person'] as const
+      return v.split(',').map((s) => s.trim()) as Array<'fragment' | 'wiki' | 'person'>
+    })
+    .pipe(z.array(searchTableEnum).min(1)),
+  mode: searchModeEnum.default('hybrid'),
   vaultId: z.string().optional(),
 })
 
 // ── Response schemas ────────────────────────────────────────────────────────
 
 export const searchResultSchema = z.object({
-  score: z.number(),
-  fragmentId: z.string(),
+  id: z.string(),
+  type: searchTableEnum,
   title: z.string(),
-  fragment: z.string(),
-  tags: z.array(z.string()),
-  vaultId: z.string().nullable().optional(),
-  threadId: z.string().nullable().optional(),
+  snippet: z.string(),
+  score: z.number(),
 })
 
 export const searchResponseSchema = z.object({

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -45,6 +45,17 @@ export const updateThreadBodySchema = z.object({
 
 export { queuedResponseSchema as threadRegenerateResponseSchema }
 
+// ── Bouncer mode schemas ──────────────────────────────────────────────────
+
+export const bouncerModeBodySchema = z.object({
+  mode: z.enum(['auto', 'review']),
+})
+
+export const bouncerModeResponseSchema = z.object({
+  id: lookupKeySchema,
+  bouncerMode: z.enum(['auto', 'review']),
+})
+
 // ── Publish schemas ────────────────────────────────────────────────────────
 
 export const publishWikiResponseSchema = z.object({

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -32,7 +32,7 @@ export const threadListResponseSchema = z.object({
 // ── Request schemas ─────────────────────────────────────────────────────────
 
 export const createThreadBodySchema = z.object({
-  name: z.string().min(1, 'name is required'),
+  name: z.string().min(3, 'name must be at least 3 characters'),
   type: z.string().default('log'),
   prompt: z.string().optional(),
 })

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -18,6 +18,7 @@ export const QUEUE_NAMES = {
   link: 'link-queue',
   reclassify: 'reclassify-queue',
   provision: 'provision-queue',
+  regen: 'regen-queue',
   scheduler: 'regen-scheduler-queue',
   dlq: 'ingest-dlq',
 } as const
@@ -115,6 +116,7 @@ export interface QueueProducer {
   enqueueExtraction(job: ExtractionJob): Promise<string>
   enqueueLink(job: LinkJob): Promise<string>
   enqueueReclassify(job: ReclassifyJob): Promise<string>
+  enqueueRegen(job: RegenJob): Promise<string>
   enqueueProvision(job: ProvisionJob): Promise<string>
   getQueue(name: string): Queue
   close(): Promise<void>
@@ -126,6 +128,7 @@ export interface QueueWorker {
   startExtractionWorker(processor: (job: ExtractionJob) => Promise<JobResult>): Worker
   startLinkWorker(processor: (job: LinkJob) => Promise<JobResult>): Worker
   startReclassifyWorker(processor: (job: ReclassifyJob) => Promise<JobResult>): Worker
+  startRegenWorker(processor: (job: RegenJob) => Promise<JobResult>): Worker
   startProvisionWorker(processor: (job: ProvisionJob) => Promise<JobResult>): Worker
 }
 
@@ -176,6 +179,16 @@ export class BullMQProducer implements QueueProducer {
     return bullJob.id ?? job.jobId
   }
 
+  async enqueueRegen(job: RegenJob): Promise<string> {
+    const queue = this.getQueue(QUEUE_NAMES.regen)
+    // Use wiki key as jobId for deduplication — BullMQ skips if a job
+    // with the same id is already waiting, so rapid fragment links to the
+    // same wiki only produce one regen job.
+    const dedupeId = `regen-${job.objectKey}`
+    const bullJob = await queue.add('regen', job, { jobId: dedupeId })
+    return bullJob.id ?? job.jobId
+  }
+
   async enqueueProvision(job: ProvisionJob): Promise<string> {
     const queue = this.getQueue(QUEUE_NAMES.provision)
     const bullJob = await queue.add('provision', job, { jobId: job.jobId })
@@ -215,6 +228,14 @@ export class BullMQWorker implements QueueWorker {
     return new Worker(
       QUEUE_NAMES.reclassify,
       async (job: Job<ReclassifyJob>) => processor(job.data),
+      { connection: this.connection, concurrency: 1, autorun: true }
+    )
+  }
+
+  startRegenWorker(processor: (job: RegenJob) => Promise<JobResult>): Worker {
+    return new Worker(
+      QUEUE_NAMES.regen,
+      async (job: Job<RegenJob>) => processor(job.data),
       { connection: this.connection, concurrency: 1, autorun: true }
     )
   }

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -22,6 +22,7 @@ const inputSchema = z.object({
   people: z.string().optional(),
   existingWiki: z.string().optional(),
   edits: z.string().optional(),
+  relatedWikis: z.string().optional(),
 })
 
 const schemaMap: Record<WikiType, z.ZodType> = {
@@ -48,6 +49,7 @@ export function loadWikiGenerationSpec(
     people?: string
     existingWiki?: string
     edits?: string
+    relatedWikis?: string
   }
 ): PromptResult {
   const validated = inputSchema.parse(vars)

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -65,6 +65,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -122,6 +131,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -65,6 +65,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -122,6 +131,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/collection.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/collection.yaml
@@ -62,6 +62,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -119,6 +128,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -68,6 +68,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -125,6 +134,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/goal.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/goal.yaml
@@ -66,6 +66,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -123,6 +132,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -65,6 +65,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -122,6 +131,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/principles.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principles.yaml
@@ -65,6 +65,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -122,6 +131,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -68,6 +68,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -125,6 +134,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -66,6 +66,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -123,6 +132,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -65,6 +65,15 @@ template: |
   {{edits}}
   {{/if}}
 
+  {{#if relatedWikis}}
+  [RELATED WIKIS]
+  The following wikis exist in the knowledge base. If this document
+  references content that belongs to another wiki, link to it using
+  [[wiki-slug]] syntax instead of reproducing the content.
+
+  {{relatedWikis}}
+  {{/if}}
+
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. Follow the document structure exactly.
@@ -122,6 +131,9 @@ input_variables:
     required: false
   - name: edits
     description: User edit log entries to preserve across regeneration
+    required: false
+  - name: relatedWikis
+    description: Other wikis in the knowledge base for cross-linking
     required: false
 
 output:


### PR DESCRIPTION
## Summary

Closes the remaining gaps across M3-M6 milestones. 5 commits, each verified with `tsc --noEmit`.

### Commits

- **`ab74f1c` feat(m3): close M3 gaps** — Wiki creation quality gate (name ≥3 chars), embedding computed on regen, wiki-to-wiki hyperlinking via `[[slug]]` syntax in all 10 YAML templates
- **`4b203e9` feat(search): hybrid search with RRF fusion** — Multi-table BM25 + pgvector search across fragments, wikis, people. RRF fusion, mode selection (hybrid/bm25/vector), graceful embedding fallback
- **`327a67d` feat(mcp): search tool** — Wraps hybrid search as MCP tool with tables filter and mode selection
- **`532a07d` feat(regen): background regen worker** — Shared `regenerateWiki()` function, BullMQ regen processor, fragment-triggered scheduling with dedup by wiki key
- **`6aed2fd` feat(api): M6 API routes** — Fragment/people CRUD with backlinks, graph subgraph filter, bouncer mode, fragment accept/reject

### New/updated endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/search?q=&tables=&mode=` | Hybrid search (BM25 + vector + RRF) |
| GET | `/fragments?limit=&offset=&vaultId=` | Fragment list with pagination |
| GET | `/fragments/:id` | Fragment detail + content + backlinks |
| PUT | `/fragments/:id` | Update fragment |
| POST | `/fragments/:id/accept` | Accept fragment into review-mode wiki |
| POST | `/fragments/:id/reject` | Reject fragment from wiki |
| GET | `/people?limit=&offset=` | People list with pagination |
| GET | `/people/:id` | Person detail + content + backlinks |
| PUT | `/people/:id` | Update person |
| GET | `/graph?wikiId=` | Graph with wiki subgraph filter + snippets |
| PATCH | `/wikis/:id/bouncer` | Toggle bouncer mode (auto/review) |

### New MCP tool

| Tool | Description |
|------|-------------|
| `search` | Hybrid BM25 + pgvector search with RRF fusion, multi-table |

### Schema changes

- `bouncer_mode text NOT NULL DEFAULT 'auto'` added to `wikis` (migration 0005)

### Milestone impact

| Milestone | Status after merge |
|-----------|-------------------|
| M3: Wiki Composition | **Closed** — quality gate, embedding, hyperlinking, background regen |
| M4: Search | **Closed** — hybrid search with RRF fusion |
| M5: MCP Server | **Closed** — all tools shipped, HTTP transport |
| M6: API Routes | **Substantially complete** — CRUD, graph, bouncer, review |

Closes #21

## Test plan

- [ ] `npx tsc --noEmit` — zero errors
- [ ] `GET /search?q=test` returns results with type/title/snippet/score
- [ ] `GET /search?q=test&mode=bm25` works without embedding
- [ ] `GET /fragments` returns paginated list
- [ ] `GET /fragments/:id` includes backlinks
- [ ] `GET /people/:id` includes content + mention backlinks
- [ ] `PATCH /wikis/:id/bouncer` toggles mode
- [ ] `POST /fragments/:id/reject` with review-mode wiki soft-deletes edge
- [ ] Background regen: ingest entry → fragment created → regen job enqueued

🤖 Generated with [Claude Code](https://claude.com/claude-code)