### PR TITLE
Wire wiki prompt overrides into Quill generation pipeline

### DIFF
--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -3,7 +3,7 @@ import { createIngestAgents, createStringCaller, embedText } from '@robin/agent'
 import { loadWikiGenerationSpec } from '@robin/shared'
 import type { WikiType } from '@robin/shared'
 import { db as defaultDb, type DB } from '../db/client.js'
-import { wikis, edges, fragments, edits } from '../db/schema.js'
+import { wikis, wikiTypes, edges, fragments, edits } from '../db/schema.js'
 import { loadOpenRouterConfigFromDb } from './openrouter-config.js'
 import { nanoid } from './id.js'
 import { logger } from './logger.js'
@@ -91,6 +91,20 @@ export async function regenerateWiki(
     ? otherWikis.map((w) => `- ${w.slug} (${w.type}): ${w.name}`).join('\n')
     : undefined
 
+  // Resolve custom prompt override: wiki-level > type-level > YAML default
+  let customPrompt: string | undefined
+  if (wiki.prompt) {
+    customPrompt = wiki.prompt
+  } else {
+    const [wikiType] = await database
+      .select({ prompt: wikiTypes.prompt })
+      .from(wikiTypes)
+      .where(and(eq(wikiTypes.slug, wiki.type), eq(wikiTypes.userModified, true)))
+    if (wikiType?.prompt) {
+      customPrompt = wikiType.prompt
+    }
+  }
+
   // Load prompt spec and call LLM
   const spec = loadWikiGenerationSpec(wiki.type as WikiType, {
     fragments: fragmentsText,
@@ -100,7 +114,7 @@ export async function regenerateWiki(
     existingWiki: previousContent || undefined,
     edits: editsSummary,
     relatedWikis: relatedWikisText,
-  })
+  }, customPrompt)
 
   const markdown = await callLlm(spec.system, spec.user)
 

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -50,11 +50,23 @@ export function loadWikiGenerationSpec(
     existingWiki?: string
     edits?: string
     relatedWikis?: string
-  }
+  },
+  customPrompt?: string
 ): PromptResult {
   const validated = inputSchema.parse(vars)
   const spec = loadSpec(`${type}.yaml`, 'wiki-types')
-  const user = renderTemplate(spec.template, validated)
+
+  let template = spec.template
+  if (customPrompt) {
+    // Replace the [DOCUMENT STRUCTURE] section (up to the next section marker)
+    // Sections are indented with 2 spaces in the YAML template
+    template = template.replace(
+      /  \[DOCUMENT STRUCTURE\][\s\S]*?(?=\n  \[)/,
+      `  [DOCUMENT STRUCTURE]\n${customPrompt}\n`
+    )
+  }
+
+  const user = renderTemplate(template, validated)
   return {
     system: spec.system_message,
     user,


### PR DESCRIPTION
## Summary

Closes #24

Wiki prompt overrides were stored in the database but ignored during regeneration. This PR wires them into the Quill generation pipeline with the following priority chain:

1. **`wikis.prompt`** (per-wiki override) — highest priority
2. **`wikiTypes.prompt`** (per-type override, only when `userModified = true`) — fallback
3. **YAML default `[DOCUMENT STRUCTURE]`** — baseline

### Files changed

- **`packages/shared/src/prompts/loaders/wiki-generation.ts`** — `loadWikiGenerationSpec` now accepts an optional `customPrompt` parameter. When provided, replaces the `[DOCUMENT STRUCTURE]` section in the YAML template before Handlebars rendering.
- **`core/src/lib/regen.ts`** — `regenerateWiki` resolves the prompt override from wiki row or wiki_types table and passes it to `loadWikiGenerationSpec`.

## Test plan

- [ ] Verify regeneration uses per-wiki `prompt` when set
- [ ] Verify regeneration falls back to `wikiTypes.prompt` when wiki prompt is empty and type has `userModified = true`
- [ ] Verify regeneration uses YAML default when neither override exists
- [ ] Confirm `npx tsc --noEmit` passes in both `packages/shared` and `core`