### PR TITLE
feat: add wiki progress tracking with milestones

### DIFF
--- a/core/drizzle/migrations/0008_wiki_progress.sql
+++ b/core/drizzle/migrations/0008_wiki_progress.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wikis" ADD COLUMN "progress" jsonb;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781762400000,
       "tag": "0007_trust_gates",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781848800000,
+      "tag": "0008_wiki_progress",
+      "breakpoints": true
     }
   ]
 }

--- a/core/scripts/generate-openapi-manifest.ts
+++ b/core/scripts/generate-openapi-manifest.ts
@@ -48,6 +48,8 @@ import {
   publicWikiResponseSchema,
   toggleRegenerateBodySchema,
   toggleRegenerateResponseSchema,
+  updateProgressBodySchema,
+  updateProgressResponseSchema,
   // wiki types
   wikiTypeResponseSchema,
   wikiTypeListResponseSchema,
@@ -135,6 +137,8 @@ const schemaRegistry: Record<string, ZodType> = {
   publicWikiResponseSchema,
   toggleRegenerateBodySchema,
   toggleRegenerateResponseSchema,
+  updateProgressBodySchema,
+  updateProgressResponseSchema,
   // wiki types
   wikiTypeResponseSchema,
   wikiTypeListResponseSchema,
@@ -234,6 +238,7 @@ const routes: RouteSpec[] = [
   { method: 'POST', path: '/wikis/{id}/publish', operationId: 'publishWiki', summary: 'Publish a wiki with a stable nanoid slug', tags: ['Wikis'], auth: 'session', request: { params: { id: 'lookupKey' } }, responses: { '200': { description: 'Publish status', schemaName: 'publishWikiResponseSchema' }, '400': { description: 'No content to publish', schemaName: 'errorResponseSchema' }, '404': { description: 'Not found', schemaName: 'errorResponseSchema' } } },
   { method: 'POST', path: '/wikis/{id}/unpublish', operationId: 'unpublishWiki', summary: 'Unpublish a wiki (preserves slug for re-publish)', tags: ['Wikis'], auth: 'session', request: { params: { id: 'lookupKey' } }, responses: { '200': { description: 'Unpublish status', schemaName: 'publishWikiResponseSchema' }, '404': { description: 'Not found', schemaName: 'errorResponseSchema' } } },
   { method: 'POST', path: '/wikis/{targetId}/merge', operationId: 'mergeWikis', summary: 'Merge wikis (not implemented)', tags: ['Wikis'], auth: 'session', responses: { '501': { description: 'Not implemented', schemaName: 'errorResponseSchema' } } },
+  { method: 'PUT', path: '/wikis/{id}/progress', operationId: 'updateWikiProgress', summary: 'Update wiki progress milestones', tags: ['Wikis'], auth: 'session', request: { params: { id: 'lookupKey' }, body: { schemaName: 'updateProgressBodySchema' } }, responses: { '200': { description: 'Updated progress', schemaName: 'updateProgressResponseSchema' }, '404': { description: 'Not found', schemaName: 'errorResponseSchema' } } },
 
   // ── Wiki Types ───────────────────────────────────────────────────────────
   { method: 'GET', path: '/wiki-types', operationId: 'listWikiTypes', summary: 'List all wiki types', tags: ['Wiki Types'], auth: 'session', responses: { '200': { description: 'List of wiki types', schemaName: 'wikiTypeListResponseSchema' } } },

--- a/core/src/__tests__/wiki-progress.test.ts
+++ b/core/src/__tests__/wiki-progress.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import {
+  wikiMilestoneSchema,
+  wikiProgressSchema,
+  updateProgressBodySchema,
+} from '../schemas/wikis.schema.js'
+
+// ── Schema unit tests ──────────────────────────────────────────────────────
+
+describe('wikiMilestoneSchema', () => {
+  it('accepts a valid milestone', () => {
+    const result = wikiMilestoneSchema.safeParse({ label: 'Scope defined', completed: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty label', () => {
+    const result = wikiMilestoneSchema.safeParse({ label: '', completed: false })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing completed', () => {
+    const result = wikiMilestoneSchema.safeParse({ label: 'Draft' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('wikiProgressSchema', () => {
+  it('accepts valid progress', () => {
+    const result = wikiProgressSchema.safeParse({
+      milestones: [{ label: 'Scope', completed: true }],
+      percentage: 100,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects percentage below 0', () => {
+    const result = wikiProgressSchema.safeParse({
+      milestones: [{ label: 'A', completed: false }],
+      percentage: -1,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects percentage above 100', () => {
+    const result = wikiProgressSchema.safeParse({
+      milestones: [{ label: 'A', completed: true }],
+      percentage: 101,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty milestones array', () => {
+    const result = wikiProgressSchema.safeParse({
+      milestones: [],
+      percentage: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects milestones array with more than 50 items', () => {
+    const milestones = Array.from({ length: 51 }, (_, i) => ({
+      label: `M${i}`,
+      completed: false,
+    }))
+    const result = wikiProgressSchema.safeParse({ milestones, percentage: 0 })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('updateProgressBodySchema', () => {
+  it('accepts milestones without percentage', () => {
+    const result = updateProgressBodySchema.safeParse({
+      milestones: [
+        { label: 'Scope', completed: true },
+        { label: 'Draft', completed: false },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty milestones', () => {
+    const result = updateProgressBodySchema.safeParse({ milestones: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips unknown fields', () => {
+    const result = updateProgressBodySchema.safeParse({
+      milestones: [{ label: 'A', completed: true }],
+      percentage: 100,
+    })
+    expect(result.success).toBe(true)
+    expect((result as any).data.percentage).toBeUndefined()
+  })
+
+  it('rejects milestones with empty label', () => {
+    const result = updateProgressBodySchema.safeParse({
+      milestones: [{ label: '', completed: false }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects more than 50 milestones', () => {
+    const milestones = Array.from({ length: 51 }, (_, i) => ({
+      label: `Step ${i}`,
+      completed: false,
+    }))
+    const result = updateProgressBodySchema.safeParse({ milestones })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ── Route tests ────────────────────────────────────────────────────────────
+
+const mockDbSelect = vi.fn()
+const mockDbUpdate = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    update: (...args: unknown[]) => mockDbUpdate(...args),
+  },
+}))
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookup_key',
+    name: 'wikis.name',
+    type: 'wikis.type',
+    prompt: 'wikis.prompt',
+    state: 'wikis.state',
+    vaultId: 'wikis.vault_id',
+    lastRebuiltAt: 'wikis.last_rebuilt_at',
+    createdAt: 'wikis.created_at',
+    updatedAt: 'wikis.updated_at',
+    progress: 'wikis.progress',
+  },
+}))
+
+const mockEmitAuditEvent = vi.fn()
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: (...args: unknown[]) => mockEmitAuditEvent(...args),
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (_c: any, next: any) => {
+    await next()
+  }),
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../lib/validation.js', () => ({
+  validationHook: (result: any, c: any) => {
+    if (!result.success) {
+      return c.json({ error: 'Validation failed', fields: result.error.flatten() }, 400)
+    }
+  },
+}))
+
+import { wikisRoutes } from '../routes/wikis.js'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/wikis', wikisRoutes)
+  return app
+}
+
+const now = new Date()
+
+function makeWiki(overrides: Record<string, unknown> = {}) {
+  return {
+    lookupKey: 'wiki01TEST',
+    slug: 'test-wiki',
+    name: 'Test Wiki',
+    type: 'goal',
+    prompt: '',
+    state: 'RESOLVED',
+    content: '',
+    vaultId: null,
+    lastRebuiltAt: null,
+    published: false,
+    publishedSlug: null,
+    publishedAt: null,
+    regenerate: true,
+    bouncerMode: 'auto',
+    dedupHash: null,
+    lockedBy: null,
+    lockedAt: null,
+    deletedAt: null,
+    progress: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function selectChainMock(rows: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockResolvedValue(rows)
+  return chain
+}
+
+function updateChainMock() {
+  const chain: Record<string, any> = {}
+  chain.set = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockResolvedValue(undefined)
+  return chain
+}
+
+describe('PUT /wikis/:id/progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEmitAuditEvent.mockResolvedValue(undefined)
+  })
+
+  it('returns 200 with correct percentage for mixed milestones', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([makeWiki()]))
+    mockDbUpdate.mockReturnValue(updateChainMock())
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        milestones: [
+          { label: 'Scope', completed: true },
+          { label: 'Draft', completed: true },
+          { label: 'Review', completed: false },
+          { label: 'Ship', completed: false },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.progress.percentage).toBe(50)
+    expect(body.progress.milestones).toHaveLength(4)
+  })
+
+  it('returns 404 for nonexistent wiki', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([]))
+
+    const app = createApp()
+    const res = await app.request('/wikis/nonexistent/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        milestones: [{ label: 'A', completed: true }],
+      }),
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for empty milestones array', async () => {
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ milestones: [] }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('computes 100% when all milestones completed', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([makeWiki()]))
+    mockDbUpdate.mockReturnValue(updateChainMock())
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        milestones: [
+          { label: 'A', completed: true },
+          { label: 'B', completed: true },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.progress.percentage).toBe(100)
+  })
+
+  it('computes 0% when no milestones completed', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([makeWiki()]))
+    mockDbUpdate.mockReturnValue(updateChainMock())
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        milestones: [
+          { label: 'A', completed: false },
+          { label: 'B', completed: false },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.progress.percentage).toBe(0)
+  })
+
+  it('emits audit event with correct params', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([makeWiki()]))
+    mockDbUpdate.mockReturnValue(updateChainMock())
+
+    const app = createApp()
+    await app.request('/wikis/wiki01TEST/progress', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        milestones: [
+          { label: 'Scope', completed: true },
+          { label: 'Draft', completed: false },
+        ],
+      }),
+    })
+
+    expect(mockEmitAuditEvent).toHaveBeenCalledTimes(1)
+    const [, params] = mockEmitAuditEvent.mock.calls[0]
+    expect(params.entityType).toBe('wiki')
+    expect(params.entityId).toBe('wiki01TEST')
+    expect(params.eventType).toBe('progress_updated')
+    expect(params.detail.percentage).toBe(50)
+    expect(params.detail.totalMilestones).toBe(2)
+    expect(params.detail.completedMilestones).toBe(1)
+  })
+})

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -227,6 +227,10 @@ export const wikis = pgTable(
     bouncerMode: text('bouncer_mode').notNull().default('auto'), // 'auto' | 'review'
     embedding: vector('embedding', { dimensions: 1536 }),
     searchVector: tsvector('search_vector'),
+    progress: jsonb('progress').$type<{
+      milestones: { label: string; completed: boolean }[]
+      percentage: number
+    } | null>(),
   },
   (t) => [
     uniqueIndex('wikis_slug_uidx').on(t.slug),

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -23,6 +23,8 @@ import {
   toggleRegenerateResponseSchema,
   spawnWikiBodySchema,
   spawnWikiResponseSchema,
+  updateProgressBodySchema,
+  updateProgressResponseSchema,
 } from '../schemas/wikis.schema.js'
 import { emitAuditEvent } from '../db/audit.js'
 import { timelineQuerySchema } from '../schemas/audit.schema.js'
@@ -45,6 +47,7 @@ function prepareThread(
     lastUpdated: t.lastUpdated ?? t.updatedAt.toISOString(),
     shortDescriptor: t.shortDescriptor ?? '',
     descriptor: t.descriptor ?? '',
+    progress: t.progress ?? null,
   }
 }
 
@@ -380,6 +383,39 @@ wikisRouter.patch('/:id/bouncer', zValidator('json', bouncerModeBodySchema, vali
 
   return c.json(bouncerModeResponseSchema.parse({ id, bouncerMode: mode }))
 })
+
+// PUT /wikis/:id/progress — update progress milestones
+wikisRouter.put(
+  '/:id/progress',
+  zValidator('json', updateProgressBodySchema, validationHook),
+  async (c) => {
+    const id = c.req.param('id')
+    const { milestones } = c.req.valid('json')
+
+    const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
+    if (!wiki) return c.json({ error: 'Not found' }, 404)
+
+    const completed = milestones.filter((m) => m.completed).length
+    const percentage = Math.round((completed / milestones.length) * 100)
+    const progress = { milestones, percentage }
+
+    await db
+      .update(wikis)
+      .set({ progress, updatedAt: new Date() })
+      .where(eq(wikis.lookupKey, id))
+
+    await emitAuditEvent(db, {
+      entityType: 'wiki',
+      entityId: id,
+      eventType: 'progress_updated',
+      source: 'api',
+      summary: `Wiki progress updated: ${wiki.name} (${percentage}%)`,
+      detail: { wikiKey: id, percentage, totalMilestones: milestones.length, completedMilestones: completed },
+    })
+
+    return c.json(updateProgressResponseSchema.parse({ progress }))
+  }
+)
 
 // POST /wikis/:id/spawn — create a related child wiki with a WIKI_RELATED_TO_WIKI edge
 wikisRouter.post(

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -397,7 +397,7 @@ wikisRouter.put(
 
     const completed = milestones.filter((m) => m.completed).length
     const percentage = Math.round((completed / milestones.length) * 100)
-    const progress = { milestones, percentage }
+    const progress = { milestones: milestones.map((m) => ({ label: m.label, completed: m.completed })), percentage }
 
     await db
       .update(wikis)

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -1,6 +1,26 @@
 import { z } from 'zod'
 import { lookupKeySchema, objectStateSchema, queuedResponseSchema } from './base.schema.js'
 
+// ── Progress schemas ───────────────────────────────────────────────────────
+
+export const wikiMilestoneSchema = z.object({
+  label: z.string().min(1, 'milestone label must not be empty'),
+  completed: z.boolean(),
+})
+
+export const wikiProgressSchema = z.object({
+  milestones: z.array(wikiMilestoneSchema).min(1).max(50),
+  percentage: z.number().min(0).max(100),
+})
+
+export const updateProgressBodySchema = z.object({
+  milestones: z.array(wikiMilestoneSchema).min(1).max(50),
+})
+
+export const updateProgressResponseSchema = z.object({
+  progress: wikiProgressSchema,
+})
+
 // ── Response schemas ────────────────────────────────────────────────────────
 
 export const threadResponseSchema = z.object({
@@ -19,6 +39,7 @@ export const threadResponseSchema = z.object({
   lastUpdated: z.string(),
   shortDescriptor: z.string().default(''),
   descriptor: z.string().default(''),
+  progress: wikiProgressSchema.nullable().default(null),
 })
 
 export const threadWithWikiResponseSchema = threadResponseSchema.extend({


### PR DESCRIPTION
## Summary

- Adds a `progress` JSONB column to the wikis table (nullable, default null) with migration `0008_wiki_progress.sql`
- Adds Zod validation schemas (`wikiMilestoneSchema`, `wikiProgressSchema`, `updateProgressBodySchema`, `updateProgressResponseSchema`) with 50-milestone cap and label validation
- Adds `PUT /wikis/:id/progress` endpoint that accepts milestones, computes percentage server-side, persists to DB, and emits an audit event
- Includes `progress` field in all existing GET wiki responses (both list and detail) via `threadResponseSchema`
- Registers new schemas and route in OpenAPI manifest

## Test plan

- [x] Schema unit tests: valid milestones, empty label rejection, percentage bounds, array size cap (50 max), empty array rejection
- [x] Route tests: 200 with correct percentage, 404 for nonexistent wiki, 400 for invalid body, 100%/0% edge cases, audit event verification
- [x] `npx tsc --noEmit` passes clean
- [x] All 19 new tests pass via `npx vitest run core/src/__tests__/wiki-progress.test.ts`

Closes #42