### PR TITLE
Phase 4 UI: preview panel + button on profile editor

### DIFF
--- a/wiki/src/app/profile/prompts/[slug]/page.tsx
+++ b/wiki/src/app/profile/prompts/[slug]/page.tsx
@@ -7,7 +7,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { useSession } from "@/hooks/useSession";
 import { useWikiTypesList, findWikiType } from "@/hooks/useWikiTypesList";
 import PromptEditor from "@/components/prompts/PromptEditor";
+import PreviewPanel from "@/components/prompts/PreviewPanel";
 import ConfirmDialog from "@/components/prompts/ConfirmDialog";
+import { cn } from "@/lib/utils";
 
 export default function PromptEditorPage({
   params,
@@ -21,6 +23,9 @@ export default function PromptEditorPage({
   const [discardOpen, setDiscardOpen] = useState(false);
   const [pendingBack, setPendingBack] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [triggerToken, setTriggerToken] = useState(0);
+  const [liveYaml, setLiveYaml] = useState("");
 
   const item = findWikiType(wikiTypes.data, slug);
 
@@ -33,6 +38,11 @@ export default function PromptEditorPage({
     } else {
       goBack();
     }
+  };
+
+  const handlePreview = () => {
+    setPreviewOpen(true);
+    setTriggerToken((t) => t + 1);
   };
 
   if (sessionLoading || wikiTypes.isLoading) {
@@ -67,7 +77,12 @@ export default function PromptEditorPage({
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto max-w-[920px] px-10 pt-12 pb-20">
+      <div
+        className={cn(
+          "mx-auto px-10 pt-12 pb-20",
+          previewOpen ? "max-w-[1440px]" : "max-w-[920px]",
+        )}
+      >
         <Button
           type="button"
           variant="ghost"
@@ -79,17 +94,46 @@ export default function PromptEditorPage({
           Back to prompts
         </Button>
 
-        <PromptEditor
-          slug={item.slug}
-          displayLabel={item.displayLabel}
-          initialYaml={item.promptYaml}
-          defaultYaml={item.defaultYaml}
-          inputVariables={item.inputVariables}
-          basedOnVersion={item.basedOnVersion}
-          userModified={item.userModified}
-          onSaved={() => setDirty(false)}
-          onDirtyChange={(d) => setDirty(d)}
-        />
+        <div
+          className={cn(
+            "grid gap-6",
+            previewOpen
+              ? "grid-cols-1 lg:grid-cols-[minmax(0,1fr)_480px]"
+              : "grid-cols-1",
+          )}
+        >
+          <div className="min-w-0">
+            <PromptEditor
+              slug={item.slug}
+              displayLabel={item.displayLabel}
+              initialYaml={item.promptYaml}
+              defaultYaml={item.defaultYaml}
+              inputVariables={item.inputVariables}
+              basedOnVersion={item.basedOnVersion}
+              userModified={item.userModified}
+              onSaved={() => setDirty(false)}
+              onDirtyChange={(d) => setDirty(d)}
+              onYamlChange={setLiveYaml}
+              footerActions={
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handlePreview}
+                >
+                  Preview
+                </Button>
+              }
+            />
+          </div>
+          {previewOpen ? (
+            <PreviewPanel
+              slug={item.slug}
+              draftYaml={liveYaml}
+              triggerToken={triggerToken}
+              onClose={() => setPreviewOpen(false)}
+            />
+          ) : null}
+        </div>
 
         <ConfirmDialog
           open={discardOpen}

--- a/wiki/src/components/prompts/PreviewPanel.tsx
+++ b/wiki/src/components/prompts/PreviewPanel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { T } from "@/lib/typography";
+import ValidationBanner from "./ValidationBanner";
+import { NETWORK_ERROR_MESSAGE } from "./errorMessages";
+import type { ApiErrorBody } from "./types";
+
+export interface PreviewPanelProps {
+  /** Wiki-type slug (e.g. "log"). Used in the fetch URL. */
+  slug: string;
+  /** Current unsaved YAML from the editor. Captured at fetch time. */
+  draftYaml: string;
+  /** Monotonic counter. Incrementing it triggers a fresh fetch. Value 0 means "no preview requested yet" — do not fetch on mount. */
+  triggerToken: number;
+  /** Called when the user clicks the X button in the panel header. */
+  onClose: () => void;
+}
+
+type PreviewWarning = { code: string; message: string };
+
+type PreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "success";
+      data: { renderedPrompt: string; warnings: PreviewWarning[] };
+    }
+  | { status: "error"; error: ApiErrorBody };
+
+export default function PreviewPanel({
+  slug,
+  draftYaml,
+  triggerToken,
+  onClose,
+}: PreviewPanelProps) {
+  const [state, setState] = useState<PreviewState>({ status: "idle" });
+  const [copied, setCopied] = useState(false);
+
+  const draftYamlRef = useRef(draftYaml);
+  useEffect(() => {
+    draftYamlRef.current = draftYaml;
+  }, [draftYaml]);
+
+  useEffect(() => {
+    if (triggerToken === 0) return;
+    const controller = new AbortController();
+    (async () => {
+      setState({ status: "loading" });
+      try {
+        const res = await fetch(`/api/wiki-types/${slug}/preview`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ promptYaml: draftYamlRef.current }),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          let body: ApiErrorBody;
+          try {
+            body = (await res.json()) as ApiErrorBody;
+          } catch {
+            body = { error: `Preview failed (${res.status})` };
+          }
+          setState({ status: "error", error: body });
+          return;
+        }
+        const json = (await res.json()) as {
+          renderedPrompt: string;
+          warnings: PreviewWarning[];
+        };
+        setState({ status: "success", data: json });
+      } catch (err) {
+        if ((err as { name?: string } | null)?.name === "AbortError") return;
+        setState({
+          status: "error",
+          error: { error: NETWORK_ERROR_MESSAGE },
+        });
+      }
+    })();
+    return () => controller.abort();
+  }, [triggerToken, slug]);
+
+  return (
+    <aside
+      className="flex flex-col gap-3 rounded border border-input bg-background p-4"
+      aria-label="Prompt preview"
+    >
+      <header className="flex items-center justify-between gap-2">
+        <span
+          style={{
+            ...T.bodySmall,
+            fontWeight: 600,
+            color: "var(--heading-color)",
+          }}
+        >
+          Preview
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close preview"
+          className="rounded p-1 text-muted-foreground hover:bg-muted"
+        >
+          <X className="size-4" aria-hidden />
+        </button>
+      </header>
+
+      {state.status === "idle" ? (
+        <p className="text-sm text-muted-foreground">
+          Click Preview to render.
+        </p>
+      ) : state.status === "loading" ? (
+        <div className="flex h-[300px] items-center justify-center">
+          <Spinner className="size-5" />
+        </div>
+      ) : state.status === "error" ? (
+        <ValidationBanner error={state.error} />
+      ) : (
+        <>
+          {state.data.warnings.length > 0 ? (
+            <div
+              role="status"
+              className="flex flex-col gap-1.5 rounded border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-sm"
+            >
+              <div className="flex items-center gap-2">
+                <AlertTriangle
+                  className="size-4 shrink-0 text-amber-600"
+                  aria-hidden
+                />
+                <span className="font-medium text-amber-900 dark:text-amber-200">
+                  {state.data.warnings.length === 1 ? "Warning" : "Warnings"}
+                </span>
+              </div>
+              <ul className="flex flex-col gap-1">
+                {state.data.warnings.map((w, i) => (
+                  <li
+                    key={`${w.code}-${i}`}
+                    className="flex items-start gap-2"
+                  >
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] font-mono"
+                    >
+                      {w.code}
+                    </Badge>
+                    <span className="flex-1 text-foreground">{w.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                void navigator.clipboard.writeText(state.data.renderedPrompt);
+                setCopied(true);
+                window.setTimeout(() => setCopied(false), 2000);
+              }}
+              className="absolute right-2 top-2 z-10 rounded border border-input bg-background px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted"
+              aria-label="Copy rendered prompt"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+            <ScrollArea className="h-[600px] rounded border border-input">
+              <pre className="whitespace-pre-wrap break-words p-3 font-mono text-xs">
+                {state.data.renderedPrompt}
+              </pre>
+            </ScrollArea>
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/wiki/src/components/prompts/PromptEditor.tsx
+++ b/wiki/src/components/prompts/PromptEditor.tsx
@@ -63,6 +63,7 @@ export default function PromptEditor({
   footerActions,
   mode: _mode = "full-yaml",
   onDirtyChange,
+  onYamlChange,
 }: PromptEditorProps) {
   // mode !== "full-yaml" is a Phase 3 extension point — this plan treats it the same as "full-yaml".
   const [yaml, setYaml] = useState(initialYaml);
@@ -81,6 +82,9 @@ export default function PromptEditor({
   useEffect(() => {
     onDirtyChange?.(isDirty);
   }, [isDirty, onDirtyChange]);
+  useEffect(() => {
+    onYamlChange?.(yaml);
+  }, [yaml, onYamlChange]);
 
   const handleInsertVariable = useCallback((name: string) => {
     const view = viewRef.current;

--- a/wiki/src/components/prompts/ValidationBanner.tsx
+++ b/wiki/src/components/prompts/ValidationBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { AlertCircle } from "lucide-react";
 import type { ApiErrorBody } from "./types";
-import { describeSaveError } from "./errorMessages";
+import { describeApiError } from "./errorMessages";
 import { cn } from "@/lib/utils";
 
 export interface ValidationBannerProps {
@@ -11,7 +11,7 @@ export interface ValidationBannerProps {
 
 export default function ValidationBanner({ error, className }: ValidationBannerProps) {
   if (!error) return null;
-  const message = describeSaveError(error);
+  const message = describeApiError(error);
   return (
     <div
       role="alert"

--- a/wiki/src/components/prompts/errorMessages.ts
+++ b/wiki/src/components/prompts/errorMessages.ts
@@ -28,7 +28,7 @@ const MAP: Record<string, Detailer> = {
 };
 
 /** Map a server ApiErrorBody to a user-facing string. Unknown codes fall back to `error`. */
-export function describeSaveError(body: ApiErrorBody): string {
+export function describeApiError(body: ApiErrorBody): string {
   if (body.code && MAP[body.code]) return MAP[body.code](body.detail);
   if (body.error) return body.error;
   return "Save failed. Check connection and retry.";

--- a/wiki/src/components/prompts/types.ts
+++ b/wiki/src/components/prompts/types.ts
@@ -43,4 +43,6 @@ export interface PromptEditorProps {
   mode?: EditorMode;
   /** Emits whenever the editor's dirty state (yaml !== savedYaml) changes. */
   onDirtyChange?: (dirty: boolean) => void;
+  /** Phase 4 preview UI: emits the editor's current yaml on every change (user edits, reset, undo). Read-only signal — do NOT mutate yaml from this callback. */
+  onYamlChange?: (yaml: string) => void;
 }


### PR DESCRIPTION
Completes #63 (backend portion shipped via PR #65). Closes #63 on merge.

Final wave of the prompt customization overhaul. Phases 1, 2, 3, and 4-backend shipped previously (PRs #64, #66, #62→upcoming, #65).

## What this does

Adds a **Preview** button to the PromptEditor footer on the `/profile/prompts/[slug]` settings page. Clicking opens a side panel (480px, right) that POSTs the current unsaved YAML draft to `POST /wiki-types/:slug/preview` and renders the server-rendered Handlebars output plus any warnings.

**Shape A only — no LLM call.** Server renders the user's YAML template against a committed fixture and returns the rendered prompt text + warnings list. Instant, deterministic, free.

### Key behavior
- **Side panel layout** on the profile slug page: `lg:grid-cols-[minmax(0,1fr)_480px]` grid, editor on left stays fully interactive while panel is open.
- **Preview button lives ONLY on the profile page** — NOT in onboarding, NOT in AddWikiModal (Phase 2's `footerActions` slot is simply not passed there).
- **Unsaved draft sent to preview**, not the saved value. Captured via a new additive `onYamlChange?: (yaml: string) => void` prop on PromptEditor.
- **triggerToken pattern** — each button click increments a counter; PreviewPanel refetches only when the token changes (no per-keystroke fetches). AbortController cancels in-flight on rapid clicks.
- **Warnings block at top** of panel (distinct from rendered body), rendered output in `<ScrollArea>` with monospace text + height cap.
- **Copy button** on rendered output.
- **Error states** via renamed `describeApiError` (was `describeSaveError`).

## Extension points preserved
- `PromptEditor` gained exactly ONE new prop (`onYamlChange`). All existing behavior preserved.
- `errorMessages.ts` was renamed from `describeSaveError` → `describeApiError` to reflect broader usage. All callers updated.

## Out of scope
- LLM-based preview (Shape B, deferred indefinitely).
- User-thread or custom-paste fragment sources (fixture-only MVP).
- Token counting or cost estimation (no LLM = no cost).
- Preview in onboarding (low value in the fast-path).

## Test plan
- [x] `cd wiki && npx tsc --noEmit` — clean
- [x] `cd wiki && npx eslint . --quiet` — no new violations
- [x] `cd wiki && npx next build` — passes
- [ ] Reviewer: walk `.planning/phases/prompt-preview-ui/QA.md` 12 scenarios (click preview, verify rendered output, warnings, error states, Copy button, responsive modal on narrow screens, theme match).