### PR TITLE
Fix: gate /admin/queues behind NODE_ENV != production

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -101,7 +101,13 @@ app.route('/admin', adminRoutes)
 app.route('/auth', authRecoverRoutes)
 app.route('/published', publishedRoutes)
 app.use('/api/auth/*', (c) => auth.handler(c.req.raw))
-app.route('/admin/queues', bullBoardApp)
+
+// BullBoard exposes queue payloads (raw user fragments), retry controls, and
+// drain actions. It has no auth in front. Only mount outside production until
+// issue #73 ships a proper session gate.
+if (process.env.NODE_ENV !== 'production') {
+  app.route('/admin/queues', bullBoardApp)
+}
 
 /***********************************************************************
  * ## Authenticated API


### PR DESCRIPTION
Part of #73 — interim kill switch while the real session-based gate is designed.

## Problem
\`/admin/queues\` (BullBoard UI) has no auth middleware. On Railway public ingress, anyone hitting the URL can read queue job payloads (raw user fragments), retry jobs at your OpenRouter expense, or drain/pause the pipeline.

## Fix
Wrap the route registration in \`if (process.env.NODE_ENV !== 'production')\`. Trades prod ops visibility for not leaking user content. Issue #73 tracks the real fix (session middleware in front of the route).

## Changes
- \`core/src/index.ts\` — one conditional around the \`app.route('/admin/queues', bullBoardApp)\` call. Dev/test untouched.

## Test plan
- [x] \`pnpm --filter @robin/core exec tsc --noEmit\` clean
- [ ] Reviewer: \`NODE_ENV=production node core/dist/index.js\` → \`curl /admin/queues\` returns 404.
- [ ] Reviewer: \`NODE_ENV=development node core/dist/index.js\` → \`/admin/queues\` still loads as today.