### PR TITLE
feat(users): add GET/PUT /users/settings endpoints

### DIFF
--- a/core/src/routes/users.settings.test.ts
+++ b/core/src/routes/users.settings.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks (must come before dynamic import) ────────────────────────────────
+
+const mockGetConfig = vi.fn()
+const mockSetConfig = vi.fn().mockResolvedValue(undefined)
+const mockEmitAuditEvent = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: (...args: unknown[]) => mockEmitAuditEvent(...args),
+}))
+
+vi.mock('../lib/config.js', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: (...args: unknown[]) => mockSetConfig(...args),
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn().mockImplementation(async (c: any, next: any) => {
+    c.set('userId', 'test-user')
+    await next()
+  }),
+}))
+
+vi.mock('../keypair.js', () => ({ decryptPrivateKey: vi.fn() }))
+vi.mock('../mcp/jwt.js', () => ({ signMcpToken: vi.fn().mockResolvedValue('mock-token') }))
+
+// ── Import under test ──────────────────────────────────────────────────────
+
+const { users } = await import('./users.js')
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function get(path: string) {
+  return users.request(path, { method: 'GET' })
+}
+
+function put(path: string, body: unknown) {
+  return users.request(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const VALID_SETTINGS = {
+  notifications: { email: false, push: true },
+  privacy: { publicProfile: true },
+  theme: 'dark' as const,
+}
+
+const DEFAULTS = {
+  notifications: { email: true, push: true },
+  privacy: { publicProfile: false },
+  theme: 'system',
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('GET /settings', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns defaults when no config row exists', async () => {
+    mockGetConfig.mockResolvedValue(null)
+    const res = await get('/settings')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(DEFAULTS)
+  })
+
+  it('returns persisted settings after a PUT', async () => {
+    mockGetConfig.mockResolvedValue(VALID_SETTINGS)
+    const res = await get('/settings')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(VALID_SETTINGS)
+  })
+})
+
+describe('PUT /settings', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('persists valid settings and returns ok', async () => {
+    const res = await put('/settings', VALID_SETTINGS)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      scope: 'user',
+      userId: 'test-user',
+      kind: 'user_settings',
+      key: 'default',
+      value: VALID_SETTINGS,
+    })
+  })
+
+  it('rejects invalid theme with 400', async () => {
+    const res = await put('/settings', {
+      notifications: { email: true, push: true },
+      privacy: { publicProfile: false },
+      theme: 'purple',
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Validation failed')
+  })
+
+  it('emits audit event with correct params', async () => {
+    await put('/settings', VALID_SETTINGS)
+    expect(mockEmitAuditEvent).toHaveBeenCalledOnce()
+    expect(mockEmitAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entityType: 'user_settings',
+        entityId: 'test-user',
+        eventType: 'updated',
+        source: 'api',
+      }),
+    )
+  })
+})

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { eq, and, isNull, sql } from 'drizzle-orm'
+import { zValidator } from '@hono/zod-validator'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
 import {
@@ -15,6 +16,9 @@ import {
 } from '../db/schema.js'
 import { decryptPrivateKey } from '../keypair.js'
 import { signMcpToken } from '../mcp/jwt.js'
+import { validationHook } from '../lib/validation.js'
+import { getConfig, setConfig } from '../lib/config.js'
+import { emitAuditEvent } from '../db/audit.js'
 import {
   userProfileResponseSchema,
   userStatsResponseSchema,
@@ -22,6 +26,9 @@ import {
   keypairResponseSchema,
   mcpEndpointResponseSchema,
   exportDataResponseSchema,
+  userSettingsSchema,
+  userSettingsResponseSchema,
+  USER_SETTINGS_DEFAULTS,
 } from '../schemas/users.schema.js'
 import { okResponseSchema } from '../schemas/base.schema.js'
 
@@ -192,5 +199,45 @@ usersRouter.delete('/account', async (c) => {
   await db.delete(users).where(eq(users.id, userId))
   return c.json(okResponseSchema.parse({ ok: true }))
 })
+
+// GET /users/settings
+usersRouter.get('/settings', async (c) => {
+  const userId = c.get('userId') as string
+  const raw = await getConfig({ scope: 'user', userId, kind: 'user_settings', key: 'default' })
+  if (!raw) {
+    return c.json(userSettingsResponseSchema.parse(USER_SETTINGS_DEFAULTS))
+  }
+  const merged = { ...USER_SETTINGS_DEFAULTS, ...(raw as Record<string, unknown>) }
+  return c.json(userSettingsResponseSchema.parse(merged))
+})
+
+// PUT /users/settings
+usersRouter.put(
+  '/settings',
+  zValidator('json', userSettingsSchema, validationHook),
+  async (c) => {
+    const userId = c.get('userId') as string
+    const body = c.req.valid('json')
+
+    await setConfig({
+      scope: 'user',
+      userId,
+      kind: 'user_settings',
+      key: 'default',
+      value: body,
+    })
+
+    await emitAuditEvent(db, {
+      entityType: 'user_settings',
+      entityId: userId,
+      eventType: 'updated',
+      source: 'api',
+      summary: 'User settings updated',
+      detail: body as unknown as Record<string, unknown>,
+    })
+
+    return c.json(okResponseSchema.parse({ ok: true }))
+  }
+)
 
 export { usersRouter as users }

--- a/core/src/schemas/users.schema.ts
+++ b/core/src/schemas/users.schema.ts
@@ -47,4 +47,28 @@ export const exportDataResponseSchema = z.object({
   people: z.array(z.any()),
 })
 
+
+// ── User settings ──────────────────────────────────────────────────────────
+
+export const userSettingsSchema = z.object({
+  notifications: z.object({
+    email: z.boolean(),
+    push: z.boolean(),
+  }),
+  privacy: z.object({
+    publicProfile: z.boolean(),
+  }),
+  theme: z.enum(['light', 'dark', 'system']),
+})
+
+export type UserSettings = z.infer<typeof userSettingsSchema>
+
+export const USER_SETTINGS_DEFAULTS: UserSettings = {
+  notifications: { email: true, push: true },
+  privacy: { publicProfile: false },
+  theme: 'system',
+}
+
+export const userSettingsResponseSchema = userSettingsSchema
+
 export { okResponseSchema }


### PR DESCRIPTION
## Summary
- Add `userSettingsSchema` Zod schema for notifications, privacy, and theme preferences with typed defaults
- Add `GET /users/settings` endpoint that reads from `configs` table (`kind='user_settings'`) and returns defaults when no row exists
- Add `PUT /users/settings` endpoint with Zod validation, config upsert via `setConfig`, and audit event emission
- Add 5 route-level tests covering defaults, persistence, read-back, validation rejection, and audit trail

## Test plan
- [x] `npx tsc --noEmit` passes with zero new errors
- [x] `npx vitest run core/src/routes/users.settings.test.ts` -- all 5 tests pass
- [x] `npx biome lint` -- no lint errors on changed files

Closes #43