### PR TITLE
Boot hardening: pgvector auto-ensure + env fail-fast + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,68 @@
+# ============================================================================
+# Robin environment variables
+# ============================================================================
+# Copy to .env and fill in values. Vars marked REQUIRED are fatal if missing
+# in production (assertProdEnv() in core/src/bootstrap/env.ts).
+# Railway deployments can reference Postgres/Redis plugin vars via ${{...}}.
+
+# ----- Core (API + workers) ------------------------------------------------
+
+# REQUIRED. PostgreSQL connection. Railway: ${{Postgres.DATABASE_URL}}
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/robin
+
+# REQUIRED. Redis for BullMQ. Railway: ${{Redis.REDIS_URL}}
+REDIS_URL=redis://localhost:6379
+
+# REQUIRED. BetterAuth session signing. 32+ chars. Generate: openssl rand -hex 32
+BETTER_AUTH_SECRET=
+
+# REQUIRED. Encrypts stored OpenRouter API keys at rest. 64 hex chars.
+# Generate: openssl rand -hex 32
+MASTER_KEY=
+
+# REQUIRED. Encrypts provision-worker Ed25519 keypairs. 32+ chars.
+# Generate: openssl rand -hex 32
+KEY_ENCRYPTION_SECRET=
+
+# Recommended in prod. Without it, ingest jobs fail silently until the key
+# is seeded into the configs table.
+OPENROUTER_API_KEY=
+
+# Optional. Admin bootstrap on first boot. Leave empty to skip seed.
+INITIAL_USERNAME=
+INITIAL_PASSWORD=
+
+# Optional. BetterAuth cookie scope + rewrite origin.
+# Default: http://localhost:3000. Prod: https://core-xxx.up.railway.app
+SERVER_PUBLIC_URL=
+
+# Optional. CORS allowlist (comma-separated).
+# Default: http://localhost:8080. Prod: https://wiki-xxx.up.railway.app
+WIKI_ORIGIN=
+
+# Optional. Server port. Railway sets this automatically.
+PORT=3000
+
+# Optional. "development" or "production"
+NODE_ENV=development
+
+# Optional. Log verbosity. dev default: debug. prod default: info.
+LOG_LEVEL=
+
+# --- AI model overrides (all optional; fall back to MODEL_DEFAULTS in code) ---
+DEFAULT_MODEL=
+EXTRACTION_MODEL=
+WIKI_CLASSIFY_MODEL=
+WIKI_GENERATION_MODEL=
+EMBEDDING_MODEL=openai/text-embedding-3-small
+
+# --- Pipeline thresholds (tune if recall/precision drifts) ---
+DEDUP_THRESHOLD=0.6
+THREAD_CLASSIFY_THRESHOLD=0.7
+FRAG_RELATE_THRESHOLD=0.5
+
+# ----- Wiki (Next.js) ------------------------------------------------------
+
+# REQUIRED at build AND runtime. Where wiki's server-side rewrites send /api/*.
+# Local: http://localhost:3000. Railway: http://${{core.RAILWAY_PRIVATE_DOMAIN}}:${{core.PORT}}
+NEXT_PUBLIC_ROBIN_API=http://localhost:3000

--- a/core/src/bootstrap/ensure-pgvector.ts
+++ b/core/src/bootstrap/ensure-pgvector.ts
@@ -1,0 +1,59 @@
+import { sql } from 'drizzle-orm'
+import { db } from '../db/client.js'
+import { logger } from '../lib/logger.js'
+
+const log = logger.child({ component: 'ensure-pgvector' })
+
+/**
+ * Ensure the pgvector extension exists in the configured database before
+ * migrations run. Idempotent — issues `CREATE EXTENSION IF NOT EXISTS vector`.
+ *
+ * Design notes:
+ *   - Reuses the Drizzle client so we share a connection with run-migrations.
+ *   - Detects whether the extension was newly created by checking pg_extension
+ *     before and after the CREATE, purely for nicer boot logs.
+ *   - Does NOT throw if the role lacks CREATE EXTENSION privilege — we log a
+ *     clear warning telling the operator to run it manually. If vector columns
+ *     reference the type, the downstream migration will fail loudly, which is
+ *     the surfaced error we want.
+ */
+export async function ensurePgvector(): Promise<void> {
+  const existedBefore = await hasVectorExtension()
+
+  if (existedBefore) {
+    log.info('pgvector extension already present')
+    return
+  }
+
+  try {
+    await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`)
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : err },
+      'could not create pgvector extension — role likely lacks CREATE EXTENSION privilege. ' +
+        'Run `CREATE EXTENSION vector;` as a superuser. Migrations will fail if vector columns ' +
+        'reference the type.',
+    )
+    return
+  }
+
+  const existsAfter = await hasVectorExtension()
+  if (existsAfter) {
+    log.info('pgvector extension created')
+  } else {
+    log.warn('pgvector extension still missing after CREATE EXTENSION — investigate manually')
+  }
+}
+
+/** Best-effort lookup against pg_extension. Returns false on any error. */
+async function hasVectorExtension(): Promise<boolean> {
+  try {
+    const rows = await db.execute<{ extname: string }>(
+      sql`SELECT extname FROM pg_extension WHERE extname = 'vector' LIMIT 1`,
+    )
+    if (Array.isArray(rows)) return rows.length > 0
+    return false
+  } catch {
+    return false
+  }
+}

--- a/core/src/bootstrap/env.ts
+++ b/core/src/bootstrap/env.ts
@@ -1,6 +1,48 @@
 import { z } from 'zod'
 import { createConfigVar } from '@robin/shared'
 
+/**
+ * Fail-fast check for production deploys. Runs before any other bootstrap step
+ * so operators get a single clean message listing everything missing, instead
+ * of piecemeal crashes deep in module initialization (crypto.ts, db/client.ts,
+ * ...). No-op outside production so local dev isn't forced to set every var.
+ */
+export function assertProdEnv(): void {
+  if (process.env.NODE_ENV !== 'production') return
+
+  const required = [
+    'DATABASE_URL',
+    'REDIS_URL',
+    'BETTER_AUTH_SECRET',
+    'MASTER_KEY',
+    'KEY_ENCRYPTION_SECRET',
+  ] as const
+
+  const recommended = [
+    'OPENROUTER_API_KEY',
+    'SERVER_PUBLIC_URL',
+    'WIKI_ORIGIN',
+  ] as const
+
+  const missing = required.filter((k) => !process.env[k])
+  if (missing.length) {
+    console.error(`FATAL: missing required env vars in production: ${missing.join(', ')}`)
+    console.error('See .env.example at repo root for descriptions.')
+    process.exit(1)
+  }
+
+  const warn = recommended.filter((k) => !process.env[k])
+  if (warn.length) {
+    console.warn(
+      `WARN: recommended env vars not set: ${warn.join(', ')} — some features may degrade silently.`,
+    )
+  }
+}
+
+// Run the prod gate before Zod validation so a missing MASTER_KEY / DATABASE_URL
+// in production produces one clean error instead of a Zod-style wall of issues.
+assertProdEnv()
+
 export const env = createConfigVar({
   schema: {
     DATABASE_URL: z.string().min(1).describe('Postgres connection string'),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -29,6 +29,7 @@ import { bullBoardApp } from './routes/bull-board.js'
 import { adminRoutes } from './routes/admin.js'
 import { authRecoverRoutes } from './routes/auth-recover.js'
 import { checkOpenRouterKey } from './bootstrap/check-openrouter-key.js'
+import { ensurePgvector } from './bootstrap/ensure-pgvector.js'
 import { runMigrations } from './bootstrap/run-migrations.js'
 import { seedWikiTypes } from './bootstrap/seed-wiki-types.js'
 import { loadMasterKey } from './lib/crypto.js'
@@ -129,6 +130,13 @@ app.route('/ai', aiModelsRoutes)
 
 // Fail fast on missing MASTER_KEY before any crypto ops run
 loadMasterKey()
+
+// Ensure pgvector exists before migrations — some tables reference the type.
+// Best-effort: logs a warning and continues if the DB role lacks CREATE EXTENSION,
+// so the actual migration failure surfaces as the real error.
+await ensurePgvector().catch((err) => {
+  logger.warn({ err }, 'ensure-pgvector failed — continuing, migrations may fail')
+})
 
 // Apply pending migrations before any code touches the schema.
 // runMigrations is idempotent and safe to call on every boot.

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config'
-import './bootstrap/env.js'
+import { assertProdEnv } from './bootstrap/env.js'
 import { readFileSync } from 'node:fs'
 import { load as loadYaml } from 'js-yaml'
 import { Hono } from 'hono'
@@ -127,6 +127,10 @@ app.route('/ai', aiModelsRoutes)
 /***********************************************************************
  * ## Boot
  ***********************************************************************/
+
+// Explicit, idempotent prod-env gate. Also runs at module load (from env.ts),
+// so in practice this line is a no-op — kept here to document boot order.
+assertProdEnv()
 
 // Fail fast on missing MASTER_KEY before any crypto ops run
 loadMasterKey()


### PR DESCRIPTION
Companion to the Railway deploy configs PR. Removes two operator foot-guns: manual pgvector install, and piecemeal env-var failures buried in module initialization.

## What ships

- **`core/src/bootstrap/ensure-pgvector.ts`** — idempotent `CREATE EXTENSION IF NOT EXISTS vector` run before migrations. Logs created-vs-present, doesn't throw if the role lacks CREATE EXTENSION privilege (warns and lets migrations surface the real error downstream).
- **`core/src/bootstrap/env.ts::assertProdEnv()`** — first thing `index.ts` calls in production. Lists every missing required env var in one `console.error` and exits cleanly, instead of the current behavior where `MASTER_KEY` crashes in `crypto.ts`, `DATABASE_URL` crashes in `db/client.ts`, etc.
- **`.env.example`** at repo root — every env var any workspace reads, grouped by service, with required/optional labels and Railway reference hints.

## Boot order (post-change)

```
assertProdEnv()        # NEW — fail-fast for required vars in prod
loadMasterKey()
ensurePgvector()       # NEW — safe CREATE EXTENSION before migrations
runMigrations()
checkOpenRouterKey()
seedWikiTypes()
startWorkers()
listen()
```

## Test plan
- [x] `pnpm --filter @robin/core exec tsc --noEmit` — clean
- [x] `pnpm --filter @robin/core exec vitest run` — no new failures (pre-existing Style B Postgres failures untouched)
- [x] `.env.example` env list cross-checked against actual `process.env` reads across core/, wiki/, packages/*
- [x] Dry-run: `NODE_ENV=production` with all required vars unset produces a single `FATAL: missing required env vars in production: DATABASE_URL, REDIS_URL, BETTER_AUTH_SECRET, MASTER_KEY, KEY_ENCRYPTION_SECRET` line and exits
- [ ] Reviewer: deploy to a fresh Railway project and verify clean boot without manual `CREATE EXTENSION` step.
- [ ] Reviewer: start in prod mode with a missing var (e.g. unset `MASTER_KEY`) and confirm one clean error message instead of piecemeal crash.