### PR TITLE
feat: AI preferences and custom prompts endpoints

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -20,6 +20,7 @@ import { relationshipsRoutes } from './routes/relationships.js'
 import { contentRoutes } from './routes/content.js'
 import { wikiTypesRoutes } from './routes/wiki-types.js'
 import { auditRoutes } from './routes/audit.js'
+import { aiPreferencesRoutes } from './routes/ai-preferences.js'
 import { publishedRoutes } from './routes/published.js'
 // M2 dormant: internalRoutes is the git-sync webhook, preserved verbatim in
 // src/routes/internal.ts for M3/M4 refinement. Gateway is gone in M2 so the
@@ -109,6 +110,7 @@ app.route('/entries', entries)
 app.route('/search', search)
 app.route('/mcp', mcp)
 app.route('/users', users)
+app.route('/users', aiPreferencesRoutes)
 app.route('/vaults', vaultsRoutes)
 app.route('/wikis', wikisRoutes)
 app.route('/fragments', fragmentsRoutes)

--- a/core/src/routes/ai-preferences.test.ts
+++ b/core/src/routes/ai-preferences.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetConfig = vi.fn()
+const mockSetConfig = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../lib/config.js', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: (...args: unknown[]) => mockSetConfig(...args),
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('userId', 'test-user-1')
+    await next()
+  }),
+}))
+
+// ── Import under test (after mocks) ────────────────────────────────────────
+
+const { aiPreferencesRoutes } = await import('./ai-preferences.js')
+
+const app = new Hono()
+app.route('/users', aiPreferencesRoutes)
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function postJson(path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function putJson(path: string, body: unknown) {
+  return app.request(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('POST /users/preferences/ai', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('saves an OpenRouter key encrypted and returns ok', async () => {
+    const res = await postJson('/users/preferences/ai', { openRouterKey: 'sk-or-test-abc123' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockSetConfig).toHaveBeenCalledOnce()
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      scope: 'user',
+      userId: 'test-user-1',
+      kind: 'llm_key',
+      key: 'openrouter',
+      value: 'sk-or-test-abc123',
+      encrypted: true,
+    })
+  })
+
+  it('returns 400 when openRouterKey is missing', async () => {
+    const res = await postJson('/users/preferences/ai', {})
+
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toBe('Validation failed')
+    expect(mockSetConfig).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when openRouterKey is empty', async () => {
+    const res = await postJson('/users/preferences/ai', { openRouterKey: '' })
+
+    expect(res.status).toBe(400)
+    expect(mockSetConfig).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /users/preferences/ai', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns hasOpenRouterKey:true when key exists', async () => {
+    mockGetConfig.mockImplementation(async (opts: any) => {
+      if (opts.kind === 'llm_key') return 'sk-or-decrypted'
+      if (opts.kind === 'model_preference') return null
+      return null
+    })
+
+    const res = await app.request('/users/preferences/ai')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      hasOpenRouterKey: true,
+      modelPreference: null,
+    })
+  })
+
+  it('returns hasOpenRouterKey:false when no key exists', async () => {
+    mockGetConfig.mockResolvedValue(null)
+
+    const res = await app.request('/users/preferences/ai')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      hasOpenRouterKey: false,
+      modelPreference: null,
+    })
+  })
+
+  it('returns the model preference when set', async () => {
+    mockGetConfig.mockImplementation(async (opts: any) => {
+      if (opts.kind === 'llm_key') return 'sk-or-key'
+      if (opts.kind === 'model_preference') return 'anthropic/claude-3.5-sonnet'
+      return null
+    })
+
+    const res = await app.request('/users/preferences/ai')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      hasOpenRouterKey: true,
+      modelPreference: 'anthropic/claude-3.5-sonnet',
+    })
+  })
+})
+
+describe('PUT /users/prompts', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('saves prompt overrides and returns ok', async () => {
+    const body = { extraction: 'custom extraction prompt', wikiClassify: 'custom classify' }
+    const res = await putJson('/users/prompts', body)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockSetConfig).toHaveBeenCalledOnce()
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      scope: 'user',
+      userId: 'test-user-1',
+      kind: 'user_prompts',
+      key: 'overrides',
+      value: body,
+      encrypted: false,
+    })
+  })
+
+  it('accepts empty object (all fields optional)', async () => {
+    const res = await putJson('/users/prompts', {})
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockSetConfig).toHaveBeenCalledOnce()
+  })
+})
+
+describe('GET /users/prompts', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns stored prompts when overrides exist', async () => {
+    mockGetConfig.mockResolvedValue({
+      extraction: 'my extraction',
+      wikiClassify: 'my classify',
+      wikiGeneration: 'my generation',
+    })
+
+    const res = await app.request('/users/prompts')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      extraction: 'my extraction',
+      wikiClassify: 'my classify',
+      wikiGeneration: 'my generation',
+    })
+  })
+
+  it('returns all-null defaults when no overrides exist', async () => {
+    mockGetConfig.mockResolvedValue(null)
+
+    const res = await app.request('/users/prompts')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      extraction: null,
+      wikiClassify: null,
+      wikiGeneration: null,
+    })
+  })
+})

--- a/core/src/routes/ai-preferences.ts
+++ b/core/src/routes/ai-preferences.ts
@@ -1,0 +1,107 @@
+import { Hono } from 'hono'
+import { zValidator } from '@hono/zod-validator'
+import { sessionMiddleware } from '../middleware/session.js'
+import { getConfig, setConfig } from '../lib/config.js'
+import { validationHook } from '../lib/validation.js'
+import { okResponseSchema } from '../schemas/base.schema.js'
+import {
+  saveAiPreferencesBodySchema,
+  aiPreferencesResponseSchema,
+  savePromptsBodySchema,
+  promptsResponseSchema,
+} from '../schemas/ai-preferences.schema.js'
+
+const aiPreferencesRouter = new Hono()
+aiPreferencesRouter.use('*', sessionMiddleware)
+
+// POST /preferences/ai -- save OpenRouter API key (encrypted)
+aiPreferencesRouter.post(
+  '/preferences/ai',
+  zValidator('json', saveAiPreferencesBodySchema, validationHook),
+  async (c) => {
+    const userId = c.get('userId') as string
+    const body = c.req.valid('json')
+
+    await setConfig({
+      scope: 'user',
+      userId,
+      kind: 'llm_key',
+      key: 'openrouter',
+      value: body.openRouterKey,
+      encrypted: true,
+    })
+
+    return c.json(okResponseSchema.parse({ ok: true }))
+  },
+)
+
+// GET /preferences/ai -- return key-exists status and model preference
+aiPreferencesRouter.get('/preferences/ai', async (c) => {
+  const userId = c.get('userId') as string
+
+  const [rawKey, modelPref] = await Promise.all([
+    getConfig({ scope: 'user', userId, kind: 'llm_key', key: 'openrouter' }),
+    getConfig({ scope: 'user', userId, kind: 'model_preference', key: 'default' }),
+  ])
+
+  return c.json(
+    aiPreferencesResponseSchema.parse({
+      hasOpenRouterKey: rawKey != null,
+      modelPreference: typeof modelPref === 'string' ? modelPref : null,
+    }),
+  )
+})
+
+// PUT /prompts -- save custom prompt overrides
+aiPreferencesRouter.put(
+  '/prompts',
+  zValidator('json', savePromptsBodySchema, validationHook),
+  async (c) => {
+    const userId = c.get('userId') as string
+    const body = c.req.valid('json')
+
+    await setConfig({
+      scope: 'user',
+      userId,
+      kind: 'user_prompts',
+      key: 'overrides',
+      value: body,
+      encrypted: false,
+    })
+
+    return c.json(okResponseSchema.parse({ ok: true }))
+  },
+)
+
+// GET /prompts -- retrieve custom prompt overrides
+aiPreferencesRouter.get('/prompts', async (c) => {
+  const userId = c.get('userId') as string
+
+  const stored = await getConfig({
+    scope: 'user',
+    userId,
+    kind: 'user_prompts',
+    key: 'overrides',
+  })
+
+  if (!stored || typeof stored !== 'object') {
+    return c.json(
+      promptsResponseSchema.parse({
+        extraction: null,
+        wikiClassify: null,
+        wikiGeneration: null,
+      }),
+    )
+  }
+
+  const obj = stored as Record<string, unknown>
+  return c.json(
+    promptsResponseSchema.parse({
+      extraction: typeof obj.extraction === 'string' ? obj.extraction : null,
+      wikiClassify: typeof obj.wikiClassify === 'string' ? obj.wikiClassify : null,
+      wikiGeneration: typeof obj.wikiGeneration === 'string' ? obj.wikiGeneration : null,
+    }),
+  )
+})
+
+export { aiPreferencesRouter as aiPreferencesRoutes }

--- a/core/src/schemas/ai-preferences.schema.ts
+++ b/core/src/schemas/ai-preferences.schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+// POST /users/preferences/ai body
+export const saveAiPreferencesBodySchema = z.object({
+  openRouterKey: z.string().min(1),
+})
+
+// GET /users/preferences/ai response
+export const aiPreferencesResponseSchema = z.object({
+  hasOpenRouterKey: z.boolean(),
+  modelPreference: z.string().nullable(),
+})
+
+// PUT /users/prompts body -- each field is an optional string override
+export const savePromptsBodySchema = z.object({
+  extraction: z.string().optional(),
+  wikiClassify: z.string().optional(),
+  wikiGeneration: z.string().optional(),
+})
+
+// GET /users/prompts response
+export const promptsResponseSchema = z.object({
+  extraction: z.string().nullable(),
+  wikiClassify: z.string().nullable(),
+  wikiGeneration: z.string().nullable(),
+})


### PR DESCRIPTION
## Summary

- Add 4 new API endpoints under `/users` for persisting AI preferences and custom prompts
  - `POST /users/preferences/ai` -- save OpenRouter API key (encrypted via setConfig with user DEK)
  - `GET /users/preferences/ai` -- return `{ hasOpenRouterKey, modelPreference }` (never exposes raw key)
  - `PUT /users/prompts` -- save custom prompt overrides as JSON blob in configs (`kind='user_prompts'`)
  - `GET /users/prompts` -- retrieve prompt overrides or null defaults
- New Zod schemas in `core/src/schemas/ai-preferences.schema.ts`
- Route handler in `core/src/routes/ai-preferences.ts` with session auth on all endpoints
- Mounted in `core/src/index.ts` under `/users` prefix (Hono merges with existing users router)

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] 10 unit tests pass covering all endpoints (happy path + validation + edge cases)
- [ ] Manual smoke test: start server, authenticate, call all four endpoints via curl

Closes #44