### PR TITLE
feat(wiki): design system alignment — fonts, tokens, components, consistency

### DIFF
--- a/wiki/src/app/globals.css
+++ b/wiki/src/app/globals.css
@@ -182,15 +182,51 @@
   --fragment-type-reference-bg: rgba(20, 184, 166, 0.10);
   --fragment-type-reference-text: #0d9488;
   --fragment-type-reference-border: #0d9488;
+
+  /* Accent scale (chips, tabs, interactive states) */
+  --accent-100: #f0f4ff;
+  --accent-200: #d9e2ff;
+  --accent-300: #7986cb;
+  --accent-500: #3366cc;
+  --accent-600: #2a56b0;
+  --accent-700: #1a3d8f;
+  --accent-fg: #ffffff;
+
+  /* Surfaces */
+  --surface-subtle: #f8f9fa;
+  --surface-dialog-footer: #fafafa;
+
+  /* Graph */
+  --graph-edge-base: rgba(114, 119, 125, 0.5);
+  --graph-edge-wikilink: rgba(51, 102, 204, 0.55);
+  --graph-grid: rgba(162, 169, 177, 0.18);
+  --graph-panel-bg: #ffffff;
+
+  /* Diff */
+  --diff-added-bg: #d4f4d4;
+  --diff-added-text: #14532d;
+  --diff-removed-bg: #fbd5d5;
+  --diff-removed-text: #7f1d1d;
+
+  /* Shadows */
+  --shadow-dropdown: 0 4px 16px rgba(0, 0, 0, 0.15);
+  --shadow-modal: 0 0 0 1px rgb(0 0 0 / .10), 0 20px 40px -10px rgb(0 0 0 / .25);
+  --shadow-toast: 0 10px 28px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.06);
+
+  /* Code */
+  --code-block-bg: #f6f8fa;
+
+  /* Wiki link hover */
+  --wiki-link-hover: #2a56b0;
 }
 
 
 @theme inline {
-  --font-source-serif: var(--font-source-serif-4);
-  --font-inter: var(--font-inter);
+  --font-serif: var(--font-stix-two-text);
   --font-ibm-plex: var(--font-ibm-plex-sans);
-  --font-heading: var(--font-sans);
-  --font-sans: var(--font-sans);
+  --font-mono: var(--font-ibm-plex-mono);
+  --font-heading: var(--font-ibm-plex-sans);
+  --font-sans: var(--font-ibm-plex-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -242,9 +278,9 @@ body {
 }
 
 body {
-  background: #f8f9fa ;
+  background: var(--surface-subtle);
   color: var(--heading-color);
-  font-family: var(--font-inter), "Inter", sans-serif;
+  font-family: var(--font-ibm-plex-sans), "IBM Plex Sans", sans-serif;
   transition: background-color 0.2s ease, color 0.2s ease;
   overflow-x: hidden;
 }
@@ -327,15 +363,15 @@ input:focus {
   transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .wiki-search-filter-chip:hover {
-  background: #d9e2ff;
-  color: var(--wiki-link);
-  border-color: var(--wiki-link);
+  background: var(--accent-100);
+  color: var(--accent-700);
+  border-color: var(--accent-300);
 }
 .wiki-search-filter-chip--active,
 .wiki-search-filter-chip--active:hover {
-  background: var(--wiki-link);
-  border-color: var(--wiki-link);
-  color: #ffffff;
+  background: var(--accent-500);
+  border-color: var(--accent-500);
+  color: var(--accent-fg);
 }
 
 /* Article tab row — only needs left margin when it sits beside the title at lg+ */
@@ -352,22 +388,22 @@ input:focus {
 }
 .wiki-article-tab:hover {
   color: var(--wiki-link);
-  border-bottom: 2px solid var(--wiki-link);
+  border-bottom: 2px solid var(--accent-200);
 }
 .wiki-article-tab-active,
 .wiki-article-tab-active:hover {
-  color: #000000;
-  border-bottom: 2px solid #000000;
+  color: var(--accent-600);
+  border-bottom: 2px solid var(--accent-500);
 }
 
-/* Cancel action — black text, black underline on hover */
+/* Cancel action — foreground text, foreground underline on hover */
 .wiki-article-tab-muted {
-  color: #000000;
+  color: var(--heading-color);
   border-bottom: 2px solid transparent;
 }
 .wiki-article-tab-muted:hover {
-  color: #000000;
-  border-bottom: 2px solid #000000;
+  color: var(--heading-color);
+  border-bottom: 2px solid var(--heading-color);
 }
 
 /* Add Wiki header button — blue ghost, light-blue hover background */
@@ -375,7 +411,7 @@ input:focus {
   transition: background-color 0.12s ease;
 }
 .wiki-add-wiki-btn:hover {
-  background: #d9e2ff !important;
+  background: var(--accent-200) !important;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -680,7 +716,7 @@ input:focus {
 .wiki-richtext-editor .ProseMirror,
 .wiki-richtext-rendered {
   color: var(--wiki-article-text);
-  font-family: var(--font-inter), Inter, sans-serif;
+  font-family: var(--font-ibm-plex-sans), "IBM Plex Sans", sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 22px;
@@ -693,7 +729,7 @@ input:focus {
 .wiki-richtext-editor .ProseMirror p,
 .wiki-richtext-rendered p {
   margin: 0;
-  font-family: var(--font-inter), Inter, sans-serif;
+  font-family: var(--font-ibm-plex-sans), "IBM Plex Sans", sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 22px;
@@ -710,7 +746,7 @@ input:focus {
   margin: 20px 0 0;
   padding-bottom: 4px;
   border-bottom: 1px solid var(--wiki-meta-line);
-  font-family: var(--font-source-serif-4), "Source Serif 4", "Source Serif Pro", serif;
+  font-family: var(--font-stix-two-text), "STIX Two Text", Georgia, serif;
   font-size: 24px;
   font-weight: 600;
   line-height: 30px;
@@ -720,7 +756,7 @@ input:focus {
 .wiki-richtext-editor .ProseMirror h3,
 .wiki-richtext-rendered h3 {
   margin: 16px 0 0;
-  font-family: var(--font-source-serif-4), "Source Serif 4", "Source Serif Pro", serif;
+  font-family: var(--font-stix-two-text), "STIX Two Text", Georgia, serif;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -750,8 +786,8 @@ input:focus {
   margin: 0 0 12px 0;
   padding: 8px 12px;
   border-left: 3px solid var(--wiki-card-border);
-  color: #555;
-  background: #f8f8f8;
+  color: var(--wiki-sidebar-text);
+  background: var(--surface-subtle);
 }
 
 .wiki-richtext-editor .ProseMirror pre,
@@ -759,7 +795,7 @@ input:focus {
   margin: 0 0 12px 0;
   padding: 10px 12px;
   border: 1px solid var(--wiki-card-border);
-  background: #fafafa;
+  background: var(--code-block-bg);
   overflow-x: auto;
 }
 
@@ -787,7 +823,7 @@ input:focus {
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
+  --radius: 0.125rem; /* 2px — Wikipedia-inspired squared aesthetic per designsys.html */
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -831,4 +867,519 @@ input:focus {
 [data-theme="dark"] .cm-hbs-token {
   background: rgba(126, 138, 200, 0.25);
   color: #c5cae9;
+}
+
+/* ─── WikiSearchBar (.wiki-search-bar) ───────────────────── */
+.wiki-search-bar__send {
+  flex-shrink: 0;
+  padding: 4px;
+  border: none;
+  border-radius: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+.wiki-search-bar__send--compact {
+  padding: 3px;
+}
+
+.wiki-search-bar__stacked-label {
+  width: 100%;
+  max-width: 591px;
+  min-height: 88px;
+  padding: 12px;
+  box-sizing: border-box;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  overflow: hidden;
+  cursor: text;
+}
+
+.wiki-search-bar__inline-wrap {
+  width: 100%;
+  max-width: 591px;
+  min-height: 53px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-sizing: border-box;
+}
+.wiki-search-bar__inline-wrap--embedded {
+  min-height: auto;
+  padding: 0;
+}
+
+.wiki-search-bar__input-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 4px 8px;
+  border-radius: 12px;
+  gap: 8px;
+  box-sizing: border-box;
+}
+.wiki-search-bar__input-row--compact {
+  padding: 2px 6px;
+  gap: 6px;
+}
+
+/* ─── Search filter chip (.sfchip) ───────────────────────── */
+.sfchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--wiki-card-border);
+  border-radius: 2px;
+  color: var(--wiki-sidebar-text);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.sfchip__label {
+  font-size: 12px;
+  letter-spacing: -0.0288px;
+  white-space: nowrap;
+}
+.sfchip:hover {
+  background: var(--accent-100);
+  color: var(--accent-700);
+  border-color: var(--accent-300);
+}
+.sfchip--active,
+.sfchip--active:hover {
+  background: var(--accent-500);
+  color: var(--accent-fg);
+  border-color: var(--accent-500);
+}
+
+/* ─── Wiki chip (.wchip) — people/tag pills in articles ─── */
+.wchip {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 2px;
+  font-size: 12px;
+  background: var(--wiki-chip-bg);
+  color: var(--wiki-chip-text);
+  border: 1px solid var(--wiki-chip-border);
+  text-decoration: none;
+}
+
+/* ─── Toast ────────────────────────────────────────────────── */
+.wiki-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 40px;
+  z-index: 300;
+  transform: translateX(-50%);
+  border-radius: 8px;
+  background: #1a1a1a;
+  color: #fafafa;
+  padding: 10px 20px;
+  font-family: var(--font-ibm-plex-sans), "IBM Plex Sans", sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.02px;
+  box-shadow: var(--shadow-toast);
+  pointer-events: none;
+}
+
+/* ─── Tooltip ──────────────────────────────────────────────── */
+.wiki-tooltip-positioner {
+  z-index: 400;
+}
+.wiki-tooltip {
+  background: #1a1a1a;
+  color: #fafafa;
+  border-radius: 2px;
+  padding: 4px 8px;
+  font-family: var(--font-ibm-plex-sans), "IBM Plex Sans", sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: 240px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+.wiki-tooltip__arrow {
+  fill: #1a1a1a;
+}
+
+/* ─── Callout/Note (.note) ─────────────────────────────────── */
+.wiki-note {
+  display: flex;
+  gap: 12px;
+  padding: 12px 14px;
+  border-left: 3px solid var(--wiki-link);
+  background: var(--note-bg, #f4f7fd);
+  font-size: 13px;
+  color: var(--wiki-article-text);
+  margin-top: 12px;
+}
+.wiki-note strong { color: #000; }
+.wiki-note--warning {
+  border-left-color: #d97706;
+  background: #fffbeb;
+}
+.wiki-note--danger {
+  border-left-color: #e11d48;
+  background: #fff1f2;
+}
+
+/* ─── Infobox (.winfo) — Wikipedia-style table ─────────────── */
+.winfo {
+  border: 1px solid var(--wiki-nav-border);
+  background: #fff;
+  font-family: "IBM Plex Sans", var(--font-ibm-plex-sans), sans-serif;
+  font-size: 13px;
+  color: var(--wiki-article-text);
+  width: 100%;
+  border-collapse: collapse;
+}
+.winfo__head {
+  font-family: "STIX Two Text", var(--font-stix-two-text), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--wiki-title);
+  padding: 10px 12px;
+  background: var(--accent-100);
+  border-bottom: 1px solid var(--wiki-nav-border);
+  text-align: center;
+  caption-side: top;
+}
+.winfo__image {
+  padding: 10px;
+  background: #f8f9fa;
+  text-align: center;
+  border-bottom: 1px solid var(--wiki-meta-line);
+}
+.winfo__caption {
+  padding: 6px 12px 10px;
+  background: #f8f9fa;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--wiki-count);
+  text-align: center;
+  border-bottom: 1px solid var(--wiki-meta-line);
+}
+.winfo__section {
+  font-family: "IBM Plex Sans", var(--font-ibm-plex-sans), sans-serif;
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--wiki-title);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 8px 12px 6px;
+  background: #f8f9fa;
+  border-top: 1px solid var(--wiki-meta-line);
+  border-bottom: 1px solid var(--wiki-meta-line);
+  text-align: center;
+}
+.winfo__row {
+  display: grid;
+  grid-template-columns: 95px 1fr;
+}
+.winfo__row > .winfo__k,
+.winfo__row > .winfo__v {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--wiki-meta-line);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.winfo__k {
+  background: #f8f9fa;
+  font-weight: 600;
+  color: var(--wiki-title);
+  border-right: 1px solid var(--wiki-meta-line);
+}
+.winfo__v {
+  color: var(--wiki-article-text);
+}
+.winfo__row:last-child > .winfo__k,
+.winfo__row:last-child > .winfo__v {
+  border-bottom: 0;
+}
+
+/* ─── Table of Contents (.wtoc) ────────────────────────────── */
+.wtoc {
+  border: 1px solid var(--wiki-toc-border);
+  background: var(--surface-subtle, #f8f9fa);
+  padding: 10px 14px 12px;
+  font-size: 13px;
+  color: var(--wiki-article-text);
+  min-width: 240px;
+}
+.wtoc__title {
+  font-family: "STIX Two Text", var(--font-stix-two-text), serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wiki-title);
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--wiki-meta-line);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.wtoc__toggle {
+  font-family: "IBM Plex Sans", var(--font-ibm-plex-sans), sans-serif;
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--wiki-count);
+  text-decoration: none;
+  text-transform: lowercase;
+  letter-spacing: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.wtoc__toggle:hover { color: var(--accent-700); }
+.wtoc__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: toc;
+}
+.wtoc__item {
+  counter-increment: toc;
+  padding: 2px 0;
+}
+.wtoc__item::before {
+  content: counters(toc, ".") " ";
+  font-family: "IBM Plex Mono", var(--font-ibm-plex-mono), monospace;
+  font-size: 12px;
+  color: var(--wiki-count);
+  margin-right: 6px;
+}
+.wtoc__link {
+  color: var(--wiki-link);
+  text-decoration: none;
+}
+.wtoc__link:hover { text-decoration: underline; }
+
+/* ─── Citations (.cite) ────────────────────────────────────── */
+sup.cite {
+  font-size: 11px;
+  line-height: 0;
+  vertical-align: super;
+  margin-left: 1px;
+  font-family: "IBM Plex Sans", var(--font-ibm-plex-sans), sans-serif;
+  font-weight: 400;
+}
+sup.cite a {
+  color: var(--wiki-link);
+  text-decoration: none;
+}
+sup.cite a:hover { text-decoration: underline; }
+
+/* ─── Edit link (.wedit) ──────────────────────────────────── */
+.wedit {
+  font-family: "IBM Plex Sans", var(--font-ibm-plex-sans), sans-serif;
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--wiki-count);
+  text-decoration: none;
+  letter-spacing: 0;
+}
+.wedit::before { content: "["; }
+.wedit::after  { content: "]"; }
+.wedit:hover   { color: var(--accent-700); }
+
+/* ─── External link arrow (.ext) ──────────────────────────── */
+a.ext::after {
+  content: "\2197";
+  font-size: 0.85em;
+  margin-left: 2px;
+  display: inline-block;
+  color: var(--wiki-count);
+  text-decoration: none;
+}
+
+/* ─── References list (.wrefs) ─────────────────────────────── */
+.wrefs {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  counter-reset: ref;
+  font-size: 13px;
+  color: var(--wiki-article-text);
+  line-height: 1.55;
+}
+.wrefs li {
+  counter-increment: ref;
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  padding: 4px 0;
+}
+.wrefs li::before {
+  content: counter(ref) ".";
+  font-family: "IBM Plex Mono", var(--font-ibm-plex-mono), monospace;
+  font-size: 12px;
+  color: var(--wiki-count);
+  padding-top: 1px;
+}
+.wrefs__back {
+  color: var(--wiki-link);
+  text-decoration: none;
+  margin-right: 6px;
+  font-family: "IBM Plex Mono", var(--font-ibm-plex-mono), monospace;
+  font-size: 12px;
+}
+.wrefs__back:hover { text-decoration: underline; }
+
+/* ─── See-also (.wsee) ─────────────────────────────────────── */
+.wsee {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  column-count: 2;
+  column-gap: 32px;
+  font-size: 14px;
+}
+.wsee li {
+  padding: 2px 0;
+  break-inside: avoid;
+}
+.wsee a {
+  color: var(--wiki-link);
+  text-decoration: none;
+}
+.wsee a:hover { text-decoration: underline; }
+
+/* ─── Hint (.hint) ─────────────────────────────────────────── */
+.hint {
+  font-family: "IBM Plex Mono", var(--font-ibm-plex-mono), monospace;
+  font-size: 11px;
+  color: var(--wiki-count);
+  margin-top: -8px;
+  margin-bottom: 16px;
+}
+
+/* ─── Dark mode ─────────────────────────────────────────────── */
+[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --heading-color: #e8e8e8;
+  --heading-secondary: #aaaaaa;
+  --section-label: #999999;
+  --subtitle: #888888;
+  --subtitle-soft: rgba(255, 255, 255, 0.6);
+  --input-bg: #2a2a2a;
+  --input-border: #555555;
+  --input-label: #bbbbbb;
+  --input-placeholder: #666666;
+  --helper-text: #999999;
+  --btn-primary-bg: #e8e8e8;
+  --btn-primary-text: #1a1a1a;
+  --btn-disabled-bg: #333333;
+  --btn-disabled-text: #666666;
+  --card-border: rgba(255, 255, 255, 0.1);
+  --card-title: #e8e8e8;
+  --card-desc: #aaaaaa;
+  --body-text: #bbbbbb;
+  --wiki-link: #6699dd;
+  --wiki-link-hover: #88bbff;
+  --wiki-sidebar-text: #aaaaaa;
+  --wiki-nav-border: #444444;
+  --wiki-toc-border: #444444;
+  --wiki-count: #999999;
+  --wiki-chevron: #999999;
+  --wiki-title: #e8e8e8;
+  --wiki-chat-bg: rgba(255, 255, 255, 0.04);
+  --wiki-chat-placeholder: #777777;
+  --wiki-chat-send-bg: rgba(255, 255, 255, 0.08);
+  --wiki-chat-send-icon: #999999;
+  --wiki-header-user: #999999;
+  --wiki-header-icon: #aaaaaa;
+  --wiki-card-border: #444444;
+  --wiki-card-header: #cccccc;
+  --wiki-article-text: #cccccc;
+  --wiki-article-link: #6699dd;
+  --wiki-article-h2: #e0e0e0;
+  --wiki-search-border: #444444;
+  --wiki-search-placeholder: #777777;
+  --wiki-search-icon: #777777;
+  --wiki-search-section-line: #444444;
+  --wiki-search-chip-bg: #2a2a2a;
+  --wiki-search-chip-active-bg: #333333;
+  --wiki-infobox-title: #cccccc;
+  --wiki-infobox-text: rgba(255, 255, 255, 0.7);
+  --wiki-meta-line: #444444;
+  --wiki-featured-link: #6699dd;
+  --wiki-featured-desc: #aaaaaa;
+  --wiki-featured-meta: #888888;
+  --wiki-featured-readmore: #6699dd;
+  --wiki-chip-bg: rgba(121, 134, 203, 0.15);
+  --wiki-chip-border: #5c6bc0;
+  --wiki-chip-text: #9fa8da;
+  --wiki-item-link: #6699dd;
+  --wiki-item-date: rgba(255, 255, 255, 0.4);
+  --wiki-badge-stroke: #999999;
+
+  /* Accent scale */
+  --accent-100: #1a2340;
+  --accent-200: #263366;
+  --accent-300: #5c6bc0;
+  --accent-500: #6699dd;
+  --accent-600: #88bbff;
+  --accent-700: #aaddff;
+  --accent-fg: #1a1a1a;
+
+  /* Surfaces */
+  --surface-subtle: #222222;
+  --surface-dialog-footer: #1e1e1e;
+
+  /* Graph */
+  --graph-edge-base: rgba(160, 165, 170, 0.4);
+  --graph-edge-wikilink: rgba(102, 153, 221, 0.55);
+  --graph-grid: rgba(255, 255, 255, 0.06);
+  --graph-panel-bg: #1e1e1e;
+
+  /* Diff */
+  --diff-added-bg: #1a3a1a;
+  --diff-added-text: #8fdf8f;
+  --diff-removed-bg: #3a1a1a;
+  --diff-removed-text: #f09090;
+
+  /* Shadows */
+  --shadow-dropdown: 0 4px 16px rgba(0, 0, 0, 0.4);
+  --shadow-modal: 0 0 0 1px rgb(255 255 255 / .06), 0 20px 40px -10px rgb(0 0 0 / .5);
+  --shadow-toast: 0 10px 28px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.08);
+
+  /* Code */
+  --code-block-bg: #2a2a2a;
+
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.3 0 0);
+  --input: oklch(0.3 0 0);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.205 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.3 0 0);
+  --sidebar-ring: oklch(0.556 0 0);
 }

--- a/wiki/src/app/layout.tsx
+++ b/wiki/src/app/layout.tsx
@@ -1,22 +1,13 @@
 import type { Metadata } from "next";
-import { Source_Serif_4, Inter, IBM_Plex_Sans, Geist } from "next/font/google";
+import { STIX_Two_Text, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { ThemeProvider } from "@/context/ThemeContext";
 
-const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
-
-const sourceSerif = Source_Serif_4({
-  variable: "--font-source-serif-4",
-  subsets: ["latin"],
-  weight: ["400", "600", "700"],
-  display: "swap",
-});
-
-const inter = Inter({
-  variable: "--font-inter",
+const stixTwoText = STIX_Two_Text({
+  variable: "--font-stix-two-text",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   display: "swap",
@@ -25,7 +16,14 @@ const inter = Inter({
 const ibmPlexSans = IBM_Plex_Sans({
   variable: "--font-ibm-plex-sans",
   subsets: ["latin"],
-  weight: ["400", "500"],
+  weight: ["400", "500", "600"],
+  display: "swap",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  variable: "--font-ibm-plex-mono",
+  subsets: ["latin"],
+  weight: ["400"],
   display: "swap",
 });
 
@@ -44,11 +42,10 @@ export default function RootLayout({
       lang="en"
       className={cn(
         "h-full",
-        sourceSerif.variable,
-        inter.variable,
+        stixTwoText.variable,
         ibmPlexSans.variable,
+        ibmPlexMono.variable,
         "font-sans",
-        geist.variable,
       )}
       suppressHydrationWarning
     >

--- a/wiki/src/app/wiki/explorer/page.tsx
+++ b/wiki/src/app/wiki/explorer/page.tsx
@@ -24,6 +24,7 @@ import {
   getWikiTypeIcon,
 } from "@/components/wiki/WikiTypeBadge";
 import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
 import { Spinner } from "@/components/ui/spinner";
 import {
   useExplorerFilters,
@@ -193,35 +194,20 @@ function ExplorerInner() {
                   const isExplicit = filters.types.includes(type);
 
                   return (
-                    <button
+                    <Chip
                       key={type}
-                      type="button"
+                      icon={<Icon size={12} strokeWidth={1.5} />}
+                      label={meta.label}
+                      active={isActive}
                       onClick={() => toggleType(type)}
-                      className={
-                        isActive
-                          ? "wiki-search-filter-chip wiki-search-filter-chip--active"
-                          : "wiki-search-filter-chip"
-                      }
                     >
-                      <span className="relative flex h-3 w-3 shrink-0 items-center justify-center">
-                        <Icon size={12} strokeWidth={1.5} />
-                      </span>
-                      <span
-                        style={{
-                          ...T.micro,
-                          letterSpacing: "-0.0288px",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {meta.label}
-                      </span>
                       {isExplicit && (
                         <span
                           className="ml-0.5 inline-block h-1.5 w-1.5 rounded-full bg-current"
                           aria-hidden
                         />
                       )}
-                    </button>
+                    </Chip>
                   );
                 })}
               </div>
@@ -243,59 +229,33 @@ function ExplorerInner() {
                   Group
                 </span>
                 <div className="flex flex-wrap items-start" style={{ gap: 8 }}>
-                  <button
-                    type="button"
+                  <Chip
+                    label="All groups"
+                    active={filters.group === null}
                     onClick={() => setFilter("group", null)}
-                    className={
-                      filters.group === null
-                        ? "wiki-search-filter-chip wiki-search-filter-chip--active"
-                        : "wiki-search-filter-chip"
-                    }
-                  >
-                    <span
-                      style={{
-                        ...T.micro,
-                        letterSpacing: "-0.0288px",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      All groups
-                    </span>
-                  </button>
+                  />
                   {groups.map((group) => (
-                    <button
+                    <Chip
                       key={group.id}
-                      type="button"
+                      icon={
+                        <span
+                          className="inline-block h-2.5 w-2.5 rounded-full"
+                          style={{
+                            backgroundColor:
+                              group.color || "var(--wiki-count)",
+                          }}
+                          aria-hidden
+                        />
+                      }
+                      label={group.name}
+                      active={filters.group === group.id}
                       onClick={() =>
                         setFilter(
                           "group",
                           filters.group === group.id ? null : group.id,
                         )
                       }
-                      className={
-                        filters.group === group.id
-                          ? "wiki-search-filter-chip wiki-search-filter-chip--active"
-                          : "wiki-search-filter-chip"
-                      }
-                    >
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-                        style={{
-                          backgroundColor:
-                            group.color || "var(--wiki-count)",
-                        }}
-                        aria-hidden
-                      />
-                      <span
-                        style={{
-                          ...T.micro,
-                          letterSpacing: "-0.0288px",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {group.name}
-                      </span>
-                    </button>
+                    />
                   ))}
                 </div>
               </div>
@@ -323,49 +283,23 @@ function ExplorerInner() {
                     { value: "alpha", label: "A-Z" },
                   ] as const
                 ).map(({ value, label }) => (
-                  <button
+                  <Chip
                     key={value}
-                    type="button"
+                    label={label}
+                    active={filters.sort === value}
                     onClick={() => setFilter("sort", value)}
-                    className={
-                      filters.sort === value
-                        ? "wiki-search-filter-chip wiki-search-filter-chip--active"
-                        : "wiki-search-filter-chip"
-                    }
-                  >
-                    <span
-                      style={{
-                        ...T.micro,
-                        letterSpacing: "-0.0288px",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {label}
-                    </span>
-                  </button>
+                  />
                 ))}
               </div>
             </div>
 
             {/* Clear filters */}
             {hasActiveFilters && (
-              <button
-                type="button"
+              <Chip
+                icon={<X size={12} strokeWidth={1.5} />}
+                label="Clear filters"
                 onClick={clearFilters}
-                className="wiki-search-filter-chip"
-                style={{ gap: 6 }}
-              >
-                <X size={12} strokeWidth={1.5} />
-                <span
-                  style={{
-                    ...T.micro,
-                    letterSpacing: "-0.0288px",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  Clear filters
-                </span>
-              </button>
+              />
             )}
           </div>
         )}

--- a/wiki/src/app/wiki/fragments/[id]/page.tsx
+++ b/wiki/src/app/wiki/fragments/[id]/page.tsx
@@ -57,19 +57,19 @@ function FragmentInfobox({ fragment }: { fragment: FragmentData }) {
         alignSelf: "flex-start",
       }}
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={label}>Type</p>
         <p style={body}>{fragment.type}</p>
       </div>
 
       {fragment.tags.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <p style={label}>Tags</p>
           <p style={body}>{fragment.tags.join(", ")}</p>
         </div>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={label}>Created</p>
         <p style={body}>{formatDate(fragment.createdAt)}</p>
       </div>

--- a/wiki/src/app/wiki/people/[id]/page.tsx
+++ b/wiki/src/app/wiki/people/[id]/page.tsx
@@ -96,13 +96,13 @@ function PeopleInfobox({
       </button>
 
       {person.relationship && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <p style={label}>Relationship</p>
           <p style={{ ...body, margin: 0 }}>{person.relationship}</p>
         </div>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={label}>Last Updated</p>
         <p
           style={{

--- a/wiki/src/components/graph/GraphCanvas.tsx
+++ b/wiki/src/components/graph/GraphCanvas.tsx
@@ -22,40 +22,102 @@ type GraphCanvasProps = {
   currentDepth: number;
 };
 
-// Edge / chrome palette
-const EDGE_BASE = "rgba(114, 119, 125, 0.5)";
-const EDGE_WIKILINK = "rgba(51, 102, 204, 0.55)";
-const EDGE_HOVER = "#3366cc";
-const LABEL_COLOR = "#202122";
-const LABEL_COLOR_HOVER = "#000000";
-const SELECTED_STROKE = "#202122";
-const HOVER_STROKE = "#555555";
-const GRID_COLOR = "rgba(162, 169, 177, 0.18)";
-const TOOLTIP_BG = "#ffffff";
-const TOOLTIP_BORDER = "#a2a9b1";
-
-const PERSON_COLOR = "#854d0e";
-const WIKI_FALLBACK = "#475569";
-const FRAGMENT_FALLBACK = "#0284c7";
-
-const SUBTYPE_COLOR: Record<string, string> = {
-  Log: "#475569",
-  Research: "#7c3aed",
-  Belief: "#2563eb",
-  Decision: "#ea580c",
-  Project: "#0891b2",
-  Objective: "#d97706",
-  Skill: "#059669",
-  Agent: "#c026d3",
-  Voice: "#db2777",
-  Principles: "#e11d48",
-  Fact: "#0284c7",
-  Question: "#9333ea",
-  Idea: "#ca8a04",
-  Action: "#16a34a",
-  Quote: "#4f46e5",
-  Reference: "#0d9488",
+// Resolved at mount from CSS custom properties (see useGraphColors below).
+// Fallbacks match the light-mode defaults from globals.css.
+type GraphColors = {
+  edgeBase: string;
+  edgeWikilink: string;
+  edgeHover: string;
+  labelColor: string;
+  labelColorHover: string;
+  selectedStroke: string;
+  hoverStroke: string;
+  gridColor: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+  panelBg: string;
+  personColor: string;
+  wikiFallback: string;
+  fragmentFallback: string;
+  subtypeColors: Record<string, string>;
 };
+
+function readGraphColors(): GraphColors {
+  if (typeof document === "undefined") return defaultGraphColors();
+  const s = getComputedStyle(document.documentElement);
+  const v = (name: string, fb: string) => s.getPropertyValue(name).trim() || fb;
+  return {
+    edgeBase: v("--graph-edge-base", "rgba(114, 119, 125, 0.5)"),
+    edgeWikilink: v("--graph-edge-wikilink", "rgba(51, 102, 204, 0.55)"),
+    edgeHover: v("--wiki-link", "#3366cc"),
+    labelColor: v("--wiki-title", "#202122"),
+    labelColorHover: v("--heading-color", "#000000"),
+    selectedStroke: v("--wiki-title", "#202122"),
+    hoverStroke: v("--wiki-sidebar-text", "#555555"),
+    gridColor: v("--graph-grid", "rgba(162, 169, 177, 0.18)"),
+    tooltipBg: v("--graph-panel-bg", "#ffffff"),
+    tooltipBorder: v("--wiki-nav-border", "#a2a9b1"),
+    panelBg: v("--graph-panel-bg", "#ffffff"),
+    personColor: v("--wiki-type-people-text", "#854d0e"),
+    wikiFallback: v("--wiki-type-log-text", "#475569"),
+    fragmentFallback: v("--fragment-type-fact-text", "#0284c7"),
+    subtypeColors: {
+      Log: v("--wiki-type-log-text", "#475569"),
+      Research: v("--wiki-type-research-text", "#7c3aed"),
+      Belief: v("--wiki-type-belief-text", "#2563eb"),
+      Decision: v("--wiki-type-decision-text", "#ea580c"),
+      Project: v("--wiki-type-project-text", "#0891b2"),
+      Objective: v("--wiki-type-objective-text", "#d97706"),
+      Skill: v("--wiki-type-skill-text", "#059669"),
+      Agent: v("--wiki-type-agent-text", "#c026d3"),
+      Voice: v("--wiki-type-voice-text", "#db2777"),
+      Principles: v("--wiki-type-principles-text", "#e11d48"),
+      Fact: v("--fragment-type-fact-text", "#0284c7"),
+      Question: v("--fragment-type-question-text", "#9333ea"),
+      Idea: v("--fragment-type-idea-text", "#ca8a04"),
+      Action: v("--fragment-type-action-text", "#16a34a"),
+      Quote: v("--fragment-type-quote-text", "#4f46e5"),
+      Reference: v("--fragment-type-reference-text", "#0d9488"),
+    },
+  };
+}
+
+function defaultGraphColors(): GraphColors {
+  return {
+    edgeBase: "rgba(114, 119, 125, 0.5)",
+    edgeWikilink: "rgba(51, 102, 204, 0.55)",
+    edgeHover: "#3366cc",
+    labelColor: "#202122",
+    labelColorHover: "#000000",
+    selectedStroke: "#202122",
+    hoverStroke: "#555555",
+    gridColor: "rgba(162, 169, 177, 0.18)",
+    tooltipBg: "#ffffff",
+    tooltipBorder: "#a2a9b1",
+    panelBg: "#ffffff",
+    personColor: "#854d0e",
+    wikiFallback: "#475569",
+    fragmentFallback: "#0284c7",
+    subtypeColors: {
+      Log: "#475569",
+      Research: "#7c3aed",
+      Belief: "#2563eb",
+      Decision: "#ea580c",
+      Project: "#0891b2",
+      Objective: "#d97706",
+      Skill: "#059669",
+      Agent: "#c026d3",
+      Voice: "#db2777",
+      Principles: "#e11d48",
+      Fact: "#0284c7",
+      Question: "#9333ea",
+      Idea: "#ca8a04",
+      Action: "#16a34a",
+      Quote: "#4f46e5",
+      Reference: "#0d9488",
+    },
+  };
+}
 
 // Physics constants
 const SPRING_LENGTH = 120;
@@ -74,10 +136,10 @@ const HOP_REVEAL_DURATION = 300; // ms per hop level
 // Hop-level opacity
 const HOP_OPACITY = [1, 1, 0.7, 0.45] as const;
 
-function nodeColor(n: GraphNode): string {
-  if (n.type === "person") return PERSON_COLOR;
-  if (n.subtype && SUBTYPE_COLOR[n.subtype]) return SUBTYPE_COLOR[n.subtype];
-  return n.type === "fragment" ? FRAGMENT_FALLBACK : WIKI_FALLBACK;
+function nodeColor(n: GraphNode, colors: GraphColors): string {
+  if (n.type === "person") return colors.personColor;
+  if (n.subtype && colors.subtypeColors[n.subtype]) return colors.subtypeColors[n.subtype];
+  return n.type === "fragment" ? colors.fragmentFallback : colors.wikiFallback;
 }
 
 export default function GraphCanvas({
@@ -98,6 +160,7 @@ export default function GraphCanvas({
   const hoveredRef = useRef<string | null>(null);
   const timeRef = useRef(0);
   const activeTypesRef = useRef(activeTypes);
+  const colorsRef = useRef<GraphColors>(defaultGraphColors());
   const dragRef = useRef<{
     nodeId: string | null;
     isPanning: boolean;
@@ -159,6 +222,11 @@ export default function GraphCanvas({
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [dims, setDims] = useState({ width: 0, height: 0 });
+
+  // Read CSS custom properties once at mount
+  useEffect(() => {
+    colorsRef.current = readGraphColors();
+  }, []);
 
   useEffect(() => {
     activeTypesRef.current = activeTypes;
@@ -414,10 +482,11 @@ export default function GraphCanvas({
       }
 
       // Render
+      const gc = colorsRef.current;
       ctx.save();
       ctx.clearRect(0, 0, dims.width, dims.height);
 
-      ctx.fillStyle = "#ffffff";
+      ctx.fillStyle = gc.panelBg;
       ctx.fillRect(0, 0, dims.width, dims.height);
 
       // Subtle grid
@@ -426,7 +495,7 @@ export default function GraphCanvas({
       const gridSize = 40 * zoom;
       const ox = ((pan.x % gridSize) + gridSize) % gridSize;
       const oy = ((pan.y % gridSize) + gridSize) % gridSize;
-      ctx.strokeStyle = GRID_COLOR;
+      ctx.strokeStyle = gc.gridColor;
       ctx.lineWidth = 0.5;
       for (let x = ox; x < dims.width; x += gridSize) {
         ctx.beginPath();
@@ -485,15 +554,15 @@ export default function GraphCanvas({
         } else if (connectedHover) {
           const pulse = Math.sin(t * 3) * 0.15 + 0.85;
           ctx.globalAlpha = egoAlpha;
-          ctx.strokeStyle = EDGE_HOVER;
+          ctx.strokeStyle = gc.edgeHover;
           ctx.lineWidth = 1.75 * pulse;
         } else if (e.edgeType === "wikilink") {
           ctx.globalAlpha = egoAlpha;
-          ctx.strokeStyle = EDGE_WIKILINK;
+          ctx.strokeStyle = gc.edgeWikilink;
           ctx.lineWidth = 1.25;
         } else {
           ctx.globalAlpha = egoAlpha;
-          ctx.strokeStyle = EDGE_BASE;
+          ctx.strokeStyle = gc.edgeBase;
           ctx.lineWidth = 1;
         }
         ctx.stroke();
@@ -520,7 +589,7 @@ export default function GraphCanvas({
         const isHovered = hoveredRef.current === n.id;
         const isSelected = selectedId === n.id;
         const isFocusNode = egoActive && n.id === focusId;
-        const color = nodeColor(n);
+        const color = nodeColor(n, gc);
         const size = n.size * (isHovered ? 1.15 : 1);
 
         // Compute combined alpha
@@ -547,7 +616,7 @@ export default function GraphCanvas({
         ctx.fill();
 
         if (isSelected || isHovered) {
-          ctx.strokeStyle = isSelected ? SELECTED_STROKE : HOVER_STROKE;
+          ctx.strokeStyle = isSelected ? gc.selectedStroke : gc.hoverStroke;
           ctx.lineWidth = isSelected ? 2.5 : 1.5;
           ctx.stroke();
         }
@@ -555,7 +624,7 @@ export default function GraphCanvas({
         // Ego-center ring
         if (isFocusNode) {
           ctx.globalAlpha = 0.8;
-          ctx.strokeStyle = SELECTED_STROKE;
+          ctx.strokeStyle = gc.selectedStroke;
           ctx.lineWidth = 2;
           ctx.beginPath();
           ctx.arc(n.x, n.y, size + 4, 0, Math.PI * 2);
@@ -572,7 +641,7 @@ export default function GraphCanvas({
             if (labelAlpha > 0) {
               ctx.globalAlpha = labelAlpha;
               ctx.font = `500 ${isHovered ? 12 : 11}px Inter, system-ui, sans-serif`;
-              ctx.fillStyle = isHovered ? LABEL_COLOR_HOVER : LABEL_COLOR;
+              ctx.fillStyle = isHovered ? gc.labelColorHover : gc.labelColor;
               ctx.textAlign = "center";
               ctx.textBaseline = "top";
               ctx.fillText(n.label, n.x, n.y + size + 6);
@@ -582,7 +651,7 @@ export default function GraphCanvas({
           // Full-graph mode: show all wiki + person labels
           if ((n.type === "wiki" || n.type === "person") && !dimmed) {
             ctx.font = `500 ${isHovered ? 12 : 11}px Inter, system-ui, sans-serif`;
-            ctx.fillStyle = isHovered ? LABEL_COLOR_HOVER : LABEL_COLOR;
+            ctx.fillStyle = isHovered ? gc.labelColorHover : gc.labelColor;
             ctx.textAlign = "center";
             ctx.textBaseline = "top";
             ctx.fillText(n.label, n.x, n.y + size + 6);
@@ -597,14 +666,14 @@ export default function GraphCanvas({
           const th = 22;
           const tx = n.x - tw / 2;
           const ty = n.y - size - th - 6;
-          ctx.fillStyle = TOOLTIP_BG;
-          ctx.strokeStyle = TOOLTIP_BORDER;
+          ctx.fillStyle = gc.tooltipBg;
+          ctx.strokeStyle = gc.tooltipBorder;
           ctx.lineWidth = 1;
           ctx.beginPath();
           ctx.roundRect(tx, ty, tw, th, 4);
           ctx.fill();
           ctx.stroke();
-          ctx.fillStyle = LABEL_COLOR;
+          ctx.fillStyle = gc.labelColor;
           ctx.textAlign = "center";
           ctx.textBaseline = "middle";
           ctx.fillText(n.label, n.x, ty + th / 2);

--- a/wiki/src/components/graph/GraphDepthSlider.tsx
+++ b/wiki/src/components/graph/GraphDepthSlider.tsx
@@ -18,7 +18,7 @@ export function GraphDepthSlider({ depth, onDepthChange, hasFocus }: GraphDepthS
         bottom: 16,
         left: "50%",
         transform: "translateX(-50%)",
-        background: "#ffffff",
+        background: "var(--graph-panel-bg)",
         border: "1px solid var(--wiki-card-border)",
         padding: "8px 14px",
         display: "flex",

--- a/wiki/src/components/graph/GraphDetailPanel.tsx
+++ b/wiki/src/components/graph/GraphDetailPanel.tsx
@@ -12,34 +12,53 @@ const TYPE_LABEL: Record<GraphNodeType, string> = {
 };
 
 const TYPE_BADGE_BG: Record<GraphNodeType, string> = {
-  wiki: "#eef2ff",
-  fragment: "#ecfeff",
-  person: "#fef3c7",
+  wiki: "var(--wiki-type-log-bg)",
+  fragment: "var(--fragment-type-fact-bg)",
+  person: "var(--wiki-type-people-bg)",
 };
 
 const TYPE_BADGE_COLOR: Record<GraphNodeType, string> = {
-  wiki: "#475569",
-  fragment: "#0284c7",
-  person: "#854d0e",
+  wiki: "var(--wiki-type-log-text)",
+  fragment: "var(--fragment-type-fact-text)",
+  person: "var(--wiki-type-people-text)",
 };
 
 const SUBTYPE_COLOR: Record<string, string> = {
-  Log: "#475569",
-  Research: "#7c3aed",
-  Belief: "#2563eb",
-  Decision: "#ea580c",
-  Project: "#0891b2",
-  Objective: "#d97706",
-  Skill: "#059669",
-  Agent: "#c026d3",
-  Voice: "#db2777",
-  Principles: "#e11d48",
-  Fact: "#0284c7",
-  Question: "#9333ea",
-  Idea: "#ca8a04",
-  Action: "#16a34a",
-  Quote: "#4f46e5",
-  Reference: "#0d9488",
+  Log: "var(--wiki-type-log-text)",
+  Research: "var(--wiki-type-research-text)",
+  Belief: "var(--wiki-type-belief-text)",
+  Decision: "var(--wiki-type-decision-text)",
+  Project: "var(--wiki-type-project-text)",
+  Objective: "var(--wiki-type-objective-text)",
+  Skill: "var(--wiki-type-skill-text)",
+  Agent: "var(--wiki-type-agent-text)",
+  Voice: "var(--wiki-type-voice-text)",
+  Principles: "var(--wiki-type-principles-text)",
+  Fact: "var(--fragment-type-fact-text)",
+  Question: "var(--fragment-type-question-text)",
+  Idea: "var(--fragment-type-idea-text)",
+  Action: "var(--fragment-type-action-text)",
+  Quote: "var(--fragment-type-quote-text)",
+  Reference: "var(--fragment-type-reference-text)",
+};
+
+const SUBTYPE_BG: Record<string, string> = {
+  Log: "var(--wiki-type-log-bg)",
+  Research: "var(--wiki-type-research-bg)",
+  Belief: "var(--wiki-type-belief-bg)",
+  Decision: "var(--wiki-type-decision-bg)",
+  Project: "var(--wiki-type-project-bg)",
+  Objective: "var(--wiki-type-objective-bg)",
+  Skill: "var(--wiki-type-skill-bg)",
+  Agent: "var(--wiki-type-agent-bg)",
+  Voice: "var(--wiki-type-voice-bg)",
+  Principles: "var(--wiki-type-principles-bg)",
+  Fact: "var(--fragment-type-fact-bg)",
+  Question: "var(--fragment-type-question-bg)",
+  Idea: "var(--fragment-type-idea-bg)",
+  Action: "var(--fragment-type-action-bg)",
+  Quote: "var(--fragment-type-quote-bg)",
+  Reference: "var(--fragment-type-reference-bg)",
 };
 
 type GraphDetailPanelProps = {
@@ -66,7 +85,7 @@ export function GraphDetailPanel({
     right: 0,
     height: "100%",
     width: 240,
-    background: "#ffffff",
+    background: "var(--graph-panel-bg)",
     borderLeft: "1px solid var(--wiki-card-border)",
     padding: 12,
     overflowY: "auto",
@@ -109,7 +128,7 @@ export function GraphDetailPanel({
                   justifyContent: "space-between",
                   alignItems: "center",
                   padding: "6px 8px",
-                  background: active ? "var(--wiki-search-chip-bg)" : "#fafafa",
+                  background: active ? "var(--wiki-search-chip-bg)" : "var(--surface-dialog-footer)",
                   border: "1px solid var(--wiki-card-border)",
                   cursor: "pointer",
                   textAlign: "left",
@@ -242,8 +261,8 @@ export function GraphDetailPanel({
               fontWeight: 500,
               padding: "2px 8px",
               borderRadius: 10,
-              background: `${SUBTYPE_COLOR[selectedNode.subtype] ?? "#666"}18`,
-              color: SUBTYPE_COLOR[selectedNode.subtype] ?? "#666",
+              background: SUBTYPE_BG[selectedNode.subtype] ?? "var(--surface-subtle)",
+              color: SUBTYPE_COLOR[selectedNode.subtype] ?? "var(--wiki-sidebar-text)",
             }}
           >
             {selectedNode.subtype}
@@ -305,7 +324,7 @@ export function GraphDetailPanel({
                     fontWeight: 500,
                     padding: "2px 8px",
                     borderRadius: 10,
-                    background: "#f4f4f4",
+                    background: "var(--surface-subtle)",
                     color: "var(--wiki-sidebar-text)",
                   }}
                 >
@@ -325,7 +344,7 @@ export function GraphDetailPanel({
           width: "100%",
           padding: "8px 12px",
           background: "var(--wiki-title)",
-          color: "#ffffff",
+          color: "var(--accent-fg)",
           border: "none",
           cursor: "pointer",
           ...T.buttonSmall,

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { T } from "@/lib/typography";
 import { Button } from "@/components/ui/button";
 import { ActionButton } from "@/components/ui/action-button";
+import { Toast } from "@/components/ui/toast";
 import {
   Dialog,
   DialogContent,
@@ -441,8 +442,8 @@ export default function AddWikiModal({
                   ? `Customized ${typeLabel} Prompt`
                   : `Default ${typeLabel} Prompt`;
               const badgeColors = wikiPromptEdited
-                ? { fg: "#3366cc", bg: "rgba(51, 102, 204, 0.10)", bd: "#3366cc" }
-                : { fg: "#545353", bg: "#f5f5f5", bd: "#e5e5e5" };
+                ? { fg: "var(--wiki-link)", bg: "rgba(51, 102, 204, 0.10)", bd: "var(--wiki-link)" }
+                : { fg: "var(--input-label)", bg: "var(--surface-subtle)", bd: "var(--btn-disabled-bg)" };
               return (
                 <div
                   className="flex h-10 w-full items-center justify-between rounded-lg border border-input bg-transparent px-2.5"
@@ -501,7 +502,7 @@ export default function AddWikiModal({
               type="button"
               onClick={handleConfirm}
               disabled={submitting}
-              className="rounded-none bg-[#3366cc] text-white hover:bg-[#2a56b0]"
+              className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
             >
               {locked
                 ? confirmLabel
@@ -580,25 +581,11 @@ export default function AddWikiModal({
         </DialogContent>
       </Dialog>
 
-      {/* Saved toast (kept as a simple fixed banner) */}
-      {!open && showSavedToast ? (
-        <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className="fixed left-1/2 bottom-10 z-[300] -translate-x-1/2 rounded-lg bg-[#1a1a1a] px-5 py-2.5 text-[#fafafa]"
-          style={{
-            ...T.button,
-            fontWeight: 500,
-            letterSpacing: "-0.02px",
-            boxShadow:
-              "0 10px 28px rgba(0,0,0,0.35), 0 0 0 1px rgba(255,255,255,0.06)",
-            pointerEvents: "none",
-          }}
-        >
-          {toastMessage}
-        </div>
-      ) : null}
+      <Toast
+        message={toastMessage}
+        visible={!open && showSavedToast}
+        onDismiss={() => setShowSavedToast(false)}
+      />
     </>
   );
 }

--- a/wiki/src/components/layout/Header.tsx
+++ b/wiki/src/components/layout/Header.tsx
@@ -31,7 +31,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
           onClick={onMenuToggle}
           className="flex cursor-pointer items-center justify-center"
           style={{
-            padding: "5px 13px",
+            padding: "4px 12px",
             height: 32,
             borderRadius: 2,
             background: "none",
@@ -189,7 +189,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
                 border: "1px solid var(--card-border)",
                 borderRadius: 6,
                 padding: "4px 0",
-                boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
+                boxShadow: "var(--shadow-dropdown)",
               }}
             >
               <button

--- a/wiki/src/components/layout/Sidebar.tsx
+++ b/wiki/src/components/layout/Sidebar.tsx
@@ -150,8 +150,8 @@ function SidebarSection({
   return (
     <div
       style={{
-        paddingLeft: 22,
-        paddingRight: 14,
+        paddingLeft: 24,
+        paddingRight: 16,
         paddingTop: 16,
         paddingBottom: 24,
       }}

--- a/wiki/src/components/ui/action-button.tsx
+++ b/wiki/src/components/ui/action-button.tsx
@@ -26,7 +26,7 @@ export interface ActionButtonProps extends BaseButtonProps {
 }
 
 const brandClasses =
-  "rounded-none bg-[#3366cc] text-white hover:bg-[#2a56b0] disabled:bg-[var(--btn-disabled-bg)] disabled:text-[var(--btn-disabled-text)]";
+  "rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)] disabled:bg-[var(--btn-disabled-bg)] disabled:text-[var(--btn-disabled-text)]";
 
 export function ActionButton({
   loading = false,

--- a/wiki/src/components/ui/card.tsx
+++ b/wiki/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground shadow-[0_0_0_1px_rgb(0_0_0/0.10)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}

--- a/wiki/src/components/ui/chip.tsx
+++ b/wiki/src/components/ui/chip.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface ChipProps {
+  label: string
+  icon?: ReactNode
+  active?: boolean
+  onClick?: () => void
+  className?: string
+  /** Extra content after the label (e.g. an active-indicator dot) */
+  children?: ReactNode
+}
+
+function Chip({ label, icon, active, onClick, className, children }: ChipProps) {
+  return (
+    <button
+      type="button"
+      data-slot="chip"
+      data-active={active || undefined}
+      onClick={onClick}
+      className={cn("sfchip", active && "sfchip--active", className)}
+    >
+      {icon ? (
+        <span className="flex h-3 w-3 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+      ) : null}
+      <span className="sfchip__label">{label}</span>
+      {children}
+    </button>
+  )
+}
+
+export { Chip, type ChipProps }

--- a/wiki/src/components/ui/dialog.tsx
+++ b/wiki/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground shadow-[0_0_0_1px_rgb(0_0_0/0.10),0_20px_40px_-10px_rgb(0_0_0/0.25)] duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -102,7 +102,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-[#fafafa] p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/wiki/src/components/ui/toast.tsx
+++ b/wiki/src/components/ui/toast.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { cn } from "@/lib/utils"
+
+interface ToastProps {
+  message: string
+  visible: boolean
+  onDismiss?: () => void
+  /** Auto-dismiss duration in ms (default 2000) */
+  duration?: number
+  className?: string
+}
+
+function Toast({ message, visible, onDismiss, duration = 2000, className }: ToastProps) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!visible) return
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      onDismiss?.()
+      timerRef.current = null
+    }, duration)
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [visible, duration, onDismiss])
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-slot="toast"
+      className={cn("wiki-toast", className)}
+    >
+      {message}
+    </div>
+  )
+}
+
+export { Toast, type ToastProps }

--- a/wiki/src/components/ui/tooltip.tsx
+++ b/wiki/src/components/ui/tooltip.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Tooltip as TooltipRoot } from "@base-ui/react/tooltip"
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipRoot.Provider
+const TooltipTrigger = TooltipRoot.Trigger
+const TooltipPortal = TooltipRoot.Portal
+
+function TooltipPositioner({
+  className,
+  ...props
+}: React.ComponentProps<typeof TooltipRoot.Positioner>) {
+  return (
+    <TooltipRoot.Positioner
+      data-slot="tooltip-positioner"
+      className={cn("wiki-tooltip-positioner", className)}
+      {...props}
+    />
+  )
+}
+
+function TooltipPopup({
+  className,
+  ...props
+}: React.ComponentProps<typeof TooltipRoot.Popup>) {
+  return (
+    <TooltipRoot.Popup
+      data-slot="tooltip-popup"
+      className={cn("wiki-tooltip", className)}
+      {...props}
+    />
+  )
+}
+
+function TooltipArrow({
+  className,
+  ...props
+}: React.ComponentProps<typeof TooltipRoot.Arrow>) {
+  return (
+    <TooltipRoot.Arrow
+      data-slot="tooltip-arrow"
+      className={cn("wiki-tooltip__arrow", className)}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  children,
+  content,
+  delayDuration = 400,
+}: {
+  children: React.ReactNode
+  content: React.ReactNode
+  delayDuration?: number
+}) {
+  return (
+    <TooltipProvider delay={delayDuration}>
+      <TooltipRoot.Root>
+        <TooltipTrigger render={(props) => <span {...props}>{children}</span>} />
+        <TooltipPortal>
+          <TooltipPositioner sideOffset={6}>
+            <TooltipPopup>
+              <TooltipArrow />
+              {content}
+            </TooltipPopup>
+          </TooltipPositioner>
+        </TooltipPortal>
+      </TooltipRoot.Root>
+    </TooltipProvider>
+  )
+}
+
+export {
+  Tooltip,
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipPortal,
+  TooltipPositioner,
+  TooltipPopup,
+  TooltipArrow,
+}

--- a/wiki/src/components/wiki/BrowseByType.tsx
+++ b/wiki/src/components/wiki/BrowseByType.tsx
@@ -222,7 +222,7 @@ export default function BrowseByType() {
     <div
       style={{
         border: "1px solid var(--wiki-card-border)",
-        backgroundColor: "rgba(238, 238, 238, 1)",
+        backgroundColor: "var(--surface-subtle)",
         width: "100%",
       }}
     >

--- a/wiki/src/components/wiki/EntryArticle.tsx
+++ b/wiki/src/components/wiki/EntryArticle.tsx
@@ -21,7 +21,7 @@ function EyeOpenIcon() {
     <svg width={17} height={13} viewBox="0 0 17 13" fill="none" aria-hidden>
       <path
         d="M8.5 0.25C4.636 0.25 1.34 2.66 0 6.25C1.34 9.84 4.636 12.25 8.5 12.25C12.364 12.25 15.66 9.84 17 6.25C15.66 2.66 12.364 0.25 8.5 0.25ZM8.5 10.25C6.291 10.25 4.5 8.459 4.5 6.25C4.5 4.041 6.291 2.25 8.5 2.25C10.709 2.25 12.5 4.041 12.5 6.25C12.5 8.459 10.709 10.25 8.5 10.25ZM8.5 4.25C7.395 4.25 6.5 5.145 6.5 6.25C6.5 7.355 7.395 8.25 8.5 8.25C9.605 8.25 10.5 7.355 10.5 6.25C10.5 5.145 9.605 4.25 8.5 4.25Z"
-        fill="rgba(0, 0, 0, 1)"
+        fill="var(--foreground)"
       />
     </svg>
   );
@@ -32,7 +32,7 @@ function EyeClosedIcon() {
     <svg width={17} height={15} viewBox="0 0 17 15" fill="none" aria-hidden>
       <path
         d="M8.5 2.5C10.709 2.5 12.5 4.291 12.5 6.5C12.5 7.02 12.39 7.51 12.21 7.97L14.54 10.3C15.77 9.29 16.73 7.99 17 6.5C15.66 2.91 12.364 0.5 8.5 0.5C7.474 0.5 6.49 0.68 5.57 0.99L7.28 2.7C7.74 2.52 8.22 2.5 8.5 2.5ZM0.94 1.37L2.69 3.12L3.08 3.51C1.73 4.55 0.68 5.93 0 6.5C1.34 10.09 4.636 12.5 8.5 12.5C9.63 12.5 10.71 12.28 11.71 11.89L12.08 12.26L14.38 14.56L15.33 13.61L1.89 0.42L0.94 1.37ZM5.18 5.61L6.32 6.75C6.29 6.83 6.27 6.92 6.27 7C6.27 8.105 7.165 9 8.27 9C8.35 9 8.44 8.98 8.52 8.95L9.66 10.09C9.24 10.3 8.78 10.43 8.27 10.43C6.061 10.43 4.27 8.639 4.27 6.43C4.27 5.92 4.4 5.46 4.61 5.04L5.18 5.61ZM8.36 4.08L10.69 6.41L10.71 6.27C10.71 5.165 9.815 4.27 8.71 4.27L8.36 4.08Z"
-        fill="rgba(0, 0, 0, 1)"
+        fill="var(--foreground)"
       />
     </svg>
   );
@@ -83,7 +83,7 @@ export function EntryInfobox({ type, source, createdAt }: EntryInfoboxProps) {
       {rows.map((row) => (
         <div
           key={row.label}
-          style={{ display: "flex", flexDirection: "column", gap: 7 }}
+          style={{ display: "flex", flexDirection: "column", gap: 8 }}
         >
           <p style={infoboxLabel}>{row.label}</p>
           <p style={{ ...infoboxBodyMuted, margin: 0, whiteSpace: "normal" }}>
@@ -151,14 +151,14 @@ export function EntryArticle({
           maxWidth: 864,
           display: "flex",
           flexDirection: "column",
-          gap: 56,
+          gap: 48,
         }}
       >
         <div
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: 22,
+            gap: 24,
             width: "100%",
           }}
         >
@@ -205,7 +205,7 @@ export function EntryArticle({
                     autoFocus
                     style={{
                       margin: 0,
-                      paddingBottom: 7,
+                      paddingBottom: 8,
                       ...T.h1,
                       fontFamily: FONT.SERIF,
                       color: "var(--wiki-title)",
@@ -221,7 +221,7 @@ export function EntryArticle({
                     className="wiki-article-h1"
                     style={{
                       margin: 0,
-                      paddingBottom: 7,
+                      paddingBottom: 8,
                       ...T.h1,
                       fontFamily: FONT.SERIF,
                       color: "var(--wiki-title)",
@@ -241,7 +241,7 @@ export function EntryArticle({
                   style={{
                     display: "flex",
                     alignItems: "flex-end",
-                    gap: 13,
+                    gap: 12,
                     flexShrink: 0,
                   }}
                 >
@@ -260,7 +260,7 @@ export function EntryArticle({
                           ...T.bodySmall,
                           fontFamily: FONT.SANS,
                           lineHeight: "20px",
-                          paddingBottom: 7,
+                          paddingBottom: 8,
                           whiteSpace: "nowrap",
                         }}
                       >
@@ -279,7 +279,7 @@ export function EntryArticle({
                           ...T.bodySmall,
                           fontFamily: FONT.SANS,
                           lineHeight: "20px",
-                          paddingBottom: 7,
+                          paddingBottom: 8,
                           whiteSpace: "nowrap",
                         }}
                       >
@@ -310,7 +310,7 @@ export function EntryArticle({
                             ...T.bodySmall,
                             fontFamily: FONT.SANS,
                             lineHeight: "20px",
-                            paddingBottom: 7,
+                            paddingBottom: 8,
                             whiteSpace: "nowrap",
                           }}
                         >

--- a/wiki/src/components/wiki/FeaturedArticle.tsx
+++ b/wiki/src/components/wiki/FeaturedArticle.tsx
@@ -46,7 +46,7 @@ export default function FeaturedArticle() {
       <div
         style={{
           borderBottom: "1px solid var(--wiki-card-border)",
-          backgroundColor: "#eeeeee",
+          backgroundColor: "var(--surface-subtle)",
           padding: "10px 16px",
         }}
       >

--- a/wiki/src/components/wiki/MarkdownContent.tsx
+++ b/wiki/src/components/wiki/MarkdownContent.tsx
@@ -160,7 +160,7 @@ const components: Components = {
   pre: ({ children }) => (
     <pre
       style={{
-        backgroundColor: "#f6f8fa",
+        backgroundColor: "var(--code-block-bg)",
         border: "1px solid var(--wiki-card-border)",
         borderRadius: 4,
         padding: 12,

--- a/wiki/src/components/wiki/WikiChip.tsx
+++ b/wiki/src/components/wiki/WikiChip.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils"
+
+interface WikiChipProps {
+  label: string
+  href?: string
+  className?: string
+}
+
+function WikiChip({ label, href, className }: WikiChipProps) {
+  const classes = cn("wchip", className)
+
+  if (href) {
+    return (
+      <a data-slot="wiki-chip" href={href} className={classes}>
+        {label}
+      </a>
+    )
+  }
+
+  return (
+    <span data-slot="wiki-chip" className={classes}>
+      {label}
+    </span>
+  )
+}
+
+export { WikiChip, type WikiChipProps }

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -39,7 +39,7 @@ function EyeOpenIcon() {
     <svg width={17} height={13} viewBox="0 0 17 13" fill="none" aria-hidden>
       <path
         d="M8.5 0.25C4.636 0.25 1.34 2.66 0 6.25C1.34 9.84 4.636 12.25 8.5 12.25C12.364 12.25 15.66 9.84 17 6.25C15.66 2.66 12.364 0.25 8.5 0.25ZM8.5 10.25C6.291 10.25 4.5 8.459 4.5 6.25C4.5 4.041 6.291 2.25 8.5 2.25C10.709 2.25 12.5 4.041 12.5 6.25C12.5 8.459 10.709 10.25 8.5 10.25ZM8.5 4.25C7.395 4.25 6.5 5.145 6.5 6.25C6.5 7.355 7.395 8.25 8.5 8.25C9.605 8.25 10.5 7.355 10.5 6.25C10.5 5.145 9.605 4.25 8.5 4.25Z"
-        fill="rgba(0, 0, 0, 1)"
+        fill="var(--foreground)"
       />
     </svg>
   );
@@ -50,7 +50,7 @@ function EyeClosedIcon() {
     <svg width={17} height={15} viewBox="0 0 17 15" fill="none" aria-hidden>
       <path
         d="M8.5 2.5C10.709 2.5 12.5 4.291 12.5 6.5C12.5 7.02 12.39 7.51 12.21 7.97L14.54 10.3C15.77 9.29 16.73 7.99 17 6.5C15.66 2.91 12.364 0.5 8.5 0.5C7.474 0.5 6.49 0.68 5.57 0.99L7.28 2.7C7.74 2.52 8.22 2.5 8.5 2.5ZM0.94 1.37L2.69 3.12L3.08 3.51C1.73 4.55 0.68 5.93 0 6.5C1.34 10.09 4.636 12.5 8.5 12.5C9.63 12.5 10.71 12.28 11.71 11.89L12.08 12.26L14.38 14.56L15.33 13.61L1.89 0.42L0.94 1.37ZM5.18 5.61L6.32 6.75C6.29 6.83 6.27 6.92 6.27 7C6.27 8.105 7.165 9 8.27 9C8.35 9 8.44 8.98 8.52 8.95L9.66 10.09C9.24 10.3 8.78 10.43 8.27 10.43C6.061 10.43 4.27 8.639 4.27 6.43C4.27 5.92 4.4 5.46 4.61 5.04L5.18 5.61ZM8.36 4.08L10.69 6.41L10.71 6.27C10.71 5.165 9.815 4.27 8.71 4.27L8.36 4.08Z"
-        fill="rgba(0, 0, 0, 1)"
+        fill="var(--foreground)"
       />
     </svg>
   );
@@ -138,12 +138,12 @@ export function WikiInfoboxTypeUpdated({
         </button>
       ) : null}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={infoboxLabel}>Type</p>
         <p style={{ ...infoboxBodyMuted, margin: 0 }}>{typeLabel}</p>
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={infoboxLabel}>Last Updated</p>
         <p
           style={{
@@ -235,7 +235,7 @@ export function WikiInfoboxGoalStyle({
       {rows.map((row) => (
         <div
           key={row.label}
-          style={{ display: "flex", flexDirection: "column", gap: 7 }}
+          style={{ display: "flex", flexDirection: "column", gap: 8 }}
         >
           <p style={infoboxLabel}>{row.label}</p>
           <p
@@ -414,14 +414,14 @@ export function WikiEntityArticle({
           maxWidth: 864,
           display: "flex",
           flexDirection: "column",
-          gap: 56,
+          gap: 48,
         }}
       >
         <div
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: 22,
+            gap: 24,
             width: "100%",
           }}
         >
@@ -469,7 +469,7 @@ export function WikiEntityArticle({
                           alignItems: "center",
                           gap: 4,
                           backgroundColor: draftChipColors.bg,
-                          color: "rgba(0, 0, 0, 1)",
+                          color: "var(--foreground)",
                           borderColor: draftChipColors.border,
                           borderWidth: 1,
                           borderStyle: "solid",
@@ -535,7 +535,7 @@ export function WikiEntityArticle({
                     aria-label="Wiki title"
                     style={{
                       margin: 0,
-                      paddingBottom: 7,
+                      paddingBottom: 8,
                       ...T.h1,
                       fontFamily: FONT.SERIF,
                       color: "var(--wiki-title)",
@@ -551,7 +551,7 @@ export function WikiEntityArticle({
                     className="wiki-article-h1"
                     style={{
                       margin: 0,
-                      paddingBottom: 7,
+                      paddingBottom: 8,
                       ...T.h1,
                       fontFamily: FONT.SERIF,
                       color: "var(--wiki-title)",
@@ -570,7 +570,7 @@ export function WikiEntityArticle({
                   style={{
                     display: "flex",
                     alignItems: "flex-end",
-                    gap: 13,
+                    gap: 12,
                     flexShrink: 0,
                   }}
                 >
@@ -589,7 +589,7 @@ export function WikiEntityArticle({
                           ...T.bodySmall,
                           fontFamily: FONT.SANS,
                           lineHeight: "20px",
-                          paddingBottom: 7,
+                          paddingBottom: 8,
                           whiteSpace: "nowrap",
                         }}
                       >
@@ -608,7 +608,7 @@ export function WikiEntityArticle({
                           ...T.bodySmall,
                           fontFamily: FONT.SANS,
                           lineHeight: "20px",
-                          paddingBottom: 7,
+                          paddingBottom: 8,
                           whiteSpace: "nowrap",
                         }}
                       >
@@ -655,7 +655,7 @@ export function WikiEntityArticle({
                             ...T.bodySmall,
                             fontFamily: FONT.SANS,
                             lineHeight: "20px",
-                            paddingBottom: 7,
+                            paddingBottom: 8,
                             whiteSpace: "nowrap",
                           }}
                         >

--- a/wiki/src/components/wiki/WikiFurniture.tsx
+++ b/wiki/src/components/wiki/WikiFurniture.tsx
@@ -1,0 +1,148 @@
+import { cn } from "@/lib/utils"
+
+/* ── Citation: superscript [1] style ── */
+
+interface WikiCitationProps {
+  index: number
+  href?: string
+  className?: string
+}
+
+function WikiCitation({ index, href, className }: WikiCitationProps) {
+  return (
+    <sup data-slot="wiki-citation" className={cn("cite", className)}>
+      <a href={href ?? `#ref-${index}`}>[{index}]</a>
+    </sup>
+  )
+}
+
+/* ── Edit link: bracket [edit] beside headings ── */
+
+interface WikiEditLinkProps {
+  href?: string
+  onClick?: () => void
+  className?: string
+}
+
+function WikiEditLink({ href, onClick, className }: WikiEditLinkProps) {
+  return (
+    <a
+      data-slot="wiki-edit-link"
+      href={href ?? "#"}
+      onClick={onClick ? (e) => { e.preventDefault(); onClick(); } : undefined}
+      className={cn("wedit", className)}
+    >
+      edit
+    </a>
+  )
+}
+
+/* ── External link: arrow after <a> ── */
+
+interface WikiExternalLinkProps {
+  href: string
+  children: React.ReactNode
+  className?: string
+}
+
+function WikiExternalLink({ href, children, className }: WikiExternalLinkProps) {
+  return (
+    <a
+      data-slot="wiki-external-link"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn("ext", className)}
+    >
+      {children}
+    </a>
+  )
+}
+
+/* ── References list: numbered entries with back-link ^ ── */
+
+interface ReferenceEntry {
+  id: string
+  content: React.ReactNode
+  backHref?: string
+}
+
+interface WikiReferencesListProps {
+  entries: ReferenceEntry[]
+  className?: string
+}
+
+function WikiReferencesList({ entries, className }: WikiReferencesListProps) {
+  return (
+    <ol data-slot="wiki-references" className={cn("wrefs", className)}>
+      {entries.map((entry) => (
+        <li key={entry.id} id={entry.id}>
+          <a
+            href={entry.backHref ?? "#"}
+            className="wrefs__back"
+            aria-label="Jump back"
+          >
+            ^
+          </a>
+          <span>{entry.content}</span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/* ── See Also: two-column link list ── */
+
+interface SeeAlsoItem {
+  label: string
+  href: string
+}
+
+interface WikiSeeAlsoProps {
+  items: SeeAlsoItem[]
+  className?: string
+}
+
+function WikiSeeAlso({ items, className }: WikiSeeAlsoProps) {
+  return (
+    <ul data-slot="wiki-see-also" className={cn("wsee", className)}>
+      {items.map((item) => (
+        <li key={item.href}>
+          <a href={item.href}>{item.label}</a>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/* ── Hint: small monospace hint text ── */
+
+interface WikiHintProps {
+  children: React.ReactNode
+  className?: string
+}
+
+function WikiHint({ children, className }: WikiHintProps) {
+  return (
+    <p data-slot="wiki-hint" className={cn("hint", className)}>
+      {children}
+    </p>
+  )
+}
+
+export {
+  WikiCitation,
+  WikiEditLink,
+  WikiExternalLink,
+  WikiReferencesList,
+  WikiSeeAlso,
+  WikiHint,
+  type WikiCitationProps,
+  type WikiEditLinkProps,
+  type WikiExternalLinkProps,
+  type WikiReferencesListProps,
+  type ReferenceEntry,
+  type WikiSeeAlsoProps,
+  type SeeAlsoItem,
+  type WikiHintProps,
+}

--- a/wiki/src/components/wiki/WikiHistoryTimeline.tsx
+++ b/wiki/src/components/wiki/WikiHistoryTimeline.tsx
@@ -42,15 +42,15 @@ const formatRelative = (ts: number) => {
 
 const diffStyles = {
   added: {
-    backgroundColor: "#d4f4d4",
-    color: "#14532d",
+    backgroundColor: "var(--diff-added-bg)",
+    color: "var(--diff-added-text)",
     textDecoration: "none",
     padding: "0 1px",
     borderRadius: 2,
   },
   removed: {
-    backgroundColor: "#fbd5d5",
-    color: "#7f1d1d",
+    backgroundColor: "var(--diff-removed-bg)",
+    color: "var(--diff-removed-text)",
     textDecoration: "line-through",
     padding: "0 1px",
     borderRadius: 2,
@@ -193,7 +193,7 @@ export default function WikiHistoryTimeline({ revisions }: WikiHistoryTimelinePr
                 width: 11,
                 height: 11,
                 borderRadius: "50%",
-                background: isLatest ? "#000" : "#fff",
+                background: isLatest ? "var(--foreground)" : "var(--background)",
                 border: "2px solid var(--wiki-meta-line)",
               }}
             />
@@ -240,8 +240,8 @@ export default function WikiHistoryTimeline({ revisions }: WikiHistoryTimelinePr
                     gap: 6,
                   }}
                 >
-                  <span style={{ color: "#14532d" }}>+{diff.added}</span>
-                  <span style={{ color: "#7f1d1d" }}>−{diff.removed}</span>
+                  <span style={{ color: "var(--diff-added-text)" }}>+{diff.added}</span>
+                  <span style={{ color: "var(--diff-removed-text)" }}>−{diff.removed}</span>
                 </span>
               ) : null}
             </div>
@@ -317,7 +317,7 @@ export default function WikiHistoryTimeline({ revisions }: WikiHistoryTimelinePr
                       padding: "10px 12px",
                       border: "1px solid var(--wiki-card-border)",
                       borderRadius: 4,
-                      background: "#fafafa",
+                      background: "var(--code-block-bg)",
                       whiteSpace: "pre-wrap",
                       wordBreak: "break-word",
                       lineHeight: "22px",

--- a/wiki/src/components/wiki/WikiHomeHero.tsx
+++ b/wiki/src/components/wiki/WikiHomeHero.tsx
@@ -17,11 +17,11 @@ type HeroFilter = "people" | "fragments" | "wiki";
 
 const FILTER_COLORS: Record<HeroFilter, { fg: string; bg: string }> = {
   // People stays yellow (our deviation)
-  people: { fg: "#854d0e", bg: "#fef9c3" },
+  people: { fg: "var(--wiki-type-people-text)", bg: "var(--wiki-type-people-bg)" },
   // Fragments — pick a neutral fragment color; using the Fact/sky shade
-  fragments: { fg: "#0284c7", bg: "rgba(14, 165, 233, 0.10)" },
+  fragments: { fg: "var(--fragment-type-fact-text)", bg: "var(--fragment-type-fact-bg)" },
   // Wiki — uses the wiki-link blue
-  wiki: { fg: "#3366cc", bg: "rgba(51, 102, 204, 0.10)" },
+  wiki: { fg: "var(--wiki-link)", bg: "rgba(51, 102, 204, 0.10)" },
 };
 
 function HomeSearchBlock({ activeFilter }: { activeFilter: HeroFilter | null }) {
@@ -89,8 +89,8 @@ function FilterChip({
   onToggle: (id: HeroFilter) => void;
 }) {
   const colors = FILTER_COLORS[id];
-  const idleColor = "#a6a6a6";
-  const idleBg = "#f5f5f5";
+  const idleColor = "var(--wiki-count)";
+  const idleBg = "var(--surface-subtle)";
   return (
     <button
       type="button"

--- a/wiki/src/components/wiki/WikiInfobox.tsx
+++ b/wiki/src/components/wiki/WikiInfobox.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils"
+
+interface WikiInfoboxSection {
+  label?: string
+  rows: Array<{ key: string; value: React.ReactNode }>
+}
+
+interface WikiInfoboxProps {
+  title: string
+  image?: string
+  caption?: string
+  sections: WikiInfoboxSection[]
+  className?: string
+}
+
+function WikiInfobox({ title, image, caption, sections, className }: WikiInfoboxProps) {
+  return (
+    <table data-slot="wiki-infobox" className={cn("winfo", className)}>
+      <caption className="winfo__head">{title}</caption>
+      <tbody>
+        {image ? (
+          <>
+            <tr>
+              <td colSpan={2} className="winfo__image">
+                <img src={image} alt={caption ?? title} style={{ maxWidth: "100%" }} />
+              </td>
+            </tr>
+            {caption ? (
+              <tr>
+                <td colSpan={2} className="winfo__caption">
+                  {caption}
+                </td>
+              </tr>
+            ) : null}
+          </>
+        ) : null}
+        {sections.map((section, si) => (
+          <Section key={si} section={section} />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function Section({ section }: { section: WikiInfoboxSection }) {
+  return (
+    <>
+      {section.label ? (
+        <tr>
+          <th colSpan={2} className="winfo__section">
+            {section.label}
+          </th>
+        </tr>
+      ) : null}
+      {section.rows.map((row, ri) => (
+        <tr key={ri} className="winfo__row">
+          <td className="winfo__k">{row.key}</td>
+          <td className="winfo__v">{row.value}</td>
+        </tr>
+      ))}
+    </>
+  )
+}
+
+export { WikiInfobox, type WikiInfoboxProps, type WikiInfoboxSection }

--- a/wiki/src/components/wiki/WikiNote.tsx
+++ b/wiki/src/components/wiki/WikiNote.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils"
+
+type NoteVariant = "info" | "warning" | "danger"
+
+interface WikiNoteProps {
+  children: React.ReactNode
+  variant?: NoteVariant
+  className?: string
+}
+
+function WikiNote({ children, variant = "info", className }: WikiNoteProps) {
+  return (
+    <div
+      data-slot="wiki-note"
+      data-variant={variant}
+      className={cn("wiki-note", `wiki-note--${variant}`, className)}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { WikiNote, type WikiNoteProps, type NoteVariant }

--- a/wiki/src/components/wiki/WikiSearchBar.tsx
+++ b/wiki/src/components/wiki/WikiSearchBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { T } from "@/lib/typography";
+import { cn } from "@/lib/utils";
 
 function SendArrowIcon({ size }: { size: number }) {
   return (
@@ -37,38 +37,33 @@ export default function WikiSearchBar({
   onChange: (v: string) => void;
   onSubmit: () => void;
   placeholder?: string;
-  /** When true, no outer fill/padding (parent provides card, e.g. wiki home) */
   embedded?: boolean;
-  /** Tighter row for the fixed wiki header (50px strip) */
   compact?: boolean;
-  /** `stacked` = ROBIN home: input on top, send button bottom-right (node 217:35530) */
   layout?: "inline" | "stacked";
 }) {
   const hasValue = value.length > 0;
+  const sendSize = layout === "stacked" ? 24 : compact ? 22 : 24;
+  const iconSize = layout === "stacked" ? 16 : compact ? 14 : 16;
+
   const sendBtn = (
     <button
       type="submit"
       aria-label="Search"
+      className={cn(
+        "wiki-search-bar__send",
+        compact && layout !== "stacked" && "wiki-search-bar__send--compact",
+      )}
       style={{
-        flexShrink: 0,
-        width: layout === "stacked" ? 24 : compact ? 22 : 24,
-        height: layout === "stacked" ? 24 : compact ? 22 : 24,
-        minWidth: layout === "stacked" ? 24 : compact ? 22 : 24,
-        minHeight: layout === "stacked" ? 24 : compact ? 22 : 24,
-        padding: layout === "stacked" ? 4 : compact ? 3 : 4,
-        border: "none",
-        borderRadius: 80,
+        width: sendSize,
+        height: sendSize,
+        minWidth: sendSize,
+        minHeight: sendSize,
         background: hasValue
           ? "rgba(0, 0, 0, 0.12)"
           : "var(--wiki-chat-send-bg)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        cursor: "pointer",
-        transition: "background-color 150ms ease",
       }}
     >
-      <SendArrowIcon size={layout === "stacked" ? 16 : compact ? 14 : 16} />
+      <SendArrowIcon size={iconSize} />
     </button>
   );
 
@@ -82,33 +77,15 @@ export default function WikiSearchBar({
         }}
       >
         <label
-          className="border border-[#e5e7ea] focus-within:border-[#c8cdd2] transition-colors"
+          className={cn(
+            "wiki-search-bar__stacked-label border border-[var(--wiki-card-border)] focus-within:border-[var(--wiki-search-border)] transition-colors",
+          )}
           style={{
-            width: "100%",
-            maxWidth: 591,
-            minHeight: 88,
-            padding: 12,
-            boxSizing: "border-box",
             background: embedded ? "transparent" : "var(--wiki-chat-bg)",
             borderRadius: embedded ? 0 : 12,
-            display: "flex",
-            flexDirection: "column",
-            gap: 12,
-            justifyContent: "center",
-            overflow: "hidden",
-            cursor: "text",
           }}
         >
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              width: "100%",
-              padding: "4px 8px",
-              borderRadius: 12,
-              boxSizing: "border-box",
-            }}
-          >
+          <div className="flex w-full flex-col" style={{ padding: "4px 8px", borderRadius: 12 }}>
             <input
               type="text"
               value={value}
@@ -117,7 +94,9 @@ export default function WikiSearchBar({
               className="wiki-chat-input min-w-0 w-full bg-transparent outline-none"
               style={{
                 height: 20,
-                ...T.input,
+                fontFamily: "var(--font-ibm-plex-sans), 'IBM Plex Sans', sans-serif",
+                fontSize: 14,
+                fontWeight: 400,
                 letterSpacing: 0,
                 lineHeight: "20px",
                 color: "var(--wiki-title)",
@@ -125,17 +104,7 @@ export default function WikiSearchBar({
               }}
             />
           </div>
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              alignItems: "center",
-              justifyContent: "flex-end",
-              width: "100%",
-              gap: 8,
-              borderRadius: 12,
-            }}
-          >
+          <div className="flex w-full flex-wrap items-center justify-end" style={{ gap: 8, borderRadius: 12 }}>
             {sendBtn}
           </div>
         </label>
@@ -152,29 +121,19 @@ export default function WikiSearchBar({
       }}
     >
       <div
+        className={cn(
+          "wiki-search-bar__inline-wrap",
+          embedded && "wiki-search-bar__inline-wrap--embedded",
+        )}
         style={{
-          width: "100%",
-          maxWidth: 591,
-          minHeight: embedded ? undefined : 53,
-          padding: embedded ? 0 : 12,
-          borderRadius: 0,
           background: embedded ? "transparent" : "var(--wiki-chat-bg)",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          boxSizing: "border-box",
         }}
       >
         <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            width: "100%",
-            padding: compact ? "2px 6px" : "4px 8px",
-            borderRadius: 12,
-            gap: compact ? 6 : 8,
-            boxSizing: "border-box",
-          }}
+          className={cn(
+            "wiki-search-bar__input-row",
+            compact && "wiki-search-bar__input-row--compact",
+          )}
         >
           <input
             type="text"
@@ -184,7 +143,9 @@ export default function WikiSearchBar({
             className="wiki-chat-input min-w-0 flex-1 bg-transparent outline-none"
             style={{
               height: compact ? 18 : 20,
-              ...T.input,
+              fontFamily: "var(--font-ibm-plex-sans), 'IBM Plex Sans', sans-serif",
+              fontSize: 14,
+              fontWeight: 400,
               letterSpacing: 0,
               lineHeight: compact ? "18px" : "20px",
               color: "var(--wiki-title)",

--- a/wiki/src/components/wiki/WikiSearchResults.tsx
+++ b/wiki/src/components/wiki/WikiSearchResults.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { T } from "@/lib/typography";
 import { WikiTypeBadge } from "@/components/wiki/WikiTypeBadge";
 import { WikiSectionH2 } from "@/components/wiki/WikiEntityArticle";
 import { Spinner } from "@/components/ui/spinner";
+import { Chip } from "@/components/ui/chip";
 import { useSearch } from "@/hooks/useSearch";
 
 function SectionRule() {
@@ -19,43 +20,6 @@ function SectionRule() {
         flexShrink: 0,
       }}
     />
-  );
-}
-
-function FilterChip({
-  icon,
-  label,
-  active,
-  onClick,
-}: {
-  icon: ReactNode;
-  label: string;
-  active?: boolean;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={
-        active
-          ? "wiki-search-filter-chip wiki-search-filter-chip--active"
-          : "wiki-search-filter-chip"
-      }
-    >
-      <span className="flex h-3 w-3 shrink-0 items-center justify-center">
-        {icon}
-      </span>
-      <span
-        style={{
-          ...T.micro,
-          letterSpacing: "-0.0288px",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {label}
-      </span>
-    </button>
   );
 }
 
@@ -184,7 +148,7 @@ function SearchResultRow({ item }: { item: SearchResultItem }) {
         className="wiki-search-result-meta flex items-center"
         style={{
           ...T.micro,
-          color: "#444444",
+          color: "var(--wiki-count)",
           gap: 3,
           whiteSpace: "nowrap",
         }}
@@ -271,20 +235,20 @@ export default function WikiSearchResults({ query }: { query: string }) {
       </div>
 
       <div className="flex flex-wrap items-start" style={{ gap: 8 }}>
-        <FilterChip
+        <Chip
           icon={<IconCircle />}
           label={`All (${totalCount})`}
           active={filter === "all"}
           onClick={() => setFilter("all")}
         />
-        <FilterChip
+        <Chip
           icon={<IconFileCode />}
           label={`Fragments (${fragmentCount})`}
           active={filter === "fragments"}
           onClick={() => setFilter("fragments")}
         />
         {wikiCount > 0 && (
-          <FilterChip
+          <Chip
             icon={<IconWiki />}
             label={`Wiki (${wikiCount})`}
             active={filter === "wiki"}
@@ -292,7 +256,7 @@ export default function WikiSearchResults({ query }: { query: string }) {
           />
         )}
         {peopleCount > 0 && (
-          <FilterChip
+          <Chip
             icon={<IconUserRound />}
             label={`People (${peopleCount})`}
             active={filter === "people"}

--- a/wiki/src/components/wiki/WikiTOC.tsx
+++ b/wiki/src/components/wiki/WikiTOC.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+
+interface TOCHeading {
+  level: number
+  text: string
+  id: string
+}
+
+interface WikiTOCProps {
+  headings: TOCHeading[]
+  defaultOpen?: boolean
+  className?: string
+}
+
+function WikiTOC({ headings, defaultOpen = true, className }: WikiTOCProps) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  if (headings.length === 0) return null
+
+  return (
+    <nav data-slot="wiki-toc" className={cn("wtoc", className)}>
+      <div className="wtoc__title">
+        <span>Contents</span>
+        <button
+          type="button"
+          className="wtoc__toggle"
+          onClick={() => setOpen((v) => !v)}
+        >
+          [{open ? "hide" : "show"}]
+        </button>
+      </div>
+      {open ? (
+        <ol className="wtoc__list">
+          {headings.map((h) => (
+            <li
+              key={h.id}
+              className="wtoc__item"
+              style={{ paddingLeft: (h.level - 2) * 16 }}
+            >
+              <a href={`#${h.id}`} className="wtoc__link">
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </nav>
+  )
+}
+
+export { WikiTOC, type WikiTOCProps, type TOCHeading }

--- a/wiki/src/lib/typography.ts
+++ b/wiki/src/lib/typography.ts
@@ -1,28 +1,32 @@
 import type { CSSProperties } from "react";
 
 const SERIF =
-  "var(--font-source-serif-4), 'Source Serif 4', Georgia, serif" as const;
-const SANS = "var(--font-inter), 'Inter', sans-serif" as const;
+  "var(--font-stix-two-text), 'STIX Two Text', Georgia, serif" as const;
+const SANS =
+  "var(--font-ibm-plex-sans), 'IBM Plex Sans', sans-serif" as const;
+const MONO =
+  "var(--font-ibm-plex-mono), 'IBM Plex Mono', monospace" as const;
 
-export const FONT = { SERIF, SANS } as const;
+export const FONT = { SERIF, SANS, MONO } as const;
 
 /**
- * Shared type scale — two families only (Source Serif 4 for headings, Inter for everything else).
- * Sizes derived from Wikimedia/Wikipedia Codex design system, adapted for this app.
+ * Shared type scale — three families: STIX Two Text (serif headings),
+ * IBM Plex Sans (body/UI), IBM Plex Mono (code/indices).
+ * Sizes derived from designsys.html spec.
  */
 export const T = {
   hero: {
     fontFamily: SERIF,
-    fontSize: 40,
+    fontSize: 48,
     fontWeight: 400,
-    lineHeight: "48px",
+    lineHeight: "50px",
   } satisfies CSSProperties,
 
   h1: {
     fontFamily: SERIF,
-    fontSize: 28,
+    fontSize: 32,
     fontWeight: 400,
-    lineHeight: "35px",
+    lineHeight: "38px",
   } satisfies CSSProperties,
 
   h2: {
@@ -46,11 +50,18 @@ export const T = {
     lineHeight: "20px",
   } satisfies CSSProperties,
 
+  sectionTitle: {
+    fontFamily: SANS,
+    fontSize: 20,
+    fontWeight: 600,
+    lineHeight: "1.3",
+  } satisfies CSSProperties,
+
   body: {
     fontFamily: SANS,
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 400,
-    lineHeight: "26px",
+    lineHeight: "22px",
   } satisfies CSSProperties,
 
   bodySmall: {
@@ -105,8 +116,8 @@ export const T = {
 
   cardTitle: {
     fontFamily: SANS,
-    fontSize: 12,
-    fontWeight: 600,
+    fontSize: 15,
+    fontWeight: 500,
     lineHeight: "15px",
   } satisfies CSSProperties,
 
@@ -126,8 +137,8 @@ export const T = {
 
   label: {
     fontFamily: SANS,
-    fontSize: 12,
-    fontWeight: 400,
+    fontSize: 13,
+    fontWeight: 500,
     lineHeight: "16px",
     letterSpacing: "0.32px",
   } satisfies CSSProperties,
@@ -138,5 +149,19 @@ export const T = {
     fontWeight: 400,
     lineHeight: "18px",
     letterSpacing: "0.16px",
+  } satisfies CSSProperties,
+
+  mono: {
+    fontFamily: MONO,
+    fontSize: 13,
+    fontWeight: 400,
+    lineHeight: "1.5",
+  } satisfies CSSProperties,
+
+  monoSmall: {
+    fontFamily: MONO,
+    fontSize: 11,
+    fontWeight: 400,
+    lineHeight: "1.45",
   } satisfies CSSProperties,
 } as const;


### PR DESCRIPTION
## Summary
Full design system alignment against `wiki/designsys.html` specification.

### Phase 1 — Token Alignment
- Font stack: Source Serif 4 → **STIX Two Text**, Inter → **IBM Plex Sans**, added **IBM Plex Mono**
- Type scale: hero 48px, H1 32px, body 14px, added sectionTitle/mono/monoSmall
- 50+ hardcoded colors replaced with CSS variables across 14 files
- Added accent scale (100-700), surface, graph, diff, shadow, code-block tokens
- Border-radius overridden to 2px (Wikipedia squared aesthetic)
- Dark mode `[data-theme="dark"]` color block defined
- ActionButton uses `var(--wiki-link)`, card box-shadow matches spec

### Phase 2 — Component Parity
- **New components:** Chip, WikiChip, Toast, Tooltip, WikiNote, WikiInfobox, WikiTOC, WikiFurniture
- WikiSearchResults + Explorer refactored to use Chip component
- WikiSearchBar inline styles extracted to CSS classes
- Graph components read colors from CSS variables via `getComputedStyle`
- AddWikiModal uses Toast component

### Phase 3 — Consistency Pass
- Spacing audit: off-scale values fixed (7→8, 13→12, 22→24, 56→48)
- Card/dialog shadows match designsys.html spec
- Article tabs use accent scale (not black)
- Filter chip hover/active states use accent variables

## Stats
32 files changed, +1,416 / -425 lines. 8 new components.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] UAT suite — 142/142 green
- [ ] Visual review in browser at /wiki, /wiki/[id], /explorer, /graph, /search, /profile

Closes #78, closes #79, closes #80