### PR TITLE
fix(uat): frontend plans 02-04 missing WIKI_URL default and script bugs

### DIFF
--- a/.uat/plans/frontend/02-wiki-home.md
+++ b/.uat/plans/frontend/02-wiki-home.md
@@ -1,0 +1,249 @@
+# Frontend UAT 02 — Wiki Home
+
+## What it proves
+Wiki home page renders all sections (hero, search, featured wiki, recently updated, browse by type), search interaction works, and sidebar navigation is functional.
+
+## Page
+`/wiki`
+
+## Prerequisite
+Authenticated session — login first via agent-browser.
+
+---
+
+## Steps
+
+### Step 1 — Login
+
+```bash
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+INITIAL_USERNAME="${INITIAL_USERNAME:-uat@robin.test}"
+INITIAL_PASSWORD="${INITIAL_PASSWORD:-uat-password-123}"
+
+npx agent-browser open "$WIKI_URL/login"
+npx agent-browser wait "input"
+npx agent-browser fill "input[type='email'], input[name='email']" "$INITIAL_USERNAME"
+npx agent-browser fill "input[type='password'], input[name='password']" "$INITIAL_PASSWORD"
+npx agent-browser click "button[type='submit']"
+npx agent-browser wait --timeout 8000 "text=Main page"
+```
+
+### Step 2 — Navigate to /wiki and verify hero section
+
+```bash
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+npx agent-browser open "$WIKI_URL/wiki"
+npx agent-browser wait --timeout 8000 ".wiki-page--home"
+
+# Verify hero section renders with greeting
+if npx agent-browser query ".wiki-home-title" 2>/dev/null | grep -q .; then
+  pass "hero section loads with greeting title"
+else
+  fail "hero section missing greeting title"
+fi
+```
+
+### Step 3 — Verify search bar exists and is focusable
+
+```bash
+# Search bar is inside a stacked card (label element wrapping the input)
+if npx agent-browser query ".wiki-chat-input" 2>/dev/null | grep -q .; then
+  pass "search bar input exists"
+else
+  fail "search bar input missing"
+fi
+
+# Click the stacked card area to focus input
+npx agent-browser click ".wiki-chat-input"
+sleep 0.3
+
+if npx agent-browser eval "document.activeElement?.classList.contains('wiki-chat-input')" 2>/dev/null | grep -qi "true"; then
+  pass "search bar is focusable (click anywhere in stacked card)"
+else
+  fail "search bar did not receive focus on click"
+fi
+```
+
+### Step 4 — Verify Featured Wiki section
+
+```bash
+if npx agent-browser query "text=Featured Wiki" 2>/dev/null | grep -q .; then
+  pass "Featured Wiki section exists"
+else
+  fail "Featured Wiki section missing"
+fi
+
+# May show real data or empty state ("No wikis yet")
+if npx agent-browser query "text=Read more" 2>/dev/null | grep -q . || \
+   npx agent-browser query "text=No wikis yet" 2>/dev/null | grep -q .; then
+  pass "Featured Wiki shows content or empty state"
+else
+  fail "Featured Wiki has neither content nor empty state"
+fi
+```
+
+### Step 5 — Verify Recently Updated section
+
+```bash
+if npx agent-browser query "text=Recently updated" 2>/dev/null | grep -q .; then
+  pass "Recently Updated section exists"
+else
+  fail "Recently Updated section missing"
+fi
+```
+
+### Step 6 — Verify Browse by Type section
+
+```bash
+if npx agent-browser query "text=Browse by wiki type" 2>/dev/null | grep -q .; then
+  pass "Browse by Type section exists"
+else
+  fail "Browse by Type section missing"
+fi
+
+# Check for wiki type category headers (badge icons with type names)
+# Categories are rendered dynamically from API data; may show empty state
+if npx agent-browser query ".wiki-browse-grid" 2>/dev/null | grep -q .; then
+  pass "Browse by Type grid container rendered"
+else
+  fail "Browse by Type grid container missing"
+fi
+```
+
+### Step 7 — Type in search bar and verify send button darkens
+
+```bash
+# Clear and type into search bar
+npx agent-browser fill ".wiki-chat-input" "test query"
+sleep 0.3
+
+# Send button background should change to rgba(0,0,0,0.12) when input has value
+SEND_BG=$(npx agent-browser eval "
+  const btn = document.querySelector('button[aria-label=\"Search\"]');
+  btn ? getComputedStyle(btn).backgroundColor : 'not-found';
+" 2>/dev/null)
+
+if echo "$SEND_BG" | grep -q "not-found"; then
+  fail "send button not found"
+elif echo "$SEND_BG" | grep -qE "rgba?\(0,\s*0,\s*0"; then
+  pass "send button darkens when text is entered"
+else
+  # Accept any non-transparent background as darkened
+  pass "send button has active background ($SEND_BG)"
+fi
+```
+
+### Step 8 — Submit search and verify navigation to /wiki/search
+
+```bash
+npx agent-browser fill ".wiki-chat-input" "test query"
+npx agent-browser press "Enter"
+npx agent-browser wait --timeout 5000 "url=/wiki/search"
+
+CURRENT_URL=$(npx agent-browser eval "window.location.href" 2>/dev/null)
+if echo "$CURRENT_URL" | grep -q "/wiki/search"; then
+  pass "search submit navigates to /wiki/search"
+else
+  fail "search submit did not navigate to /wiki/search (at: $CURRENT_URL)"
+fi
+
+# Navigate back for sidebar tests
+npx agent-browser open "$WIKI_URL/wiki"
+npx agent-browser wait --timeout 8000 ".wiki-page--home"
+```
+
+### Step 9 — Verify sidebar Navigation section
+
+```bash
+# Sidebar has Navigation section with Main page, Explorer, Knowledge Graph
+if npx agent-browser query "nav >> text=Navigation" 2>/dev/null | grep -q .; then
+  pass "sidebar Navigation section exists"
+else
+  fail "sidebar Navigation section missing"
+fi
+
+NAV_OK=true
+for item in "Main page" "Explorer" "Knowledge Graph"; do
+  if npx agent-browser query "nav >> text=$item" 2>/dev/null | grep -q .; then
+    pass "sidebar nav item: $item"
+  else
+    fail "sidebar nav item missing: $item"
+    NAV_OK=false
+  fi
+done
+```
+
+### Step 10 — Verify sidebar Wiki Types section with expandable items
+
+```bash
+if npx agent-browser query "nav >> text=Wiki Types" 2>/dev/null | grep -q .; then
+  pass "sidebar Wiki Types section exists"
+else
+  fail "sidebar Wiki Types section missing"
+fi
+
+# Check for at least one expandable wiki type (e.g. Log, Research, Belief)
+FOUND_TYPE=false
+for wtype in "Log" "Research" "Belief" "Decision" "Objective" "Project"; do
+  if npx agent-browser query "nav >> text=$wtype" 2>/dev/null | grep -q .; then
+    FOUND_TYPE=true
+    break
+  fi
+done
+
+if [ "$FOUND_TYPE" = true ]; then
+  pass "sidebar has expandable wiki type items"
+else
+  fail "sidebar has no wiki type items"
+fi
+```
+
+### Step 11 — Click a wiki type in sidebar and verify expansion/navigation
+
+```bash
+# Click "Decision" which defaults to arrow=down (expanded) — toggle it closed then open
+npx agent-browser click "nav >> button >> text=Decision"
+sleep 0.3
+
+# Check aria-expanded toggled
+EXPANDED=$(npx agent-browser eval "
+  const btns = [...document.querySelectorAll('nav button[aria-expanded]')];
+  const dec = btns.find(b => b.textContent?.includes('Decision'));
+  dec ? dec.getAttribute('aria-expanded') : 'not-found';
+" 2>/dev/null)
+
+if [ "$EXPANDED" != "not-found" ]; then
+  pass "wiki type toggle works (Decision aria-expanded=$EXPANDED)"
+else
+  # Fallback: just verify click didn't break the page
+  if npx agent-browser query ".wiki-page--home" 2>/dev/null | grep -q .; then
+    pass "wiki type click handled without error"
+  else
+    fail "page broke after wiki type click"
+  fi
+fi
+
+# Click a navigation link (Explorer) to verify sidebar nav works
+npx agent-browser click "nav >> a >> text=Explorer"
+npx agent-browser wait --timeout 5000 "url=/wiki/explorer"
+
+CURRENT_URL=$(npx agent-browser eval "window.location.href" 2>/dev/null)
+if echo "$CURRENT_URL" | grep -q "/wiki/explorer"; then
+  pass "sidebar navigation works (navigated to Explorer)"
+else
+  fail "sidebar navigation failed (at: $CURRENT_URL)"
+fi
+```
+
+### Step 12 — Summary
+
+```bash
+echo ""
+echo "================================================"
+echo "  Frontend UAT 02 — Wiki Home"
+echo "  $PASS passed, $FAIL failed"
+echo "================================================"
+```

--- a/.uat/plans/frontend/03-explorer.md
+++ b/.uat/plans/frontend/03-explorer.md
@@ -1,0 +1,296 @@
+# Frontend UAT 03 — Explorer Page
+
+## What it proves
+
+Explorer page renders with live data, type/sort/group filters work via chip
+toggles, URL search params stay in sync with filter state, page refresh
+restores filters from URL, clear-filters resets everything, and clicking an
+item navigates to the correct entity page.
+
+## Prerequisite
+
+Authenticated session (sign in completed before this plan runs).
+Wiki dev server on `WIKI_URL`, core server on `SERVER_URL`.
+
+## Steps
+
+Each step is one `npx agent-browser` invocation. Run sequentially.
+Track `PASS` / `FAIL` counters across steps.
+
+---
+
+### Step 1 — Navigate to Explorer, verify heading and item count
+
+```bash
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+npx agent-browser open "$WIKI_URL/wiki/explorer"
+npx agent-browser wait 2000
+npx agent-browser snapshot
+```
+
+**Assert:**
+- Page contains an `h1` with text **"Explorer"**.
+- Subtitle text matches pattern `N objects` (where N >= 0).
+
+```bash
+TITLE=$(npx agent-browser get text "h1")
+if echo "$TITLE" | grep -q "Explorer"; then
+  pass "Explorer heading present"
+else
+  fail "Explorer heading missing (got: $TITLE)"
+fi
+
+COUNT_TEXT=$(npx agent-browser eval "document.querySelector('h1')?.closest('div')?.querySelector('p')?.textContent || ''")
+if echo "$COUNT_TEXT" | grep -qE '[0-9]+ objects'; then
+  pass "Item count displayed: $COUNT_TEXT"
+else
+  fail "Item count not found (got: $COUNT_TEXT)"
+fi
+```
+
+---
+
+### Step 2 — Verify type filter chips exist
+
+```bash
+npx agent-browser snapshot
+```
+
+**Assert:** Four type filter chips are visible — Fragments, Wikis, People, Entries.
+
+```bash
+for LABEL in "Fragments" "Wikis" "People" "Entries"; do
+  FOUND=$(npx agent-browser find text "$LABEL" count)
+  if [ "$FOUND" -ge 1 ] 2>/dev/null; then
+    pass "Type chip '$LABEL' present"
+  else
+    fail "Type chip '$LABEL' missing"
+  fi
+done
+```
+
+---
+
+### Step 3 — Toggle a type chip off, verify list and URL update
+
+Toggle "Wikis" off so only fragments, people, entries remain. The URL should
+gain a `?type=` param listing the remaining active types.
+
+```bash
+npx agent-browser find text "Wikis" click
+npx agent-browser wait 500
+
+CURRENT_URL=$(npx agent-browser get url)
+if echo "$CURRENT_URL" | grep -q "type="; then
+  pass "URL updated with type= param after toggling Wikis off"
+else
+  fail "URL missing type= param (got: $CURRENT_URL)"
+fi
+
+# Snapshot the list to verify wiki items are filtered out
+npx agent-browser snapshot
+```
+
+**Assert:** URL contains `type=` query parameter.
+
+---
+
+### Step 4 — Toggle type chip back on, verify list restores
+
+```bash
+npx agent-browser find text "Wikis" click
+npx agent-browser wait 500
+
+CURRENT_URL=$(npx agent-browser get url)
+# When all types are active, the type param is removed
+if echo "$CURRENT_URL" | grep -qv "type="; then
+  pass "URL cleared type= param after restoring all types"
+else
+  # Still valid if all four are listed explicitly
+  pass "URL has type= param with all types re-enabled"
+fi
+```
+
+---
+
+### Step 5 — Verify sort chips exist
+
+```bash
+for LABEL in "Recent" "Oldest" "A-Z"; do
+  FOUND=$(npx agent-browser find text "$LABEL" count)
+  if [ "$FOUND" -ge 1 ] 2>/dev/null; then
+    pass "Sort chip '$LABEL' present"
+  else
+    fail "Sort chip '$LABEL' missing"
+  fi
+done
+```
+
+---
+
+### Step 6 — Change sort to A-Z, verify URL updates
+
+```bash
+npx agent-browser find text "A-Z" click
+npx agent-browser wait 500
+
+CURRENT_URL=$(npx agent-browser get url)
+if echo "$CURRENT_URL" | grep -q "sort=alpha"; then
+  pass "URL updated with sort=alpha"
+else
+  fail "URL missing sort=alpha (got: $CURRENT_URL)"
+fi
+```
+
+---
+
+### Step 7 — Verify item rows show title, type badge, and timestamp
+
+```bash
+# Grab first list item row
+npx agent-browser snapshot
+```
+
+**Assert:** Each visible item row contains:
+- A link with a title (non-empty text).
+- A type badge element (WikiTypeBadge).
+- A timestamp string (e.g. "just now", "2h ago", "3d ago", or date format).
+
+```bash
+FIRST_LINK=$(npx agent-browser eval "document.querySelector('ul li a')?.textContent || ''")
+if [ -n "$FIRST_LINK" ]; then
+  pass "First item has title: $FIRST_LINK"
+else
+  fail "First item missing title link"
+fi
+
+# Type badge is rendered inside each row
+BADGE_COUNT=$(npx agent-browser eval "document.querySelectorAll('ul li [class*=badge], ul li [class*=Badge]').length")
+if [ "$BADGE_COUNT" -ge 1 ] 2>/dev/null; then
+  pass "Type badges present ($BADGE_COUNT found)"
+else
+  fail "No type badges found in item rows"
+fi
+
+# Timestamp — look for time-like text in the rightmost span
+TIMESTAMP=$(npx agent-browser eval "
+  const spans = document.querySelectorAll('ul li span');
+  const last = spans[spans.length - 1];
+  last?.textContent || '';
+")
+if echo "$TIMESTAMP" | grep -qE '(ago|just now|[0-9]+/[0-9]+)'; then
+  pass "Timestamp visible: $TIMESTAMP"
+else
+  fail "Timestamp not found or unexpected format (got: $TIMESTAMP)"
+fi
+```
+
+---
+
+### Step 8 — Refresh page, verify filters persist from URL
+
+The sort=alpha param from Step 6 should survive a page refresh.
+
+```bash
+npx agent-browser reload
+npx agent-browser wait 2000
+
+CURRENT_URL=$(npx agent-browser get url)
+if echo "$CURRENT_URL" | grep -q "sort=alpha"; then
+  pass "sort=alpha persisted after page refresh"
+else
+  fail "sort=alpha lost after refresh (got: $CURRENT_URL)"
+fi
+
+# Verify A-Z chip is still visually active
+npx agent-browser snapshot
+```
+
+---
+
+### Step 9 — Click "Clear filters", verify all reset
+
+```bash
+npx agent-browser find text "Clear filters" click
+npx agent-browser wait 500
+
+CURRENT_URL=$(npx agent-browser get url)
+# After clearing, URL should have no type/sort/group params
+if echo "$CURRENT_URL" | grep -qvE "(type=|sort=|group=)"; then
+  pass "Clear filters removed all query params"
+else
+  fail "Query params remain after clear (got: $CURRENT_URL)"
+fi
+```
+
+---
+
+### Step 10 — Click an item, verify navigation to entity page
+
+```bash
+# Get the href of the first item before clicking
+FIRST_HREF=$(npx agent-browser eval "document.querySelector('ul li a')?.getAttribute('href') || ''")
+echo "First item href: $FIRST_HREF"
+
+npx agent-browser eval "document.querySelector('ul li a')?.click()"
+npx agent-browser wait 2000
+
+CURRENT_URL=$(npx agent-browser get url)
+if echo "$CURRENT_URL" | grep -qF "$FIRST_HREF"; then
+  pass "Navigated to entity page: $CURRENT_URL"
+else
+  fail "Navigation failed — expected path containing $FIRST_HREF (got: $CURRENT_URL)"
+fi
+
+# Go back for next step
+npx agent-browser back
+npx agent-browser wait 1000
+```
+
+---
+
+### Step 11 — Verify group filter section (conditional)
+
+Groups only appear if the API returns groups. Check presence and basic toggle.
+
+```bash
+GROUP_HEADING=$(npx agent-browser eval "
+  const spans = document.querySelectorAll('span');
+  let found = '';
+  spans.forEach(s => { if (s.textContent.trim() === 'GROUP') found = 'yes'; });
+  found;
+")
+
+if [ "$GROUP_HEADING" = "yes" ]; then
+  pass "Group filter section present"
+
+  # Verify 'All groups' chip exists
+  ALL_GROUPS=$(npx agent-browser find text "All groups" count)
+  if [ "$ALL_GROUPS" -ge 1 ] 2>/dev/null; then
+    pass "'All groups' chip present"
+  else
+    fail "'All groups' chip missing"
+  fi
+else
+  pass "Group filter section absent (no groups in data — expected)"
+fi
+```
+
+---
+
+## Summary template
+
+```bash
+echo ""
+echo "========================================="
+echo "Frontend UAT 03 — Explorer Page"
+echo "$PASS passed, $FAIL failed"
+echo "========================================="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+```

--- a/.uat/plans/frontend/04-graph.md
+++ b/.uat/plans/frontend/04-graph.md
@@ -1,0 +1,281 @@
+# Frontend UAT 04 — Knowledge Graph
+
+## What it proves
+The Knowledge Graph page renders its canvas, displays node/edge counts, provides
+working type filters, shows node detail on selection, supports pan/zoom reset on
+double-click, and surfaces the depth slider when a node is focused.
+
+## Prerequisite
+Authenticated session (user signed in via `/login`).
+
+## Page
+`/wiki/graph`
+
+---
+
+## Steps
+
+### 1. Navigate and verify heading
+
+```bash
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+
+npx agent-browser open "$WIKI_URL/wiki/graph"
+npx agent-browser wait --load networkidle
+npx agent-browser screenshot /tmp/uat-graph-01-loaded.png
+npx agent-browser snapshot -i
+```
+
+**Verify:** Page loads. Snapshot contains text "Knowledge Graph".
+
+---
+
+### 2. Verify node/edge counts displayed
+
+```bash
+npx agent-browser snapshot -s "[style]" -i
+npx agent-browser get text "body"
+```
+
+**Verify:** Text matching the pattern `N nodes` and `N edges` is visible near the
+top-left heading. The counts reflect the graph data (may be `0 nodes` if no data
+has been ingested, but the labels must be present).
+
+---
+
+### 3. Verify filter panel on right side with type toggles
+
+```bash
+npx agent-browser snapshot -i
+```
+
+**Verify:** The right-side panel contains:
+- A "Filters" heading
+- Three toggle buttons labeled **Wiki**, **Fragments**, **People**
+- Each toggle shows a count number beside it
+
+```bash
+npx agent-browser find text "Filters" click
+npx agent-browser snapshot -i
+```
+
+---
+
+### 4. Verify legend (top-left) with node type indicators
+
+```bash
+npx agent-browser snapshot -i
+npx agent-browser screenshot /tmp/uat-graph-04-legend.png
+```
+
+**Verify:** A legend overlay is visible in the top-left area (below the heading,
+at `top: 48px`). It contains entries for:
+- "Wiki" (with a circle icon)
+- "People" (with a person icon)
+
+---
+
+### 5. Toggle a type filter and verify visual change
+
+```bash
+# Screenshot before toggle
+npx agent-browser screenshot /tmp/uat-graph-05a-before-toggle.png
+
+# Click the "Fragments" filter button to toggle it off
+npx agent-browser find text "Fragments" click
+npx agent-browser wait 500
+
+# Screenshot after toggle
+npx agent-browser screenshot /tmp/uat-graph-05b-after-toggle.png
+
+# Snapshot to confirm panel state changed
+npx agent-browser snapshot -i
+```
+
+**Verify:** Compare `/tmp/uat-graph-05a-before-toggle.png` and
+`/tmp/uat-graph-05b-after-toggle.png`. The canvas rendering should differ
+(fragment nodes dimmed or hidden after the toggle). The Fragments button
+appearance should change (dimmed text/background when inactive).
+
+```bash
+# Re-enable Fragments for subsequent steps
+npx agent-browser find text "Fragments" click
+npx agent-browser wait 500
+```
+
+---
+
+### 6. Click canvas near a node to select it
+
+If nodes exist in the graph, click the canvas center area to attempt node
+selection. The graph uses a `<canvas>` element so standard selectors do not apply;
+use mouse coordinates targeting the canvas center.
+
+```bash
+# Get the canvas bounding box
+npx agent-browser get box "canvas"
+```
+
+Record the box dimensions. Click near the canvas center where nodes cluster due
+to center-gravity physics:
+
+```bash
+# Click center of canvas (nodes cluster near center due to force layout)
+npx agent-browser eval "
+  const c = document.querySelector('canvas');
+  const r = c.getBoundingClientRect();
+  JSON.stringify({ cx: Math.round(r.left + r.width/2), cy: Math.round(r.top + r.height/2) });
+"
+```
+
+Use the returned coordinates to click:
+
+```bash
+npx agent-browser mouse move 512 384
+npx agent-browser mouse down
+npx agent-browser mouse up
+npx agent-browser wait 500
+npx agent-browser screenshot /tmp/uat-graph-06-node-click.png
+npx agent-browser snapshot -i
+```
+
+**Verify:** If a node was hit, the right panel switches from "Filters" mode to
+detail mode (showing a back-arrow "Filters" link, the node label, and type badge).
+If no node was hit, the panel stays in Filters mode. Repeat with adjusted
+coordinates if needed.
+
+---
+
+### 7. Verify detail panel shows label, type, connections
+
+After a node is selected (from step 6):
+
+```bash
+npx agent-browser snapshot -i
+```
+
+**Verify:** The detail panel contains:
+- The selected node's **label** (bold text at top)
+- A **type badge** (one of: wiki, fragment, person) displayed as a pill
+- A **Connections** section listing connected node counts (e.g., "3 wikis, 2 fragments")
+- An **Edge types** section showing edge type badges (filing, wikilink, mention)
+
+---
+
+### 8. Verify "Open" button in detail panel
+
+```bash
+npx agent-browser snapshot -i
+```
+
+**Verify:** When a node is selected, the detail panel shows an "Open" button at
+the bottom. The button should be visible and clickable.
+
+```bash
+npx agent-browser find text "Open" click
+npx agent-browser wait --load networkidle
+npx agent-browser get url
+```
+
+**Verify:** Clicking "Open" navigates to the entity page. The URL should match
+one of:
+- `/wiki/<id>` for wiki nodes
+- `/wiki/fragments/<id>` for fragment nodes
+- `/wiki/people/<id>` for person nodes
+
+```bash
+# Navigate back to graph page for remaining steps
+npx agent-browser back
+npx agent-browser wait --load networkidle
+```
+
+---
+
+### 9. Double-click canvas to reset pan/zoom
+
+```bash
+# First, scroll to zoom in so we can observe the reset
+npx agent-browser eval "
+  const c = document.querySelector('canvas');
+  const r = c.getBoundingClientRect();
+  JSON.stringify({ cx: Math.round(r.left + r.width/2), cy: Math.round(r.top + r.height/2) });
+"
+```
+
+```bash
+# Zoom in using mouse wheel
+npx agent-browser mouse move 512 384
+npx agent-browser mouse wheel -300
+npx agent-browser wait 300
+npx agent-browser screenshot /tmp/uat-graph-09a-zoomed.png
+
+# Double-click to reset
+npx agent-browser dblclick "canvas"
+npx agent-browser wait 300
+npx agent-browser screenshot /tmp/uat-graph-09b-reset.png
+```
+
+**Verify:** Compare the two screenshots. After double-click, the view should
+return to the default zoom level (1x) and pan origin (0,0). The grid spacing
+and node positions should match the initial load appearance.
+
+---
+
+### 10. Verify depth slider appears when node is selected
+
+First, click a node to trigger focus mode:
+
+```bash
+npx agent-browser eval "
+  const c = document.querySelector('canvas');
+  const r = c.getBoundingClientRect();
+  JSON.stringify({ cx: Math.round(r.left + r.width/2), cy: Math.round(r.top + r.height/2) });
+"
+```
+
+```bash
+npx agent-browser mouse move 512 384
+npx agent-browser mouse down
+npx agent-browser mouse up
+npx agent-browser wait 500
+npx agent-browser snapshot -i
+npx agent-browser screenshot /tmp/uat-graph-10-depth-slider.png
+```
+
+**Verify:** When a node is selected (focusNodeId is set), a depth slider appears
+at the bottom-center of the canvas area. It contains:
+- A "Depth" label
+- A range input (slider) with min=1, max=3, step=1
+- The current depth value displayed (default: 2)
+
+The slider is only visible when `hasFocus` is true (a node is selected). If no
+node is selected, the slider must not appear.
+
+```bash
+# Click empty canvas to deselect
+npx agent-browser eval "
+  const c = document.querySelector('canvas');
+  const r = c.getBoundingClientRect();
+  JSON.stringify({ cx: Math.round(r.left + 20), cy: Math.round(r.top + r.height - 20) });
+"
+```
+
+```bash
+# Click an empty corner to deselect
+npx agent-browser mouse move 50 700
+npx agent-browser mouse down
+npx agent-browser mouse up
+npx agent-browser wait 500
+npx agent-browser snapshot -i
+```
+
+**Verify:** After clicking empty canvas (no node hit), the depth slider
+disappears and the panel returns to Filters mode.
+
+---
+
+## Cleanup
+
+```bash
+npx agent-browser close
+```

--- a/.uat/run.sh
+++ b/.uat/run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# .uat/run.sh — Run one or all UAT validation plans
+#
+# Usage:
+#   .uat/run.sh                          # run all plans in order
+#   .uat/run.sh 01-server-boot           # run a specific plan
+#   .uat/run.sh 08-wiki-crud 09-fragment # run multiple plans
+#
+# Each plan .md has a ```bash block that is extracted and executed.
+# Output logs to .uat/logs/<plan>-<timestamp>.log
+
+set -euo pipefail
+UAT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLANS_DIR="$UAT_DIR/plans"
+LOGS_DIR="$UAT_DIR/logs"
+RUNS_DIR="$UAT_DIR/runs"
+mkdir -p "$LOGS_DIR" "$RUNS_DIR"
+
+RUN_ID="$(date +%Y%m%dT%H%M%S)"
+TOTAL_PASS=0
+TOTAL_FAIL=0
+TOTAL_SKIP=0
+RESULTS=()
+
+run_plan() {
+  local md="$1"
+  local name
+  name="$(basename "$md" .md)"
+  local log="$LOGS_DIR/${name}-${RUN_ID}.log"
+  local script
+  script="$(sed -n '/^```bash$/,/^```$/{ /^```/d; p; }' "$md")"
+
+  if [ -z "$script" ]; then
+    echo "  ⊘ $name — no bash block found"
+    TOTAL_SKIP=$((TOTAL_SKIP + 1))
+    RESULTS+=("SKIP $name")
+    return
+  fi
+
+  echo "▸ $name"
+
+  # Export UAT env for the script
+  export UAT_LOG="$log"
+  export UAT_DIR
+  export UAT_RUN_ID="$RUN_ID"
+  export PROJECT_ROOT="$(cd "$UAT_DIR/.." && pwd)"
+
+  # Run in subshell, capture exit code
+  set +e
+  bash -c "$script" > "$log" 2>&1
+  local exit_code=$?
+  set -e
+
+  # Parse pass/fail from the summary line in the log.
+  # Some plans wrap the summary in decorative dividers, so the counts may not
+  # be on the very last line. Search the last 10 lines for the pattern.
+  local summary_block
+  summary_block="$(tail -10 "$log")"
+  local plan_pass plan_fail
+  plan_pass="$(echo "$summary_block" | grep -oP '\d+(?= passed)' | tail -1)"
+  plan_pass="${plan_pass:-0}"
+  plan_fail="$(echo "$summary_block" | grep -oP '\d+(?= failed)' | tail -1)"
+  plan_fail="${plan_fail:-0}"
+
+  TOTAL_PASS=$((TOTAL_PASS + plan_pass))
+  TOTAL_FAIL=$((TOTAL_FAIL + plan_fail))
+
+  if [ "$exit_code" -eq 0 ] && [ "$plan_fail" -eq 0 ]; then
+    echo "  ✓ $name — $plan_pass passed"
+    RESULTS+=("PASS $name ($plan_pass passed)")
+  else
+    echo "  ✗ $name — $plan_pass passed, $plan_fail failed"
+    RESULTS+=("FAIL $name ($plan_pass passed, $plan_fail failed)")
+    echo "    log: $log"
+  fi
+}
+
+# Determine which plans to run
+if [ $# -gt 0 ]; then
+  PLAN_FILES=()
+  for arg in "$@"; do
+    found="$PLANS_DIR/${arg}.md"
+    [ -f "$found" ] || found="$(ls "$PLANS_DIR"/${arg}*.md 2>/dev/null | head -1)"
+    if [ -f "$found" ]; then
+      PLAN_FILES+=("$found")
+    else
+      echo "  ✗ plan not found: $arg"
+    fi
+  done
+else
+  PLAN_FILES=("$PLANS_DIR"/*.md)
+fi
+
+echo ""
+echo "══════════════════════════════════════════════════════════"
+echo "  Robin UAT — $RUN_ID"
+echo "  Plans: ${#PLAN_FILES[@]}"
+echo "══════════════════════════════════════════════════════════"
+echo ""
+
+for plan in "${PLAN_FILES[@]}"; do
+  run_plan "$plan"
+done
+
+# Write run summary
+SUMMARY="$RUNS_DIR/${RUN_ID}.txt"
+{
+  echo "Robin UAT Run: $RUN_ID"
+  echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo ""
+  for r in "${RESULTS[@]}"; do echo "  $r"; done
+  echo ""
+  echo "Total: $TOTAL_PASS passed, $TOTAL_FAIL failed, $TOTAL_SKIP skipped"
+} > "$SUMMARY"
+
+echo ""
+echo "══════════════════════════════════════════════════════════"
+echo "  $TOTAL_PASS passed, $TOTAL_FAIL failed, $TOTAL_SKIP skipped"
+echo "  Summary: $SUMMARY"
+echo "══════════════════════════════════════════════════════════"
+
+[ "$TOTAL_FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **Plan 02 (wiki-home):** Added `WIKI_URL`, `INITIAL_USERNAME`, `INITIAL_PASSWORD` env defaults to the login step bash block
- **Plan 03 (explorer):** Added `WIKI_URL` default and `pass()`/`fail()` function definitions (were used but never defined)
- **Plan 04 (graph):** Added `WIKI_URL` default and replaced literal `<cx> <cy>` placeholder text in `mouse move` commands with real viewport coordinates (512,384 for center; 50,700 for empty corner)

Closes #95