### PR TITLE
Fix: per-wiki prompt APPENDS to system_message instead of replacing

### DIFF
--- a/core/src/lib/regen.test.ts
+++ b/core/src/lib/regen.test.ts
@@ -209,7 +209,7 @@ describe('regenerateWiki — override hierarchy integration', () => {
     expect(llmCalls[0].user).toContain('DOCUMENT STRUCTURE')
   })
 
-  it('short-circuits type-level lookup and swaps only system_message when wiki.prompt is set', async () => {
+  it('short-circuits type-level lookup and APPENDS wiki.prompt to system_message', async () => {
     stageDbResponses([
       [baseWiki({ prompt: 'You are a pirate poet, yarrr.' })], // 1. wikis select
       [],                                                        // 2. fragment edges
@@ -220,9 +220,11 @@ describe('regenerateWiki — override hierarchy integration', () => {
     await regenerateWiki(undefined, 'wiki-key-1', { skipEmbedding: true })
 
     expect(llmCalls).toHaveLength(1)
-    // System message was REPLACED entirely — no Quill residue.
-    expect(llmCalls[0].system).toBe('You are a pirate poet, yarrr.')
-    expect(llmCalls[0].system).not.toContain('Quill')
+    // System message APPENDS: Quill base stays, pirate text follows after a blank-line.
+    expect(llmCalls[0].system).toContain('Quill')
+    expect(llmCalls[0].system).toContain('changelog author')
+    expect(llmCalls[0].system).toContain('You are a pirate poet, yarrr.')
+    expect(llmCalls[0].system).toMatch(/\n\nYou are a pirate poet, yarrr\.$/)
     // Template (user) is still the disk default — title + DOCUMENT STRUCTURE intact.
     expect(llmCalls[0].user).toContain('Test Wiki')
     expect(llmCalls[0].user).toContain('DOCUMENT STRUCTURE')
@@ -320,7 +322,7 @@ temperature: 0.3
     expect(llmCalls[0].system).toContain('Quill')
   })
 
-  it('trims trailing whitespace when swapping system_message from wiki.prompt', async () => {
+  it('trims surrounding whitespace from wiki.prompt before appending to system_message', async () => {
     stageDbResponses([
       [baseWiki({ prompt: 'pirate voice\n\n' })],
       [],
@@ -330,7 +332,9 @@ temperature: 0.3
     await regenerateWiki(undefined, 'wiki-key-1', { skipEmbedding: true })
 
     expect(llmCalls).toHaveLength(1)
-    expect(llmCalls[0].system).toBe('pirate voice')
+    // Base system_message (Quill) is preserved; pirate voice appended cleanly without trailing newlines.
+    expect(llmCalls[0].system).toContain('Quill')
+    expect(llmCalls[0].system).toMatch(/\n\npirate voice$/)
   })
 
   it('treats whitespace-only wiki.prompt as "no override" and falls through to disk default', async () => {

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -44,8 +44,11 @@ const schemaMap: Record<WikiType, z.ZodType> = {
  *
  * - `yaml`: full YAML blob (from wikiTypes.prompt). Parsed via parseSpecFromBlob;
  *   spec.system_message, spec.template, spec.temperature all come from the blob.
- * - `systemMessage`: plain text (from wikis.prompt). Disk spec is loaded; only
- *   spec.system_message is replaced — template/temperature/input_variables stay.
+ * - `systemMessage`: plain text (from wikis.prompt). Disk spec is loaded; the
+ *   text is APPENDED to spec.system_message (separated by a blank line) —
+ *   template/temperature/input_variables stay. Append (not replace) lets users
+ *   add per-wiki guidance on top of the canonical type prompt without losing
+ *   its rules or tone.
  *
  * In both cases, outputSchema is always code-sourced from schemaMap[type] —
  * user YAML can never change the LLM output contract.
@@ -79,11 +82,15 @@ export function loadWikiGenerationSpec(
     if (override.kind === 'yaml') {
       effective = parseSpecFromBlob(override.blob)
     } else {
-      // trimEnd guards against trailing whitespace subtly changing LLM behavior.
-      effective = {
-        ...diskSpec,
-        system_message: override.text.trimEnd(),
-      }
+      // Append (not replace): user text extends the canonical type system_message.
+      // trimEnd on both sides keeps the blank-line separator clean.
+      const extra = override.text.trim()
+      effective = extra
+        ? {
+            ...diskSpec,
+            system_message: `${diskSpec.system_message.trimEnd()}\n\n${extra}`,
+          }
+        : diskSpec
     }
   }
 

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -642,7 +642,7 @@ export default function AddWikiModal({
                     {typeLabel} Prompt
                   </DialogTitle>
                   <DialogDescription>
-                    {`Optional override. Replaces the type's system_message at regen time. Leave empty to use the ${typeLabelLower} default.`}
+                    {`Optional extra instructions. Appended to the ${typeLabelLower} type's system message at regen time. Leave empty to use the default alone.`}
                   </DialogDescription>
                 </DialogHeader>
 
@@ -651,7 +651,7 @@ export default function AddWikiModal({
                   onChange={(e) => setPromptDraft(e.target.value)}
                   className="min-h-[240px] resize-none"
                   rows={12}
-                  placeholder={`Leave blank to use the ${typeLabel} default.`}
+                  placeholder={`Extra guidance appended to the ${typeLabel} default. Leave blank for the default alone.`}
                 />
 
                 <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
Closes #69.

## Problem

Phase 3 shipped `wikis.prompt` with **replace** semantics — typing anything in the per-wiki prompt field wiped the YAML type's `system_message` entirely (losing Quill guidance, attribution rules, structure). Intent is additive.

## Fix

`packages/shared/src/prompts/loaders/wiki-generation.ts` — the `systemMessage` branch of `WikiGenerationOverride` now concatenates:

```
effective.system_message = `${diskSpec.system_message.trimEnd()}\n\n${userText.trim()}`
```

Empty or whitespace-only `wiki.prompt` → unchanged disk default (no trailing blank lines).

## UI copy

`AddWikiModal.tsx`:
- Description: `Optional extra instructions. Appended to the {type} type's system message at regen time. Leave empty to use the default alone.`
- Placeholder: `Extra guidance appended to the {type} default. Leave blank for the default alone.`

The words "override" / "replace" are gone from user-facing copy — this is additive.

## Tests

Two regen integration tests flipped from replace to append assertions:
- `short-circuits type-level lookup and APPENDS wiki.prompt to system_message` — asserts both Quill (base) and the pirate text (append) are present, with `\n\n` separator.
- `trims surrounding whitespace from wiki.prompt before appending` — asserts base preserved + clean append without trailing newlines.

All 7 `src/lib/regen.test.ts` cases pass.

## Out of scope

- No data migration needed (feature just shipped, no stored prod values).
- Tagged-union kind name `systemMessage` unchanged — only the behavior.