### PR TITLE
feat: add soft-delete endpoints for wikis and people

### DIFF
--- a/core/src/__tests__/wiki-history.test.ts
+++ b/core/src/__tests__/wiki-history.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+const mockDbSelect = vi.fn()
+const mockDbUpdate = vi.fn()
+const mockDbInsert = vi.fn()
+const mockDbExecute = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    update: (...args: unknown[]) => mockDbUpdate(...args),
+    insert: (...args: unknown[]) => mockDbInsert(...args),
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}))
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookup_key',
+    slug: 'wikis.slug',
+    name: 'wikis.name',
+    type: 'wikis.type',
+    prompt: 'wikis.prompt',
+    state: 'wikis.state',
+    content: 'wikis.content',
+    deletedAt: 'wikis.deleted_at',
+    updatedAt: 'wikis.updated_at',
+    vaultId: 'wikis.vault_id',
+  },
+  edges: {
+    id: 'edges.id',
+    srcType: 'edges.src_type',
+    srcId: 'edges.src_id',
+    dstType: 'edges.dst_type',
+    dstId: 'edges.dst_id',
+    edgeType: 'edges.edge_type',
+    deletedAt: 'edges.deleted_at',
+  },
+  wikiTypes: {
+    slug: 'wiki_types.slug',
+    shortDescriptor: 'wiki_types.short_descriptor',
+    descriptor: 'wiki_types.descriptor',
+  },
+  fragments: {
+    lookupKey: 'fragments.lookup_key',
+    slug: 'fragments.slug',
+    title: 'fragments.title',
+    content: 'fragments.content',
+  },
+  people: {
+    lookupKey: 'people.lookup_key',
+    name: 'people.name',
+  },
+  auditLog: {
+    entityId: 'audit_log.entity_id',
+    createdAt: 'audit_log.created_at',
+  },
+  edits: {
+    id: 'edits.id',
+    objectType: 'edits.object_type',
+    objectId: 'edits.object_id',
+    timestamp: 'edits.timestamp',
+    type: 'edits.type',
+    content: 'edits.content',
+    source: 'edits.source',
+    diff: 'edits.diff',
+  },
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('userId', 'test-user-123')
+    await next()
+  }),
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn(),
+}))
+
+vi.mock('../db/slug.js', () => ({
+  resolveWikiSlug: vi.fn(async (_db: any, slug: string) => slug),
+}))
+
+vi.mock('@robin/shared', () => ({
+  generateSlug: (name: string) => name.toLowerCase().replace(/\s+/g, '-'),
+  makeLookupKey: (prefix: string) => `${prefix}-test-key`,
+}))
+
+vi.mock('@robin/agent', () => ({
+  NoOpenRouterKeyError: class extends Error {},
+}))
+
+vi.mock('../lib/regen.js', () => ({
+  regenerateWiki: vi.fn(),
+}))
+
+vi.mock('../lib/id.js', () => ({
+  nanoid24: () => 'test-id-24',
+}))
+
+vi.mock('../lib/validation.js', () => ({
+  validationHook: (_result: any, _c: any) => {},
+}))
+
+import { wikisRoutes } from '../routes/wikis.js'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/wikis', wikisRoutes)
+  return app
+}
+
+function chainMock(finalValue: unknown) {
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockReturnValue(chain)
+  chain.orderBy = vi.fn().mockReturnValue(chain)
+  chain.limit = vi.fn().mockReturnValue(chain)
+  chain.offset = vi.fn().mockReturnValue(chain)
+  chain.leftJoin = vi.fn().mockReturnValue(chain)
+  chain.groupBy = vi.fn().mockReturnValue(chain)
+  chain.then = (resolve: any) => resolve(finalValue)
+  return chain
+}
+
+describe('Wiki History API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 404 when wiki does not exist', async () => {
+    mockDbSelect.mockReturnValueOnce(chainMock([]))
+    const app = createApp()
+    const res = await app.request('/wikis/nonexistent/history')
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toBe('Not found')
+  })
+
+  it('returns empty edits array when wiki has no edits', async () => {
+    mockDbSelect.mockReturnValueOnce(chainMock([{ lookupKey: 'wiki-1' }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([{ count: 0 }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([]))
+    const app = createApp()
+    const res = await app.request('/wikis/wiki-1/history')
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.edits).toEqual([])
+    expect(json.total).toBe(0)
+  })
+
+  it('returns edit records with correct shape', async () => {
+    const editRow = {
+      id: 'e1',
+      timestamp: new Date('2025-01-15T10:00:00Z'),
+      type: 'addition',
+      source: 'user',
+      content: 'previous content',
+      objectType: 'wiki',
+      objectId: 'wiki-1',
+      diff: '',
+    }
+    mockDbSelect.mockReturnValueOnce(chainMock([{ lookupKey: 'wiki-1' }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([{ count: 1 }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([editRow]))
+    const app = createApp()
+    const res = await app.request('/wikis/wiki-1/history')
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.total).toBe(1)
+    expect(json.edits).toHaveLength(1)
+    const edit = json.edits[0]
+    expect(edit.id).toBe('e1')
+    expect(edit.timestamp).toBe('2025-01-15T10:00:00.000Z')
+    expect(edit.type).toBe('addition')
+    expect(edit.source).toBe('user')
+    expect(edit.contentSnippet).toBe('previous content')
+  })
+
+  it('truncates contentSnippet to 200 characters', async () => {
+    const longContent = 'a'.repeat(300)
+    const editRow = {
+      id: 'e2',
+      timestamp: new Date('2025-01-15T10:00:00Z'),
+      type: 'addition',
+      source: 'user',
+      content: longContent,
+      objectType: 'wiki',
+      objectId: 'wiki-1',
+      diff: '',
+    }
+    mockDbSelect.mockReturnValueOnce(chainMock([{ lookupKey: 'wiki-1' }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([{ count: 1 }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([editRow]))
+    const app = createApp()
+    const res = await app.request('/wikis/wiki-1/history')
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.edits[0].contentSnippet).toHaveLength(200)
+  })
+
+  it('respects limit and offset query params', async () => {
+    mockDbSelect.mockReturnValueOnce(chainMock([{ lookupKey: 'wiki-1' }]))
+    mockDbSelect.mockReturnValueOnce(chainMock([{ count: 20 }]))
+    const rowsChain = chainMock([])
+    mockDbSelect.mockReturnValueOnce(rowsChain)
+    const app = createApp()
+    const res = await app.request('/wikis/wiki-1/history?limit=10&offset=5')
+    expect(res.status).toBe(200)
+    expect(rowsChain.limit).toHaveBeenCalledWith(10)
+    expect(rowsChain.offset).toHaveBeenCalledWith(5)
+  })
+})

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -641,3 +641,133 @@ export async function handleEditWiki(
     }
   }
 }
+
+/**
+ * Handle the `delete_wiki` MCP tool call.
+ *
+ * @summary Soft-delete a wiki by setting deletedAt. Existing queries
+ * already filter WHERE deletedAt IS NULL, so the wiki disappears from
+ * all listings immediately.
+ */
+export async function handleDeleteWiki(
+  deps: McpServerDeps,
+  input: { wikiKey: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+
+  if (!input.wikiKey?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: wikiKey is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const [wiki] = await deps.db
+      .select()
+      .from(threadsTable)
+      .where(and(eq(threadsTable.lookupKey, input.wikiKey.trim()), isNull(threadsTable.deletedAt)))
+
+    if (!wiki) {
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Wiki not found' }) }],
+        isError: true as const,
+      }
+    }
+
+    await deps.db
+      .update(threadsTable)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(eq(threadsTable.lookupKey, input.wikiKey.trim()))
+
+    await emitAuditEvent(deps.db, {
+      entityType: 'wiki',
+      entityId: wiki.lookupKey,
+      eventType: 'deleted',
+      source: 'mcp',
+      summary: `Wiki deleted: ${wiki.name}`,
+      detail: { wikiKey: wiki.lookupKey, wikiSlug: wiki.slug },
+    })
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, wikiKey: wiki.lookupKey }) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp delete_wiki failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `delete_person` MCP tool call.
+ *
+ * @summary Soft-delete a person by setting deletedAt.
+ */
+export async function handleDeletePerson(
+  deps: McpServerDeps,
+  input: { personKey: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+
+  if (!input.personKey?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: personKey is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const [person] = await deps.db
+      .select()
+      .from(peopleTable)
+      .where(and(eq(peopleTable.lookupKey, input.personKey.trim()), isNull(peopleTable.deletedAt)))
+
+    if (!person) {
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Person not found' }) }],
+        isError: true as const,
+      }
+    }
+
+    await deps.db
+      .update(peopleTable)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(eq(peopleTable.lookupKey, input.personKey.trim()))
+
+    await emitAuditEvent(deps.db, {
+      entityType: 'person',
+      entityId: person.lookupKey,
+      eventType: 'deleted',
+      source: 'mcp',
+      summary: `Person deleted: ${person.name}`,
+      detail: { personKey: person.lookupKey },
+    })
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, personKey: person.lookupKey }) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp delete_person failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -22,7 +22,7 @@ import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveThreadBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleDeleteWiki, handleDeletePerson } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 import { wikis, edges, auditLog } from '../db/schema.js'
 import { nanoid24 } from '../lib/id.js'
@@ -131,7 +131,37 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     }
   )
 
-  /***********************************************************************
+  server.registerTool(
+    'delete_wiki',
+    {
+      description:
+        'Soft-delete a wiki. The wiki will no longer appear in listings or search. ' +
+        'Use list_wikis to find the lookupKey first.',
+      inputSchema: {
+        wikiKey: z.string().describe('Wiki lookupKey (from list_wikis)'),
+      },
+    },
+    async ({ wikiKey }, extra) => {
+      return handleDeleteWiki(deps, { wikiKey }, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'delete_person',
+    {
+      description:
+        'Soft-delete a person. The person will no longer appear in listings or search. ' +
+        'Use find_person to find the lookupKey first.',
+      inputSchema: {
+        personKey: z.string().describe('Person lookupKey (from find_person)'),
+      },
+    },
+    async ({ personKey }, extra) => {
+      return handleDeletePerson(deps, { personKey }, extra.authInfo?.clientId as string)
+    }
+  )
+
+    /***********************************************************************
    * ## Wiki listing
    ***********************************************************************/
 

--- a/core/src/routes/people.ts
+++ b/core/src/routes/people.ts
@@ -165,4 +165,28 @@ peopleRouter.post('/:id/regenerate', async (c) => {
   return c.json({ error: 'Person regen disabled in M2 — will be restored in M3' }, 503)
 })
 
+
+// DELETE /people/:id — soft delete
+peopleRouter.delete('/:id', async (c) => {
+  const id = c.req.param('id')
+  const [person] = await db.select().from(people).where(and(eq(people.lookupKey, id), isNull(people.deletedAt)))
+  if (!person) return c.json({ error: 'Not found' }, 404)
+
+  await db
+    .update(people)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(eq(people.lookupKey, id))
+
+  await emitAuditEvent(db, {
+    entityType: 'person',
+    entityId: id,
+    eventType: 'deleted',
+    source: 'api',
+    summary: `Person deleted: ${person.name}`,
+    detail: { personKey: id },
+  })
+
+  return c.body(null, 204)
+})
+
 export { peopleRouter as peopleRoutes }

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -436,4 +436,28 @@ wikisRouter.post('/:targetId/merge', async (c) => {
   return c.json({ error: 'Not implemented — thread merge needs edges table rewrite' }, 501)
 })
 
+
+// DELETE /wikis/:id — soft delete
+wikisRouter.delete('/:id', async (c) => {
+  const id = c.req.param('id')
+  const [wiki] = await db.select().from(wikis).where(and(eq(wikis.lookupKey, id), isNull(wikis.deletedAt)))
+  if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+  await db
+    .update(wikis)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(eq(wikis.lookupKey, id))
+
+  await emitAuditEvent(db, {
+    entityType: 'wiki',
+    entityId: id,
+    eventType: 'deleted',
+    source: 'api',
+    summary: `Wiki deleted: ${wiki.name}`,
+    detail: { wikiKey: id, wikiSlug: wiki.slug },
+  })
+
+  return c.body(null, 204)
+})
+
 export { wikisRouter as wikisRoutes, prepareThread }


### PR DESCRIPTION
## Summary

- Adds `DELETE /wikis/:id` and `DELETE /people/:id` REST endpoints that soft-delete by setting `deletedAt` timestamp
- Adds `delete_wiki` and `delete_person` MCP tools with full auth checks, input validation, and audit events
- Double-delete guard: queries filter `WHERE deletedAt IS NULL` so already-deleted entities return 404
- Existing list/detail endpoints already exclude soft-deleted rows via `isNull(deletedAt)` filters

## Test plan

- [ ] `curl -X DELETE /wikis/{valid-key}` returns 204
- [ ] `curl -X DELETE /wikis/{invalid-key}` returns 404
- [ ] `curl -X DELETE /wikis/{already-deleted-key}` returns 404 (double-delete guard)
- [ ] `curl -X DELETE /people/{valid-key}` returns 204
- [ ] `curl -X DELETE /people/{invalid-key}` returns 404
- [ ] Audit log has `eventType: 'deleted'` rows after each delete
- [ ] Soft-deleted wikis/people no longer appear in GET listings
- [ ] MCP `delete_wiki` and `delete_person` tools callable via MCP client

Closes #40