### PR TITLE
feat(wikis): add type query param to GET /wikis

### DIFF
--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -344,6 +344,12 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - name: type
+          in: query
+          description: Filter by wiki type slug (e.g. belief, log, project)
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: List of wikis

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -15,6 +15,7 @@ import {
   threadResponseSchema,
   threadListResponseSchema,
   wikiDetailResponseSchema,
+  wikiListQuerySchema,
   updateThreadBodySchema,
   publishWikiResponseSchema,
   bouncerModeBodySchema,
@@ -52,9 +53,11 @@ const wikisRouter = new Hono()
 wikisRouter.use('*', sessionMiddleware)
 
 // GET /wikis — cross-vault wiki listing with fragment counts + descriptors
-wikisRouter.get('/', async (c) => {
-  const limit = Math.min(Number(c.req.query('limit') ?? 50), 200)
-  const offset = Number(c.req.query('offset') ?? 0)
+wikisRouter.get('/', zValidator('query', wikiListQuerySchema, validationHook), async (c) => {
+  const { limit, offset, type } = c.req.valid('query')
+
+  const conditions = [isNull(wikis.deletedAt)]
+  if (type) conditions.push(eq(wikis.type, type))
 
   const rows = await db
     .select({
@@ -73,7 +76,7 @@ wikisRouter.get('/', async (c) => {
         isNull(edges.deletedAt)
       )
     )
-    .where(isNull(wikis.deletedAt))
+    .where(and(...conditions))
     .groupBy(wikis.lookupKey, wikiTypes.shortDescriptor, wikiTypes.descriptor)
     .orderBy(sql`${wikis.updatedAt} DESC`)
     .limit(limit)

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -47,6 +47,14 @@ export const threadListResponseSchema = z.object({
   wikis: z.array(threadResponseSchema),
 })
 
+// ── Query schemas ──────────────────────────────────────────────────────────
+
+export const wikiListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+  type: z.string().optional(),
+})
+
 // ── Request schemas ─────────────────────────────────────────────────────────
 
 export const createThreadBodySchema = z.object({


### PR DESCRIPTION
## Summary

- Adds optional `type` query parameter to `GET /wikis` so the frontend BrowseByType component can filter wikis by type slug (e.g. `?type=belief`)
- Introduces `wikiListQuerySchema` in `core/src/schemas/wikis.schema.ts` with zod-validated `limit`, `offset`, and optional `type` fields
- Replaces manual query parsing with `zValidator('query', ...)` and conditionally adds `eq(wikis.type, type)` to the WHERE clause
- Updates `core/openapi.yaml` with the new query parameter documentation

## Test plan

- [ ] `GET /wikis` without type param returns all non-deleted wikis (existing behavior preserved)
- [ ] `GET /wikis?type=belief` returns only wikis where `type = 'belief'`
- [ ] `GET /wikis?type=nonexistent` returns `{ wikis: [] }`, not an error
- [ ] Invalid `limit`/`offset` values return 400 (zod validation)
- [ ] `npx tsc --noEmit` passes

Closes #41