### PR TITLE
fix(uat): wiki-type plans don't recognize 'Entry queued' MCP response

### DIFF
--- a/.uat/plans/wiki-types/wiki-belief.md
+++ b/.uat/plans/wiki-types/wiki-belief.md
@@ -1,0 +1,549 @@
+# Wiki Type UAT — Belief
+
+## What it proves
+End-to-end belief wiki lifecycle: create belief-typed wikis, submit belief-flavored
+entries via MCP, pipeline processes them into fragments classified under the belief
+wiki, regen produces structured belief documents (The Position / Evidence / Nuances /
+Behavior sections).
+
+## Prerequisites
+- Server running at `$SERVER_URL` (default `http://localhost:3000`)
+- `OPENROUTER_API_KEY` set for LLM calls
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+
+## Fixtures
+Three realistic belief entries (500+ words each):
+1. **Remote work superiority** — a held position on distributed work with evidence
+2. **Degrowth economics** — a worldview on post-growth economics with supporting arguments
+3. **Embodied cognition** — a mental model about mind-body integration with philosophical reasoning
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Belief"
+echo ""
+
+# ── Preflight ──────────────────────────────────────────────────────────────
+
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping belief wiki type test"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+FIXTURE_1=$(cat <<'FIXTURE_EOF'
+I have become increasingly convinced that remote-first work is not merely a pandemic
+accommodation but a fundamentally superior model for knowledge work. This is a position
+I have arrived at after six years of working in both co-located and distributed teams,
+and after watching dozens of organizations attempt the transition with varying degrees
+of commitment.
+
+The core of my argument rests on three observations. First, the default state of an
+open-plan office is interruption. Cal Newport's research on deep work aligns with what
+I have experienced firsthand: the average knowledge worker in an office gets roughly
+eleven minutes of uninterrupted focus before someone taps their shoulder, pings them on
+Slack, or pulls them into an impromptu hallway conversation. In a remote environment,
+the default state is silence. You have to actively choose to interrupt someone, which
+creates a natural filter — trivial questions get answered by searching documentation
+instead of by shouting across the room. My own data from toggling between office weeks
+and remote weeks showed a consistent 30-40% increase in deep work hours when remote.
+
+Second, remote work democratizes opportunity in ways that office-centric models cannot.
+When Sarah joined our team from rural Montana, she brought a perspective on agricultural
+technology that nobody in our San Francisco office would have had. Remote hiring lets you
+access talent pools that would never relocate for your particular company. I spoke with
+Marcus, a hiring manager at a mid-size fintech, who told me that their remote-first
+policy tripled their pipeline of senior engineers within six months. The geographic
+constraint of offices creates an artificial talent bottleneck that companies mistake for
+a talent shortage.
+
+Third, the supposed benefits of in-person collaboration are overstated and poorly
+measured. The "water cooler serendipity" argument has become a kind of corporate folk
+wisdom that nobody bothers to quantify. When researchers at Microsoft studied
+communication patterns during the shift to remote work, they found that while weak-tie
+connections decreased, the quality of collaboration within established teams actually
+improved. People prepared more for meetings because meetings had a higher activation
+cost. Written communication created better documentation. Decisions became more traceable.
+
+I do acknowledge genuine challenges. Onboarding new employees remotely requires more
+deliberate structure — you cannot rely on osmotic learning when there is no physical
+proximity. Junior team members sometimes struggle without the ambient mentorship that
+offices provide. And some collaborative tasks — particularly early-stage brainstorming
+on ambiguous problems — do benefit from the bandwidth of physical presence. Elena, our
+design lead, has made a persuasive case that the first week of a new product discovery
+phase works better in person.
+
+But these exceptions do not invalidate the general principle. They suggest a model where
+occasional in-person gatherings supplement a remote-first default, not the other way
+around. The companies that will thrive in the next decade are the ones that treat remote
+work as their primary operating mode and design their processes accordingly, rather than
+bolting remote access onto fundamentally office-centric workflows.
+
+This belief shapes how I evaluate job opportunities, how I structure my own team's
+rituals, and how I advise founders. I default to asynchronous communication, invest
+heavily in written documentation, and schedule synchronous time only when the task
+genuinely requires it. It is a position I hold with high confidence, though I remain
+open to evidence that specific domains — emergency medicine, theatrical production,
+laboratory science — operate under different constraints.
+FIXTURE_EOF
+)
+
+FIXTURE_2=$(cat <<'FIXTURE_EOF'
+I believe that the pursuit of indefinite economic growth on a finite planet is not
+merely unsustainable but actively destructive, and that the most urgent intellectual
+project of our time is developing credible alternatives to growth-dependent economics.
+This is not a fringe position — it builds on work by Herman Daly, Kate Raworth, Tim
+Jackson, and Giorgos Kallis — but it remains deeply counterintuitive to most people
+raised in growth-oriented societies.
+
+The standard defense of growth economics goes something like this: growth lifts people
+out of poverty, funds public services, and drives innovation. All of these claims
+contain truth, but they conflate a historical observation with a universal law. Growth
+did lift hundreds of millions out of poverty in the twentieth century. But the
+relationship between GDP growth and human wellbeing decouples above a certain threshold.
+Research by Richard Easterlin and subsequent studies have shown that once a country
+reaches approximately $15,000-20,000 GDP per capita, further growth produces diminishing
+returns in life satisfaction, health outcomes, and social cohesion. The United States has
+roughly tripled its per-capita GDP since 1970, yet median wages have stagnated, life
+expectancy has plateaued (and recently declined), and self-reported happiness has not
+improved.
+
+The ecological case is even starker. Our economic system requires roughly 3% annual
+growth to avoid recession. But 3% compound growth means doubling the economy every 23
+years. We are already consuming 1.7 Earths worth of resources annually. No amount of
+efficiency improvement — what economists call "decoupling" — has ever reduced absolute
+resource consumption at the global level while maintaining growth. The Jevons paradox
+keeps reasserting itself: efficiency gains lower costs, which increases consumption,
+which negates the efficiency gains. My colleague David, who works in materials science,
+has shown me data on global copper extraction that makes this pattern painfully concrete.
+We extract more copper every year despite copper-per-unit-of-GDP declining consistently.
+
+The degrowth alternative does not mean recession or austerity. It means deliberately
+redirecting economic activity away from resource-intensive production and toward care
+work, ecological restoration, education, and community resilience. It means working less,
+sharing more, and measuring prosperity by indicators other than GDP — indicators like the
+Genuine Progress Indicator or Kate Raworth's Doughnut Economics framework, which defines
+a safe operating space between ecological ceilings and social foundations.
+
+I have discussed this with Patricia, an economist at the World Bank, who pushes back
+hard. She argues that growth is the only proven mechanism for generating the tax revenue
+needed to fund the transition to renewable energy. It is a fair challenge. My response
+is that the growth needed to fund the transition is itself accelerating the ecological
+damage that makes the transition necessary. We are running faster on a treadmill that is
+speeding up beneath us.
+
+This belief shapes my personal choices — I buy less, repair more, grow some of my own
+food, and actively resist the consumer identity that advertising cultivates. But more
+importantly, it shapes my political commitments. I support universal basic services over
+universal basic income, community land trusts over private development, and cooperative
+ownership over shareholder capitalism. These are not utopian fantasies — they are
+existing models that operate successfully at scale in various parts of the world.
+
+I hold this position with strong conviction but genuine uncertainty about implementation
+paths. The transition from a growth-dependent to a post-growth economy is unprecedented,
+and I am skeptical of anyone who claims to have a detailed roadmap. What I am confident
+about is the diagnosis: infinite growth on a finite planet is a mathematical
+impossibility dressed up as common sense, and the sooner we grapple with that, the less
+painful the inevitable adjustment will be.
+FIXTURE_EOF
+)
+
+FIXTURE_3=$(cat <<'FIXTURE_EOF'
+I hold the view that cognition is not something that happens exclusively inside the
+skull but is fundamentally shaped by — and in many cases constituted by — the body and
+its interactions with the environment. This position, broadly called embodied cognition,
+challenges the computational metaphor that has dominated cognitive science since the
+1950s, and I believe it has profound implications for how we design technology, educate
+children, and understand mental health.
+
+The computational view treats the mind as software running on the hardware of the brain.
+Perception is input, cognition is processing, and action is output. This metaphor has
+been enormously productive — it gave us artificial intelligence, cognitive behavioral
+therapy, and much of modern linguistics. But it is wrong in a fundamental way. It treats
+the body as peripheral to thought, a mere vehicle for carrying the brain around. The
+evidence against this view has been accumulating for decades.
+
+Consider the work of George Lakoff and Mark Johnson on conceptual metaphor. They
+demonstrated that abstract reasoning is systematically structured by bodily experience.
+We understand time through spatial metaphors (the future is "ahead," the past is
+"behind"). We understand morality through cleanliness metaphors (a "dirty" lie, "clean"
+conscience). These are not decorative figures of speech — they shape how we actually
+reason. When researchers had subjects hold warm cups of coffee versus iced drinks, the
+warm-cup group rated strangers as having warmer personalities. The body is not just
+executing cognitive commands; it is participating in cognition.
+
+My friend Tomoko, a developmental psychologist, showed me studies on infant cognition
+that make this even more vivid. Babies do not learn about objects by passively observing
+them — they learn by grasping, mouthing, throwing, and dropping. The sensorimotor
+system is not just gathering data for the brain to process; it is the medium through
+which concepts form. Children who are prevented from physical exploration show delayed
+cognitive development even when they have full visual access to the same environment.
+The body is not optional equipment for thinking — it is foundational infrastructure.
+
+The implications extend to adult cognition in ways that should alarm anyone who spends
+eight hours a day sitting motionless in front of a screen. Research by Marily Oppezzo
+and Daniel Schwartz at Stanford found that walking increased creative output by an
+average of 60% compared to sitting. Not walking in nature versus sitting in an ugly
+room — walking on a treadmill facing a blank wall versus sitting in the same room. The
+movement itself, the rhythmic bilateral activation of the body, changes the quality of
+thought. I discussed this with Raj, a neuroscientist colleague, who pointed me to
+studies showing that even small postural changes — standing versus sitting, expansive
+versus contracted postures — measurably affect hormonal profiles, risk tolerance, and
+problem-solving strategies.
+
+This belief has reshaped how I work and think. I take walking meetings whenever possible.
+I sketch ideas on paper before typing them. I am suspicious of any educational
+technology that further divorces learning from physical engagement. When I see Silicon
+Valley evangelists promoting brain-computer interfaces as the next frontier of cognition,
+I worry that they are doubling down on the exact wrong model — trying to optimize the
+computer in the skull while ignoring the vast cognitive resources distributed throughout
+the body and environment.
+
+I recognize legitimate critiques. Andy Clark's extended mind thesis takes embodied
+cognition further than I am comfortable with — I am not convinced that my smartphone is
+literally part of my cognitive system in the same way my hands are. And the embodied
+cognition research program has suffered from replication failures in some of its most
+famous experiments, particularly the power-posing studies. These failures matter and
+should moderate confidence.
+
+But the core insight survives the replication crisis: thinking is not just brain
+activity. It is brain-body-environment activity. Any theory of mind, any educational
+system, any workplace design, any therapeutic intervention that ignores the body is
+working with an incomplete model. I believe this with enough conviction to have
+restructured my daily routines around it, and with enough humility to keep reading the
+literature as it evolves.
+FIXTURE_EOF
+)
+
+# ── Step 0: Sign in ───────────────────────────────────────────────────────
+
+echo "─ Sign in"
+SIGNIN=$(curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+
+if echo "$SIGNIN" | jq -e '.user' >/dev/null 2>&1; then
+  pass "signed in as $INITIAL_USERNAME"
+else
+  fail "sign-in failed: ${SIGNIN:0:200}"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# ── Step 1: Get MCP token ─────────────────────────────────────────────────
+
+echo ""
+echo "─ MCP token"
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -n "$MCP_URL" ] && [ "$MCP_URL" != "null" ]; then
+  MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+  MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+  pass "MCP token acquired"
+else
+  fail "mcpEndpointUrl missing from profile"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Helper: extract JSON from SSE "data:" line
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# Helper: MCP tool call
+mcp_call() {
+  local tool_name="$1"
+  local args_json="$2"
+  local call_id="${3:-99}"
+  curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$call_id,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool_name\",\"arguments\":$args_json}}" \
+    "$MCP_URL" 2>/dev/null | parse_sse
+}
+
+# ── Step 2: Seed wiki types ───────────────────────────────────────────────
+
+echo ""
+echo "─ Seed wiki types"
+SEED_HTTP=$(curl -s -o /tmp/uat-belief-seed.json -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed → HTTP $SEED_HTTP"
+
+# Verify belief type exists
+LIST_HTTP=$(curl -s -o /tmp/uat-belief-wt.json -w "%{http_code}" \
+  -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types")
+HAS_BELIEF=$(jq '[.wikiTypes[].slug] | any(. == "belief")' /tmp/uat-belief-wt.json 2>/dev/null)
+[ "$HAS_BELIEF" = "true" ] && pass "belief wiki type present" || fail "belief wiki type missing"
+
+# ── Step 3: Create 3 belief wikis ─────────────────────────────────────────
+
+echo ""
+echo "─ Create belief wikis"
+
+declare -a WIKI_KEYS=()
+declare -a WIKI_SLUGS=()
+WIKI_NAMES=("Remote Work Superiority" "Degrowth Economics" "Embodied Cognition")
+
+for i in 0 1 2; do
+  CREATE=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"${WIKI_NAMES[$i]}\",\"type\":\"belief\"}" \
+    "$SERVER_URL/wikis")
+  CREATE_HTTP=$(echo "$CREATE" | tail -1)
+  CREATE_BODY=$(echo "$CREATE" | sed '$d')
+  W_KEY=$(echo "$CREATE_BODY" | jq -r '.lookupKey // .id // ""')
+  W_SLUG=$(echo "$CREATE_BODY" | jq -r '.slug // ""')
+  W_TYPE=$(echo "$CREATE_BODY" | jq -r '.type // ""')
+
+  if [ "$CREATE_HTTP" = "201" ] && [ "$W_TYPE" = "belief" ]; then
+    WIKI_KEYS+=("$W_KEY")
+    WIKI_SLUGS+=("$W_SLUG")
+    pass "created wiki '${WIKI_NAMES[$i]}' → slug=$W_SLUG, type=$W_TYPE"
+  else
+    fail "create wiki '${WIKI_NAMES[$i]}' → HTTP $CREATE_HTTP, type=$W_TYPE"
+    WIKI_KEYS+=("")
+    WIKI_SLUGS+=("")
+  fi
+done
+
+# ── Step 4: Submit 3 entries via MCP ──────────────────────────────────────
+
+echo ""
+echo "─ Submit entries via MCP"
+
+# MCP initialize (required before tool calls)
+curl -s --max-time 10 -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-belief","version":"1.0"}}}' \
+  "$MCP_URL" >/dev/null 2>&1
+
+FIXTURES=("$FIXTURE_1" "$FIXTURE_2" "$FIXTURE_3")
+FIXTURE_LABELS=("remote work superiority" "degrowth economics" "embodied cognition")
+declare -a ENTRY_KEYS=()
+
+for i in 0 1 2; do
+  # Escape content for JSON
+  ESCAPED=$(echo "${FIXTURES[$i]}" | jq -Rs '.')
+  CALL_RESP=$(mcp_call "log_entry" "{\"content\":$ESCAPED,\"source\":\"mcp\"}" "$((10+i))")
+  CALL_LEN=${#CALL_RESP}
+
+  if [ "$CALL_LEN" -gt 5 ]; then
+    ENTRY_TEXT=$(echo "$CALL_RESP" | jq -r '.result.content[0].text // ""' 2>/dev/null)
+    if echo "$ENTRY_TEXT" | grep -q "Entry queued"; then
+      E_KEY=$(echo "$ENTRY_TEXT" | grep -oP 'entry[0-9A-Z]{26}')
+      ENTRY_KEYS+=("$E_KEY")
+      pass "MCP log_entry (${FIXTURE_LABELS[$i]}) → $E_KEY"
+    else
+      fail "MCP log_entry (${FIXTURE_LABELS[$i]}) unexpected: ${ENTRY_TEXT:0:200}"
+      ENTRY_KEYS+=("")
+    fi
+  else
+    fail "MCP log_entry (${FIXTURE_LABELS[$i]}) empty response"
+    ENTRY_KEYS+=("")
+  fi
+done
+
+# ── Step 5: Poll entries until processed (max 360s) ───────────────────────
+
+echo ""
+echo "─ Poll entries (max 360s)"
+
+ELAPSED=0
+MAX_WAIT=360
+RESOLVED_COUNT=0
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $RESOLVED_COUNT -lt 3 ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  RESOLVED_COUNT=0
+
+  for i in 0 1 2; do
+    KEY="${ENTRY_KEYS[$i]:-}"
+    [ -z "$KEY" ] && continue
+    RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$KEY" 2>/dev/null)
+    STATUS=$(echo "$RESP" | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+      RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+    fi
+  done
+
+  echo "    ${ELAPSED}s — $RESOLVED_COUNT/3 entries resolved"
+done
+
+if [ $RESOLVED_COUNT -eq 3 ]; then
+  pass "all 3 entries reached processed state in ${ELAPSED}s"
+elif [ $RESOLVED_COUNT -gt 0 ]; then
+  pass "$RESOLVED_COUNT/3 entries processed (partial — pipeline may still be running)"
+  fail "$((3 - RESOLVED_COUNT)) entries did not process within ${MAX_WAIT}s"
+else
+  fail "no entries processed within ${MAX_WAIT}s"
+fi
+
+# ── Step 6: Report fragments ─────────────────────────────────────────────
+
+echo ""
+echo "─ Report: fragments"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments exist ($FRAG_COUNT total)"
+  echo "    sample titles:"
+  echo "$FRAGS" | jq -r '.fragments[:5][] | "      - \(.title // "untitled")"' 2>/dev/null
+else
+  fail "no fragments found after pipeline"
+fi
+
+# ── Step 7: Report people ────────────────────────────────────────────────
+
+echo ""
+echo "─ Report: people"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT total)"
+  echo "    names:"
+  echo "$PEOPLE" | jq -r '.people[] | "      - \(.name // .canonicalName // "unknown")"' 2>/dev/null
+else
+  skip "no people extracted (entity extraction may have failed gracefully)"
+fi
+
+# ── Step 8: Report edges ─────────────────────────────────────────────────
+
+echo ""
+echo "─ Report: edges (graph)"
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+
+echo "    nodes: $NODE_COUNT, edges: $EDGE_COUNT"
+
+# Count edge types
+FRAG_WIKI_EDGES=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_IN_WIKI")] | length' 2>/dev/null || echo "0")
+MENTION_EDGES=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_MENTIONS_PERSON")] | length' 2>/dev/null || echo "0")
+echo "    FRAGMENT_IN_WIKI: $FRAG_WIKI_EDGES"
+echo "    FRAGMENT_MENTIONS_PERSON: $MENTION_EDGES"
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has edges ($EDGE_COUNT total)"
+else
+  skip "no edges in graph (classification may not have assigned fragments to belief wikis)"
+fi
+
+# ── Step 9: Check belief wiki state before regen ──────────────────────────
+
+echo ""
+echo "─ Belief wiki state (pre-regen)"
+
+for i in 0 1 2; do
+  KEY="${WIKI_KEYS[$i]:-}"
+  [ -z "$KEY" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$KEY")
+  W_STATE=$(echo "$DETAIL" | jq -r '.state // "unknown"')
+  W_CONTENT_LEN=$(echo "$DETAIL" | jq -r '.content // "" | length' 2>/dev/null || echo "0")
+  W_FRAG_COUNT=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  echo "    ${WIKI_NAMES[$i]}: state=$W_STATE, content=${W_CONTENT_LEN}ch, fragments=$W_FRAG_COUNT"
+done
+
+# ── Step 10: Trigger regen on each belief wiki ────────────────────────────
+
+echo ""
+echo "─ Trigger regeneration"
+
+for i in 0 1 2; do
+  KEY="${WIKI_KEYS[$i]:-}"
+  [ -z "$KEY" ] && continue
+
+  # Ensure regenerate flag is enabled
+  curl -s -o /dev/null -X PATCH \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/$KEY/regenerate"
+
+  REGEN=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$KEY/regenerate")
+  REGEN_HTTP=$(echo "$REGEN" | tail -1)
+  REGEN_BODY=$(echo "$REGEN" | sed '$d')
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    R_FRAGS=$(echo "$REGEN_BODY" | jq -r '.fragmentCount // 0')
+    pass "regen '${WIKI_NAMES[$i]}' → 200, fragmentCount=$R_FRAGS"
+  elif [ "$REGEN_HTTP" = "400" ]; then
+    skip "regen '${WIKI_NAMES[$i]}' → 400 (regeneration disabled or no fragments)"
+  else
+    fail "regen '${WIKI_NAMES[$i]}' → HTTP $REGEN_HTTP: ${REGEN_BODY:0:200}"
+  fi
+done
+
+# ── Step 11: Report final wiki state ──────────────────────────────────────
+
+echo ""
+echo "─ Belief wiki state (post-regen)"
+
+for i in 0 1 2; do
+  KEY="${WIKI_KEYS[$i]:-}"
+  [ -z "$KEY" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$KEY")
+  W_STATE=$(echo "$DETAIL" | jq -r '.state // "unknown"')
+  W_CONTENT_LEN=$(echo "$DETAIL" | jq -r '.content // "" | length' 2>/dev/null || echo "0")
+  W_FRAG_COUNT=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  W_REBUILT=$(echo "$DETAIL" | jq -r '.lastRebuiltAt // "never"')
+
+  echo "    ${WIKI_NAMES[$i]}:"
+  echo "      state=$W_STATE, content=${W_CONTENT_LEN}ch, fragments=$W_FRAG_COUNT, lastRebuilt=$W_REBUILT"
+
+  # Check for belief document structure in content
+  W_CONTENT=$(echo "$DETAIL" | jq -r '.content // ""')
+  if echo "$W_CONTENT" | grep -qi "position\|evidence\|reasoning\|nuance"; then
+    pass "wiki '${WIKI_NAMES[$i]}' has belief structure keywords"
+  elif [ "$W_CONTENT_LEN" -gt 100 ] 2>/dev/null; then
+    skip "wiki '${WIKI_NAMES[$i]}' has content but belief structure not detected (observe)"
+  else
+    skip "wiki '${WIKI_NAMES[$i]}' has no content (fragments may not be linked)"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════"
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+echo "════════════════════════════════════════"
+```

--- a/.uat/plans/wiki-types/wiki-collection.md
+++ b/.uat/plans/wiki-types/wiki-collection.md
@@ -1,0 +1,492 @@
+# Wiki Type UAT — Collection
+
+## What it proves
+End-to-end lifecycle for the **Collection** wiki type: create 3 collection wikis,
+submit entries via MCP (one per wiki), poll until the pipeline processes them,
+verify fragments/people/edges exist, trigger on-demand regeneration, and confirm
+the wiki content reflects the collection prompt structure.
+
+A Collection wiki is "a curated library organizing related bookmarks, references,
+or resources." The pipeline should extract atomic fragments from the raw entries,
+detect mentioned people, create FRAGMENT_IN_WIKI and FRAGMENT_MENTIONS_PERSON
+edges, and produce a structured markdown document with Overview / Items / When to
+Use sections.
+
+## Prerequisites
+- `OPENROUTER_API_KEY` set in the invoking shell
+- Server running at `SERVER_URL` (default `http://localhost:3000`)
+- `core/.env` populated with `INITIAL_USERNAME`, `INITIAL_PASSWORD`
+
+## Fixtures
+
+Three realistic text inputs representing curated collections. Each is submitted
+as a raw entry via MCP `log_entry`, processed through the full AI pipeline, and
+the resulting fragments are attached to the corresponding collection wiki.
+
+---
+
+### Fixture 1 — Software Engineering Reading List
+
+> A curated reading list of essential software engineering books with annotations
+> on why each matters and when to read it.
+
+```
+My Software Engineering Reading List — Annotated Picks
+
+I have been building and refining this reading list for the past four years. Every book here changed how I think about building software, and I have organized them by the stage of your career where they hit hardest. This is not a "top ten" listicle — it is a working reference I actually go back to.
+
+Foundations (read these first):
+- "The Pragmatic Programmer" by David Thomas and Andrew Hunt. This is the single best starting point for any developer. The tips on tracer bullets, DRY, and orthogonality are things I still reference in design reviews a decade later. Dave and Andy wrote the second edition in 2019, and it is significantly updated — do not read the original 1999 edition.
+- "Code Complete" by Steve McConnell. Dense, long, and worth every page. McConnell backs up every recommendation with data from empirical studies. The chapters on variable naming and code layout seem trivial until you realize how much time your team burns on style arguments that this book already settled.
+- "A Philosophy of Software Design" by John Ousterhout. Short, opinionated, and contrarian — Ousterhout argues that deep modules with simple interfaces beat the popular "small classes, small methods" advice. I resisted this at first, then realized he was right about 80 percent of the cases I encounter. Professor Maria Chen at Stanford uses this as her primary text for CS 190.
+
+Architecture and Systems Thinking:
+- "Designing Data-Intensive Applications" by Martin Kleppmann. The single most important book for anyone building distributed systems or working with databases beyond toy projects. Kleppmann explains replication, partitioning, and consistency models with diagrams that actually clarify rather than confuse. James Watkins, our staff engineer, calls this "the book that replaced three shelves of O'Reilly titles."
+- "Software Architecture: The Hard Parts" by Neal Ford, Mark Richards, Pramod Sadalage, and Zhamak Dehghani. Focuses on the trade-off decisions that architecture is actually about: coupling versus cohesion, synchronous versus asynchronous, orchestration versus choreography. The fitness functions concept is something I brought into our architecture review process after reading it.
+- "Building Evolutionary Architectures" by Ford and Richards. Companion to Hard Parts. The concept of fitness functions — automated checks that verify architectural characteristics — is something every team should adopt.
+
+Process and Culture:
+- "Accelerate" by Nicole Forsgren, Jez Humble, and Gene Kim. Links specific engineering practices to measurable outcomes through DORA metrics: deployment frequency, lead time, change fail rate, and mean time to recovery. I gave a copy to every engineering manager on my team. Sarah Park from our DevOps group ran a book club on this last quarter and it directly shaped our CI/CD migration plan.
+- "Team Topologies" by Matthew Skelton and Manuel Pais. Changed how I think about organizational structure and its effect on software architecture. The four team types (stream-aligned, enabling, complicated subsystem, platform) gave us a shared vocabulary that eliminated months of ambiguous reorg discussions.
+
+When to reach for this list: at career transitions, before starting a greenfield project, during architecture reviews, or when onboarding a new senior hire. I update it roughly every six months as new standouts emerge.
+```
+
+---
+
+### Fixture 2 — Developer Productivity Toolkit
+
+> An annotated collection of the developer tools, CLIs, and workflows
+> that form a daily working environment.
+
+```
+My Developer Productivity Toolkit — Tools I Actually Use Daily
+
+This is the canonical list of tools in my daily development workflow. Everything here has survived at least six months of real use — I drop anything that adds friction or that I find myself working around instead of with. Last reviewed January 2025 with input from my colleague Tom Rivera who runs a similar setup on Linux.
+
+Editor and IDE:
+- Neovim (nightly builds) with lazy.nvim as the plugin manager. I switched from VS Code eighteen months ago and never looked back. The combination of Telescope for fuzzy finding, nvim-lspconfig for language server integration, and oil.nvim for file management gives me a workflow that feels like an extension of my thinking rather than a tool I am operating. Tom uses the same setup but swaps oil.nvim for neo-tree — both work, it is a preference thing.
+- Claude Code as the AI coding assistant integrated directly into the terminal. The MCP protocol support means it can read my project context without me copy-pasting files. I evaluated GitHub Copilot, Cursor, and Cody — Claude Code won on accuracy for complex refactors and its ability to run shell commands in context.
+
+Terminal and Shell:
+- Ghostty as the terminal emulator. Native GPU rendering, sub-millisecond input latency, and configuration through a single text file. Mitchell Hashimoto built this after leaving HashiCorp and it shows the same attention to correctness that went into Terraform.
+- Zsh with a minimal custom config (no oh-my-zsh). I use starship for the prompt, zoxide for directory jumping, and fzf for history search. Rachel Kim on our platform team showed me the zoxide + fzf combination and it cut my directory navigation time by roughly half.
+- Tmux with a handful of custom bindings. The session persistence alone justifies it — I can detach, reboot, and reattach without losing state. I keep one session per project with a standardized window layout: editor, server logs, shell, and a test runner.
+
+Version Control and Collaboration:
+- Git with delta for diffs (syntax highlighting in the terminal) and gh (the GitHub CLI) for pull requests, issues, and reviews without leaving the terminal. I alias common workflows: "git pr" creates a PR from the current branch, "git review" checks out a PR for local testing.
+- Conventional commits enforced via commitlint and a husky pre-commit hook. Sounds bureaucratic until you need to auto-generate a changelog or bisect a regression — then the structured history pays for itself immediately.
+
+Build and Runtime:
+- Bun as the JavaScript runtime and package manager. The install speed alone (10x faster than npm) justifies it, but the built-in test runner and TypeScript support without a separate compile step eliminated three tools from my chain. Alex Doshi on the frontend team was skeptical until he saw our CI pipeline drop from 4 minutes to 90 seconds.
+- Docker with Colima on macOS (no Docker Desktop). Lightweight, scriptable, and does not eat half my RAM. For local development I use docker compose with health checks and depends_on conditions so services start in the right order.
+
+Monitoring and Debugging:
+- Grafana + Prometheus for local observability when testing distributed services. Overkill for solo work but essential when you need to understand why a request is slow across three services. I keep a pre-built docker compose stack for this.
+- jq and fx for JSON processing in the terminal. Every API response, every log line, every config file — jq handles it. Lisa Patel from our data team wrote a set of shared jq filters for our common log formats that the whole backend team uses now.
+
+When to reach for this list: when setting up a new machine, when onboarding a teammate, or when evaluating whether to add or remove a tool from the stack. The goal is a small, composable toolkit where every piece earns its place.
+```
+
+---
+
+### Fixture 3 — Design Systems Reference Shelf
+
+> A curated compilation of design system references, component libraries,
+> and learning resources with notes on what makes each one worth studying.
+
+```
+Design Systems Reference Shelf — What to Study and Why
+
+I maintain this reference shelf as a working resource for anyone on our team building or contributing to design systems. Every entry has a note on what makes it worth studying and what you will actually learn from it. This is not an exhaustive catalogue — it is an opinionated selection of the references that have most influenced how we build our own component library. Updated quarterly; last review was with our design lead, Priya Sharma, in December 2024.
+
+Production Design Systems (study the source, not just the docs):
+- Material Design 3 (Google). The most comprehensive public design system. Study it for the token architecture — every color, shape, and motion value flows from a small set of source tokens through a layered resolution system. The way they handle dynamic color (Material You) is the best public implementation of user-personalized theming. Download the Figma kit and trace how a single "primary" seed color cascades into 80+ derived tokens.
+- Carbon (IBM). Open source and deeply opinionated about accessibility. Carbon treats WCAG compliance not as a checklist but as a structural constraint that shapes every component API. Their grid system documentation is the clearest I have found anywhere. Kevin Park from IBM's design tools team gave a talk at Config 2024 that walks through how they enforce contrast ratios programmatically through their token pipeline.
+- Polaris (Shopify). Study this for its content guidelines — Polaris treats voice and tone as first-class design system artifacts alongside components. The way they document "do / don't" patterns for UX writing is something we adapted directly for our own content guidelines. Emma Liu on our content design team used Polaris as the template for our tone rubric.
+- Geist (Vercel). Minimalist and performance-driven. Geist is worth studying for what it leaves out — every component exists only because it solved a real problem in the Vercel dashboard. The CSS variable naming convention is clean and the dark mode implementation uses a single class toggle with no JavaScript. Guillermo Rauch's philosophy of "reduce to the essential" is visible in every API surface.
+
+Component Library Implementations (study the code):
+- Radix Primitives (WorkOS). The gold standard for unstyled, accessible React primitives. Every component ships with full ARIA support, keyboard navigation, and focus management built in. Study the Dialog and Popover implementations to understand how they handle focus trapping and scroll locking without breaking the page. Our own modal system is built on Radix.
+- Headless UI (Tailwind Labs). Similar philosophy to Radix but with a smaller surface area and tight Tailwind integration. Adam Wathan designed the API to match how people actually use Tailwind — the components produce no visual output, just behavior and accessibility. Compare their Combobox with Radix's Select to see two valid approaches to the same problem.
+- shadcn/ui. Not a component library in the traditional sense — it is a collection of copy-paste components built on Radix and Tailwind. Study it for the distribution model: components live in your codebase, not in node_modules. This eliminates the version-lock problem that plagues traditional libraries. Daniel Nguyen on our frontend team used shadcn as the starting point for our internal component library and it saved us roughly three months of boilerplate.
+
+Learning Resources (read these in order):
+- "Design Systems" by Alla Kholmatova (Smashing Magazine, 2017). Still the best single book on the topic. Kholmatova covers the organizational and process aspects that most technical resources skip. The chapter on naming conventions alone is worth the price.
+- "Atomic Design" by Brad Frost. Introduces the atoms-molecules-organisms-templates-pages hierarchy. The model is imperfect (the biology metaphor breaks down at the template level) but it gave us a shared vocabulary for component composition that we still use. Brad maintains a living version at atomicdesign.bradfrost.com.
+- Storybook documentation and tutorials. Not a book, but the Storybook docs are the most practical guide to building a component development environment. Their Chromatic visual regression testing integration is what we use for our own CI pipeline. Marcus Chen set up our Storybook instance and credits their docs for cutting setup time from weeks to days.
+
+Token Architecture References:
+- Style Dictionary (Amazon). The open-source tool for transforming design tokens into platform-specific outputs (CSS custom properties, iOS Swift, Android XML). Study the transform pipeline to understand how a single source-of-truth token file becomes usable across web, iOS, and Android. Priya and I spent a week evaluating token tools and Style Dictionary won on extensibility.
+- Figma Variables (native). Figma's built-in variable system is now mature enough to be the single source for design tokens in small-to-medium systems. The modes feature (light/dark, compact/comfortable) maps cleanly to the multi-dimensional token concept. For larger systems you still need Style Dictionary as a build step, but Figma Variables is the right starting point.
+
+When to reach for this shelf: when starting a new design system, when evaluating component libraries, when onboarding a designer or frontend developer, or when you need to justify a technical decision about token architecture to stakeholders. The goal is informed decisions, not cargo-culting someone else's system.
+```
+
+---
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Collection"
+echo ""
+
+# Check OpenRouter key (required for pipeline + regen)
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping collection pipeline test"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── Sign in ──────────────────────────────────────────────────────────
+curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" >/dev/null
+
+# ── Get MCP token ────────────────────────────────────────────────────
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL" ] || [ "$MCP_URL" = "null" ]; then
+  fail "mcpEndpointUrl is empty — cannot run MCP tests"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token acquired"
+
+# Helper: SSE response parser
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# Helper: MCP tool call
+mcp_call() {
+  local tool_name="$1"
+  local args_json="$2"
+  local call_id="${3:-99}"
+  local RAW
+  RAW=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$call_id,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool_name\",\"arguments\":$args_json}}" \
+    "$MCP_URL" 2>/dev/null)
+  echo "$RAW" | parse_sse
+}
+
+# ── 1. Seed wiki types ───────────────────────────────────────────────
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify collection type exists
+COLLECTION_TYPE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/collection" 2>/dev/null)
+HAS_COLLECTION=$(echo "$COLLECTION_TYPE" | jq -r '.slug // ""' 2>/dev/null)
+[ "$HAS_COLLECTION" = "collection" ] && pass "collection wiki type exists" || fail "collection wiki type missing (got: $HAS_COLLECTION)"
+
+# ── 2. Create 3 collection wikis ─────────────────────────────────────
+declare -a WIKI_IDS WIKI_SLUGS
+WIKI_NAMES=("Engineering Reading List" "Developer Productivity Toolkit" "Design Systems Reference Shelf")
+
+for i in 0 1 2; do
+  CREATE=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"${WIKI_NAMES[$i]}\",\"type\":\"collection\"}" \
+    "$SERVER_URL/wikis")
+  CREATE_HTTP=$(echo "$CREATE" | tail -1)
+  CREATE_BODY=$(echo "$CREATE" | sed '$d')
+  WID=$(echo "$CREATE_BODY" | jq -r '.lookupKey // .id // ""')
+  WSLUG=$(echo "$CREATE_BODY" | jq -r '.slug // ""')
+
+  if [ "$CREATE_HTTP" = "201" ] && [ -n "$WID" ]; then
+    WIKI_IDS[$i]="$WID"
+    WIKI_SLUGS[$i]="$WSLUG"
+    pass "created wiki[$i]: ${WIKI_NAMES[$i]} (id=$WID, slug=$WSLUG)"
+  else
+    fail "create wiki[$i] → HTTP $CREATE_HTTP"
+    WIKI_IDS[$i]=""
+    WIKI_SLUGS[$i]=""
+  fi
+done
+
+# Verify all 3 have type=collection
+for i in 0 1 2; do
+  [ -z "${WIKI_IDS[$i]}" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_IDS[$i]}")
+  WTYPE=$(echo "$DETAIL" | jq -r '.type // ""')
+  [ "$WTYPE" = "collection" ] && pass "wiki[$i] type=collection" || fail "wiki[$i] type=$WTYPE (expected collection)"
+done
+
+# ── 3. Submit 3 entries via MCP log_entry ─────────────────────────────
+# Each entry maps to one wiki. The pipeline will extract fragments;
+# we will manually attach them to the correct wiki afterward via log_fragment.
+
+# Fixture 1: Software Engineering Reading List
+read -r -d '' FIXTURE_1 << 'FIXTURE_EOF'
+My Software Engineering Reading List — Annotated Picks. I have been building and refining this reading list for the past four years. Every book here changed how I think about building software, and I have organized them by the stage of your career where they hit hardest. This is not a top ten listicle — it is a working reference I actually go back to. Foundations (read these first): The Pragmatic Programmer by David Thomas and Andrew Hunt. This is the single best starting point for any developer. The tips on tracer bullets, DRY, and orthogonality are things I still reference in design reviews a decade later. Dave and Andy wrote the second edition in 2019. Code Complete by Steve McConnell. Dense, long, and worth every page. McConnell backs up every recommendation with data from empirical studies. A Philosophy of Software Design by John Ousterhout. Short, opinionated, and contrarian — Ousterhout argues that deep modules with simple interfaces beat the popular small classes small methods advice. Professor Maria Chen at Stanford uses this as her primary text for CS 190. Architecture and Systems Thinking: Designing Data-Intensive Applications by Martin Kleppmann. The single most important book for anyone building distributed systems. Kleppmann explains replication, partitioning, and consistency models with diagrams that actually clarify rather than confuse. James Watkins, our staff engineer, calls this the book that replaced three shelves of O'Reilly titles. Software Architecture The Hard Parts by Neal Ford, Mark Richards, Pramod Sadalage, and Zhamak Dehghani. Focuses on the trade-off decisions that architecture is actually about. The fitness functions concept is something I brought into our architecture review process. Accelerate by Nicole Forsgren, Jez Humble, and Gene Kim. Links specific engineering practices to measurable outcomes through DORA metrics. Sarah Park from our DevOps group ran a book club on this last quarter and it directly shaped our CI/CD migration plan. Team Topologies by Matthew Skelton and Manuel Pais. Changed how I think about organizational structure and its effect on software architecture. When to reach for this list: at career transitions, before starting a greenfield project, during architecture reviews, or when onboarding a new senior hire.
+FIXTURE_EOF
+
+# Fixture 2: Developer Productivity Toolkit
+read -r -d '' FIXTURE_2 << 'FIXTURE_EOF'
+My Developer Productivity Toolkit — Tools I Actually Use Daily. This is the canonical list of tools in my daily development workflow. Everything here has survived at least six months of real use. Last reviewed January 2025 with input from my colleague Tom Rivera who runs a similar setup on Linux. Editor and IDE: Neovim nightly builds with lazy.nvim as the plugin manager. I switched from VS Code eighteen months ago and never looked back. The combination of Telescope for fuzzy finding, nvim-lspconfig for language server integration, and oil.nvim for file management gives me a workflow that feels like an extension of my thinking. Tom uses the same setup but swaps oil.nvim for neo-tree. Claude Code as the AI coding assistant integrated directly into the terminal. The MCP protocol support means it can read my project context without me copy-pasting files. Terminal and Shell: Ghostty as the terminal emulator. Native GPU rendering, sub-millisecond input latency, and configuration through a single text file. Mitchell Hashimoto built this after leaving HashiCorp. Zsh with a minimal custom config. I use starship for the prompt, zoxide for directory jumping, and fzf for history search. Rachel Kim on our platform team showed me the zoxide plus fzf combination and it cut my directory navigation time by roughly half. Tmux with custom bindings for session persistence. Version Control and Collaboration: Git with delta for diffs and gh the GitHub CLI for pull requests, issues, and reviews without leaving the terminal. Conventional commits enforced via commitlint and a husky pre-commit hook. Build and Runtime: Bun as the JavaScript runtime and package manager. The install speed alone justifies it, but the built-in test runner and TypeScript support without a separate compile step eliminated three tools from my chain. Alex Doshi on the frontend team was skeptical until he saw our CI pipeline drop from 4 minutes to 90 seconds. Docker with Colima on macOS. Monitoring and Debugging: Grafana plus Prometheus for local observability. jq and fx for JSON processing in the terminal. Lisa Patel from our data team wrote a set of shared jq filters for our common log formats that the whole backend team uses. When to reach for this list: when setting up a new machine, when onboarding a teammate, or when evaluating whether to add or remove a tool from the stack.
+FIXTURE_EOF
+
+# Fixture 3: Design Systems Reference Shelf
+read -r -d '' FIXTURE_3 << 'FIXTURE_EOF'
+Design Systems Reference Shelf — What to Study and Why. I maintain this reference shelf as a working resource for anyone building or contributing to design systems. Every entry has a note on what makes it worth studying. Updated quarterly; last review was with our design lead, Priya Sharma, in December 2024. Production Design Systems: Material Design 3 from Google. The most comprehensive public design system. Study it for the token architecture — every color shape and motion value flows from a small set of source tokens through a layered resolution system. Carbon from IBM. Open source and deeply opinionated about accessibility. Carbon treats WCAG compliance not as a checklist but as a structural constraint. Kevin Park from IBM's design tools team gave a talk at Config 2024 that walks through how they enforce contrast ratios programmatically. Polaris from Shopify. Study this for its content guidelines — Polaris treats voice and tone as first-class design system artifacts alongside components. Emma Liu on our content design team used Polaris as the template for our tone rubric. Geist from Vercel. Minimalist and performance-driven. Guillermo Rauch's philosophy of reduce to the essential is visible in every API surface. Component Library Implementations: Radix Primitives from WorkOS. The gold standard for unstyled accessible React primitives. Our own modal system is built on Radix. Headless UI from Tailwind Labs. Adam Wathan designed the API to match how people actually use Tailwind. shadcn/ui. Not a component library in the traditional sense — it is a collection of copy-paste components built on Radix and Tailwind. Daniel Nguyen on our frontend team used shadcn as the starting point for our internal component library and it saved us roughly three months of boilerplate. Learning Resources: Design Systems by Alla Kholmatova. Still the best single book on the topic. Atomic Design by Brad Frost. Introduces the atoms-molecules-organisms-templates-pages hierarchy. Storybook documentation and tutorials. Marcus Chen set up our Storybook instance and credits their docs for cutting setup time from weeks to days. Token Architecture: Style Dictionary from Amazon. Priya and I spent a week evaluating token tools and Style Dictionary won on extensibility. Figma Variables native. When to reach for this shelf: when starting a new design system, when evaluating component libraries, when onboarding a designer or frontend developer.
+FIXTURE_EOF
+
+FIXTURES=("$FIXTURE_1" "$FIXTURE_2" "$FIXTURE_3")
+declare -a ENTRY_KEYS
+
+for i in 0 1 2; do
+  # Escape the fixture for JSON
+  ESCAPED=$(printf '%s' "${FIXTURES[$i]}" | jq -Rs '.')
+  RESP=$(mcp_call "log_entry" "{\"content\":$ESCAPED,\"source\":\"mcp\"}" $((10+i)))
+
+  if [ -z "$RESP" ] || [ ${#RESP} -lt 5 ]; then
+    fail "MCP log_entry[$i] returned empty response"
+    ENTRY_KEYS[$i]=""
+    continue
+  fi
+
+  # Extract entry key from "Entry queued: entry01ABC..."
+  EKEY=$(echo "$RESP" | jq -r '.result.content[0].text // ""' 2>/dev/null | grep -oP 'entry[0-9A-Z]{26}' || true)
+
+  if [ -n "$EKEY" ]; then
+    ENTRY_KEYS[$i]="$EKEY"
+    pass "MCP log_entry[$i] → queued ($EKEY)"
+  else
+    # Check for error or duplicate
+    TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // .error.message // "unknown"' 2>/dev/null)
+    fail "MCP log_entry[$i] unexpected response: ${TEXT:0:120}"
+    ENTRY_KEYS[$i]=""
+  fi
+done
+
+# ── 4. Poll until entries are processed (max 360s) ────────────────────
+echo ""
+echo "  ⟳ polling entry processing (max 360s)..."
+ELAPSED=0
+MAX_WAIT=360
+PROCESSED_COUNT=0
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $PROCESSED_COUNT -lt 3 ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  PROCESSED_COUNT=0
+
+  for i in 0 1 2; do
+    [ -z "${ENTRY_KEYS[$i]:-}" ] && continue
+    ENTRY_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/${ENTRY_KEYS[$i]}" 2>/dev/null)
+    STATUS=$(echo "$ENTRY_RESP" | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+      PROCESSED_COUNT=$((PROCESSED_COUNT + 1))
+    fi
+  done
+  echo "    ${ELAPSED}s — $PROCESSED_COUNT/3 entries processed"
+done
+
+for i in 0 1 2; do
+  [ -z "${ENTRY_KEYS[$i]:-}" ] && continue
+  ENTRY_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/entries/${ENTRY_KEYS[$i]}" 2>/dev/null)
+  STATUS=$(echo "$ENTRY_RESP" | jq -r '.ingestStatus // .state // "unknown"')
+  if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+    pass "entry[$i] reached $STATUS"
+  elif [ "$STATUS" = "failed" ]; then
+    LAST_ERR=$(echo "$ENTRY_RESP" | jq -r '.lastError // "unknown"')
+    fail "entry[$i] failed: $LAST_ERR"
+  else
+    fail "entry[$i] stuck at $STATUS after ${MAX_WAIT}s"
+  fi
+done
+
+# ── 5. Report fragments ──────────────────────────────────────────────
+echo ""
+echo "  ── Fragments ──"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created ($FRAG_COUNT total)"
+  echo "    first 5 titles:"
+  echo "$FRAGS" | jq -r '.fragments[:5][] | "      - \(.title // "untitled")"' 2>/dev/null
+else
+  fail "no fragments found after pipeline"
+fi
+
+# ── 6. Report people ─────────────────────────────────────────────────
+echo ""
+echo "  ── People ──"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT total)"
+  echo "    names:"
+  echo "$PEOPLE" | jq -r '.people[] | "      - \(.canonicalName // .name)"' 2>/dev/null
+else
+  skip "no people extracted (entity extraction is observe-only)"
+fi
+
+# ── 7. Report edges ──────────────────────────────────────────────────
+echo ""
+echo "  ── Edges ──"
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+
+echo "    nodes: $NODE_COUNT, edges: $EDGE_COUNT"
+
+# Count edge types
+FRAG_WIKI_EDGES=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_IN_WIKI")] | length' 2>/dev/null || echo "0")
+FRAG_PERSON_EDGES=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_MENTIONS_PERSON")] | length' 2>/dev/null || echo "0")
+echo "    FRAGMENT_IN_WIKI: $FRAG_WIKI_EDGES"
+echo "    FRAGMENT_MENTIONS_PERSON: $FRAG_PERSON_EDGES"
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has edges ($EDGE_COUNT)"
+else
+  skip "no edges yet (edge creation is observe-only)"
+fi
+
+# ── 8. Attach fragments to collection wikis via log_fragment ──────────
+# Use the first available fragments and attach them to our wikis so
+# regeneration has content to work with.
+echo ""
+echo "  ── Attaching fragments to collection wikis ──"
+
+FRAG_SLUGS=$(echo "$FRAGS" | jq -r '[.fragments[].slug // empty] | .[]' 2>/dev/null)
+FRAG_SLUG_ARRAY=()
+while IFS= read -r line; do
+  [ -n "$line" ] && FRAG_SLUG_ARRAY+=("$line")
+done <<< "$FRAG_SLUGS"
+
+ATTACHED=0
+for i in 0 1 2; do
+  [ -z "${WIKI_SLUGS[$i]:-}" ] && continue
+  # Grab a subset of fragments for each wiki (round-robin)
+  FRAG_IDX=$((i * 2))
+  for offset in 0 1; do
+    IDX=$((FRAG_IDX + offset))
+    [ $IDX -ge ${#FRAG_SLUG_ARRAY[@]} ] && continue
+    FSLUG="${FRAG_SLUG_ARRAY[$IDX]}"
+    [ -z "$FSLUG" ] && continue
+
+    # Use log_fragment to attach a new fragment to this wiki
+    ATTACH_CONTENT="Attached reference from fragment $FSLUG for ${WIKI_NAMES[$i]}"
+    ESCAPED_ATTACH=$(printf '%s' "$ATTACH_CONTENT" | jq -Rs '.')
+    ATTACH_RESP=$(mcp_call "log_fragment" "{\"content\":$ESCAPED_ATTACH,\"threadSlug\":\"${WIKI_SLUGS[$i]}\"}" $((20+i*2+offset)))
+
+    if echo "$ATTACH_RESP" | jq -e '.result.content[0].text' >/dev/null 2>&1; then
+      ATTACHED=$((ATTACHED + 1))
+    fi
+  done
+done
+
+if [ $ATTACHED -gt 0 ]; then
+  pass "attached $ATTACHED fragments to collection wikis via log_fragment"
+else
+  skip "no fragments attached (log_fragment may not have resolved slugs)"
+fi
+
+# ── 9. Trigger regeneration for each collection wiki ──────────────────
+echo ""
+echo "  ── Regeneration ──"
+
+for i in 0 1 2; do
+  [ -z "${WIKI_IDS[$i]:-}" ] && continue
+
+  # Ensure regenerate is enabled
+  curl -s -o /dev/null -X PATCH -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/${WIKI_IDS[$i]}/regenerate"
+
+  REGEN=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_IDS[$i]}/regenerate")
+  REGEN_HTTP=$(echo "$REGEN" | tail -1)
+  REGEN_BODY=$(echo "$REGEN" | sed '$d')
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    REGEN_FCOUNT=$(echo "$REGEN_BODY" | jq -r '.fragmentCount // 0')
+    pass "regen wiki[$i] → 200 (fragmentCount=$REGEN_FCOUNT)"
+  else
+    ERR_MSG=$(echo "$REGEN_BODY" | jq -r '.error // .detail // "unknown"' 2>/dev/null)
+    fail "regen wiki[$i] → HTTP $REGEN_HTTP: $ERR_MSG"
+  fi
+done
+
+# ── 10. Report final wiki state ───────────────────────────────────────
+echo ""
+echo "  ── Final Wiki State ──"
+
+for i in 0 1 2; do
+  [ -z "${WIKI_IDS[$i]:-}" ] && continue
+
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_IDS[$i]}")
+  W_NAME=$(echo "$DETAIL" | jq -r '.name // "?"')
+  W_TYPE=$(echo "$DETAIL" | jq -r '.type // "?"')
+  W_STATE=$(echo "$DETAIL" | jq -r '.state // "?"')
+  W_CONTENT_LEN=$(echo "$DETAIL" | jq -r '.content // "" | length')
+  W_REBUILT=$(echo "$DETAIL" | jq -r '.lastRebuiltAt // "never"')
+
+  echo "    wiki[$i]: $W_NAME"
+  echo "      type=$W_TYPE state=$W_STATE content=${W_CONTENT_LEN}chars rebuilt=$W_REBUILT"
+
+  # Verify content has collection structure markers
+  HAS_OVERVIEW=$(echo "$DETAIL" | jq -r '.content // ""' | grep -ci "overview" || true)
+  HAS_ITEMS=$(echo "$DETAIL" | jq -r '.content // ""' | grep -ci "items" || true)
+
+  if [ "$W_CONTENT_LEN" -gt 50 ] 2>/dev/null; then
+    pass "wiki[$i] has generated content ($W_CONTENT_LEN chars)"
+  else
+    fail "wiki[$i] content too short or empty ($W_CONTENT_LEN chars)"
+  fi
+
+  if [ "$HAS_OVERVIEW" -gt 0 ] && [ "$HAS_ITEMS" -gt 0 ]; then
+    pass "wiki[$i] has collection structure (Overview + Items sections)"
+  else
+    skip "wiki[$i] collection structure not detected (observe-only — LLM output varies)"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Collection wiki type UAT complete"
+echo "  $PASS passed, $FAIL failed, $SKIP skipped"
+echo "════════════════════════════════════════════"
+```

--- a/.uat/plans/wiki-types/wiki-decision.md
+++ b/.uat/plans/wiki-types/wiki-decision.md
@@ -1,0 +1,562 @@
+# Wiki Type UAT — Decision
+
+## What it proves
+End-to-end lifecycle for the **Decision** wiki type: create 3 decision wikis,
+seed wiki types, submit 3 realistic entries via MCP `log_entry`, poll until
+the pipeline processes them, verify fragments/people/edges were created,
+trigger on-demand regen, and report final wiki state.
+
+## Prerequisites
+- `OPENROUTER_API_KEY` for LLM calls (skips gracefully if missing)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` for sign-in
+- Server running at `SERVER_URL` (default `http://localhost:3000`)
+
+## Fixtures
+
+### Fixture 1 — Architecture Decision: Event Sourcing vs CRUD for Order Management
+
+> A classic ADR (Architecture Decision Record) for a backend migration.
+
+```
+We need to decide on the persistence strategy for the new order management
+system that will replace the legacy monolith's order module. The current system
+uses a single PostgreSQL table with mutable rows — when an order changes status,
+the row is updated in place. This has caused three production incidents in the
+past quarter where audit trails were lost, customer support couldn't reconstruct
+what happened to an order, and our analytics pipeline produced incorrect
+conversion metrics because intermediate states were invisible.
+
+Marcus from platform engineering proposed event sourcing: every state change
+becomes an immutable event appended to a log, and the current state is derived
+by replaying events. He demonstrated a prototype using EventStoreDB that
+handled our peak load (roughly 2,400 orders per minute during flash sales)
+with p99 latency under 12ms. The approach gives us a complete audit trail
+for free, enables temporal queries ("what did this order look like at 3pm
+yesterday"), and makes it straightforward to build new read models without
+touching the write path.
+
+Priya from the data team was initially skeptical. She raised concerns about
+eventual consistency — our current system serves real-time inventory counts
+from the same table, and moving to event sourcing would mean read models could
+lag behind writes. After testing Marcus's prototype, the lag was consistently
+under 200ms, which Priya agreed was acceptable for inventory display (we
+already show "approximately X in stock" for items with fewer than 10 units).
+She also pointed out that event sourcing would actually simplify her team's
+work: instead of CDC (Change Data Capture) polling the orders table every
+30 seconds, they could subscribe directly to the event stream.
+
+Chen from frontend engineering raised a different concern: debugging. With
+CRUD, you can inspect a row and see the current state. With event sourcing,
+you need tooling to replay events and inspect projections. Marcus acknowledged
+this and committed to building a developer console that shows the event
+timeline for any aggregate. Chen was satisfied with this commitment but
+noted it should be part of the MVP, not a follow-up.
+
+We also evaluated a hybrid approach suggested by our CTO Dana: keep CRUD for
+the primary order table but add an event log table that records every change
+as a side effect. This would preserve the simple query model while adding
+auditability. Marcus argued this creates a consistency problem — the event
+log and the order table could drift if a transaction partially fails. Dana
+conceded this point after Marcus showed a real example from the Q3 incident
+where exactly this kind of drift occurred in our current audit_log table.
+
+The team decided on full event sourcing with EventStoreDB. The migration will
+happen in three phases: Phase 1 deploys the event store alongside the existing
+system in shadow mode (writes go to both, reads still come from PostgreSQL).
+Phase 2 switches reads to projections built from the event store. Phase 3
+decommissions the PostgreSQL order table. Each phase has a rollback plan.
+Marcus and Priya will co-own the implementation. Target completion is end of
+Q2. The decision was unanimous after the prototype demonstration addressed
+everyone's concerns.
+```
+
+### Fixture 2 — Product Decision: Abandoning the Native Mobile App
+
+> A product strategy pivot with stakeholder tension and market data.
+
+```
+After eighteen months of development and three beta releases, we have decided
+to discontinue the native iOS and Android apps for Meridian and go all-in on
+the progressive web app (PWA). This was not an easy decision — the native apps
+represent roughly $1.2M in engineering investment and the mobile team of four
+engineers will need to be redeployed.
+
+The data forced our hand. Our analytics from the past six months tell a clear
+story: 73% of our mobile users access Meridian through the mobile browser,
+not the native app. Of the 27% who installed the native app, daily active
+usage dropped 40% after the first week. The native app's rating on both stores
+sits at 3.1 stars, dragged down by complaints about sync delays and feature
+parity gaps — features ship to web first, and the native ports lag by 6-8
+weeks on average.
+
+Tom from product analytics presented a cohort analysis showing that users
+who started on the PWA had 2.3x higher 90-day retention than native app
+users. He attributed this to the PWA receiving features immediately (no app
+store review cycle), having zero install friction, and sharing the exact
+same codebase as desktop — so bugs get fixed once, not three times.
+
+Jessica from mobile engineering pushed back strongly. She argued that push
+notifications on iOS still require a native app for reliability (Safari's
+Web Push support is inconsistent), that the native app's offline mode is
+superior to the service worker approach, and that abandoning native signals
+to enterprise customers that we're not a "serious" platform. These are
+legitimate concerns. On push notifications, our infrastructure lead Rafael
+confirmed that iOS 17.4's Web Push improvements have closed most of the
+reliability gap — our test suite shows 97.3% delivery rate on PWA vs 99.1%
+on native, and the delta is narrowing with each Safari release. On offline
+mode, Tom's data showed only 4% of sessions involve any offline usage, and
+those users average 2.1 minutes offline — too short for the complex sync
+engine Jessica's team built.
+
+The enterprise signaling concern deserves honest acknowledgment. Three of
+our twelve enterprise prospects specifically asked about native apps during
+sales calls. Our VP of Sales Rachel confirmed this. However, Rachel also
+noted that none of the three listed it as a dealbreaker — their actual
+requirements were biometric authentication (available via WebAuthn), MDM
+compatibility (achievable with managed browser profiles), and offline
+document viewing (which our PWA already supports for the read path). Rachel
+is comfortable repositioning the PWA as our mobile strategy for enterprise
+if we invest in those three capabilities.
+
+We considered a third option: using React Native or Capacitor to generate
+native wrappers around the PWA. Our architect Wei evaluated this over two
+weeks and concluded it would give us the app store presence without the
+maintenance burden, but would introduce a new layer of abstraction bugs.
+His recommendation was to go pure PWA and revisit native wrappers only if
+app store presence becomes a measurable acquisition channel — which it
+currently is not (app store organic discovery accounts for less than 2%
+of signups).
+
+The decision: sunset the native apps over 90 days, migrate the four mobile
+engineers to the web platform team, and invest the freed capacity into PWA
+enhancements (offline improvements, WebAuthn, MDM documentation). Jessica
+will lead the PWA mobile experience squad. We will revisit native if our
+enterprise pipeline data changes or if a specific high-value deal requires it.
+Dissent from Jessica is noted and respected — she has a standing invitation
+to trigger a re-evaluation if the PWA approach hits a wall she predicted.
+```
+
+### Fixture 3 — Strategy Decision: Switching from Per-Seat to Usage-Based Pricing
+
+> A pricing model pivot with finance, sales, and customer impact analysis.
+
+```
+After analyzing churn patterns for the past two quarters, we are moving
+Arclight from per-seat licensing ($45/user/month) to usage-based pricing
+tied to API calls and compute minutes. This is the most consequential
+business model change since launch and will affect every customer, every
+sales conversation, and our revenue forecasting models.
+
+The catalyst was losing four mid-market accounts in Q4, all citing the same
+reason: they were paying for 200+ seats but actual monthly active users
+averaged 60-80. Our per-seat model punished companies that wanted broad
+access but had variable usage patterns. Nadia from customer success
+interviewed all four churned accounts. Every one said they would have
+stayed on a usage model — they valued Arclight but couldn't justify the
+per-seat cost for dormant licenses. One account, DataForge (our third-largest
+customer at $108K ARR), explicitly said they'd return if we switched to
+usage pricing. Their CTO Kenji told Nadia: "We love the product. We hate
+paying for seats that open the dashboard once a month."
+
+Our CFO Martin modeled three scenarios. Scenario A (status quo): projected
+12% annual churn, $4.2M ARR by year-end. Scenario B (usage-based, current
+customer base): initial ARR drop to $3.6M as low-usage seats disappear
+from billing, but churn projected to fall to 5% because customers only pay
+for what they use — recovery to $4.8M ARR within 18 months as reduced
+friction drives expansion within accounts. Scenario C (hybrid — base
+platform fee plus usage): $3.9M starting ARR with similar churn reduction.
+Martin recommends Scenario B because it's simpler to explain, simpler to
+bill, and the 18-month recovery timeline is within our runway (we have
+26 months of cash at current burn).
+
+Lucas from sales raised a serious concern: usage-based pricing makes
+revenue less predictable, which hurts our ability to forecast and could
+complicate our Series B raise expected in Q3. He proposed committed-use
+discounts — customers who commit to a minimum monthly spend get a 20%
+discount on overages. This creates a predictability floor while preserving
+the usage-based flexibility. Martin agreed this was a good hybrid mechanism
+and incorporated it into the Scenario B model, which improved the 18-month
+projection to $5.1M ARR because committed-use contracts reduce uncertainty
+on both sides.
+
+Samira from engineering flagged implementation complexity. Our billing
+system was built for seat counting — it literally runs a SELECT COUNT(*)
+on active users at the end of each billing cycle. Moving to usage-based
+billing requires metering infrastructure: event collection, aggregation,
+rated billing, invoice line item detail, and usage dashboards so customers
+can monitor their spend. Samira estimated 8-10 weeks of engineering work
+with two engineers. She recommended Metronome as the billing engine rather
+than building in-house, which would cut the timeline to 4-5 weeks. The
+Metronome contract is $2,400/month — trivial against the revenue impact.
+
+We also considered keeping per-seat pricing but adding a lower tier.
+Research lead Vikram pointed out that most competitors (Segment, Datadog,
+Snowflake) have already moved to usage-based models and customers in our
+ICP expect it. Adding a cheaper per-seat tier wouldn't address the core
+complaint — companies don't want to count heads, they want to pay for
+outcomes. Vikram's competitive analysis showed that every company in our
+space that switched to usage pricing saw net revenue retention improve by
+15-25 percentage points within two years.
+
+The final decision: adopt Scenario B (pure usage-based) with Lucas's
+committed-use discount mechanism. Samira will lead the Metronome integration
+starting next sprint. Sales will begin positioning the change with existing
+customers in Month 1, migrate billing in Month 2, and enforce the new model
+for all accounts in Month 3. Martin will provide updated financial models
+weekly during the transition. Nadia will reach out to DataForge and the
+other three churned accounts with the new pricing. Success criteria: net
+revenue retention above 110% by month 6, and churn rate below 6%
+annualized by month 9. We will evaluate at the 6-month mark and have
+a pre-committed rollback plan if NRR drops below 95%.
+```
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR" /tmp/uat-decision-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Decision"
+echo ""
+
+# --- Preflight: OpenRouter key required for LLM pipeline ---
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping decision wiki-type UAT"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# --- Sign in ---
+SIGNIN_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+[ "$SIGNIN_HTTP" = "200" ] && pass "sign-in → 200" || fail "sign-in → HTTP $SIGNIN_HTTP"
+
+# --- Get MCP token ---
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL" ] || [ "$MCP_URL" = "null" ]; then
+  fail "mcpEndpointUrl not found in profile"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token acquired"
+
+# Helper: extract JSON from SSE "data:" line
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# --- 1. Seed wiki types ---
+SEED_HTTP=$(curl -s -o /tmp/uat-decision-seed.json -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify decision type exists
+LIST_HTTP=$(curl -s -o /tmp/uat-decision-types.json -w "%{http_code}" \
+  -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types")
+if [ "$LIST_HTTP" = "200" ]; then
+  HAS_DECISION=$(jq '[.wikiTypes[].slug] | any(. == "decision")' /tmp/uat-decision-types.json 2>/dev/null)
+  [ "$HAS_DECISION" = "true" ] && pass "decision wiki type present after seed" || fail "decision wiki type missing"
+else
+  fail "GET /wiki-types → HTTP $LIST_HTTP"
+fi
+
+# --- 2. Create 3 decision wikis via REST ---
+WIKI_KEYS=()
+WIKI_SLUGS=()
+
+create_decision_wiki() {
+  local name="$1"
+  local result
+  result=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"$name\",\"type\":\"decision\",\"prompt\":\"\"}" \
+    "$SERVER_URL/wikis")
+  local http=$(echo "$result" | tail -1)
+  local body=$(echo "$result" | sed '$d')
+  local key=$(echo "$body" | jq -r '.lookupKey // .id // ""')
+  local slug=$(echo "$body" | jq -r '.slug // ""')
+
+  if [ "$http" = "201" ] && [ -n "$key" ] && [ "$key" != "null" ]; then
+    pass "POST /wikis → 201 ($name), key=$key"
+    WIKI_KEYS+=("$key")
+    WIKI_SLUGS+=("$slug")
+  else
+    fail "POST /wikis → HTTP $http ($name)"
+  fi
+}
+
+create_decision_wiki "Event Sourcing vs CRUD for Orders"
+create_decision_wiki "Abandoning the Native Mobile App"
+create_decision_wiki "Usage-Based Pricing Switch"
+
+if [ "${#WIKI_KEYS[@]}" -lt 3 ]; then
+  fail "expected 3 wikis, created ${#WIKI_KEYS[@]} — aborting"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# Verify all 3 have type=decision
+for i in 0 1 2; do
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  TYPE=$(echo "$DETAIL" | jq -r '.type // ""')
+  [ "$TYPE" = "decision" ] && pass "wiki $i type=decision" || fail "wiki $i type=$TYPE (expected decision)"
+done
+
+# --- 3. Submit 3 entries via MCP log_entry ---
+# Each entry is a realistic decision-record text.
+
+FIXTURE_1='We need to decide on the persistence strategy for the new order management system that will replace the legacy monolith order module. The current system uses a single PostgreSQL table with mutable rows — when an order changes status, the row is updated in place. This has caused three production incidents in the past quarter where audit trails were lost, customer support could not reconstruct what happened to an order, and our analytics pipeline produced incorrect conversion metrics because intermediate states were invisible. Marcus from platform engineering proposed event sourcing: every state change becomes an immutable event appended to a log, and the current state is derived by replaying events. He demonstrated a prototype using EventStoreDB that handled our peak load (roughly 2,400 orders per minute during flash sales) with p99 latency under 12ms. The approach gives us a complete audit trail for free, enables temporal queries, and makes it straightforward to build new read models without touching the write path. Priya from the data team was initially skeptical about eventual consistency — our current system serves real-time inventory counts from the same table. After testing the prototype, the lag was consistently under 200ms, which Priya agreed was acceptable. Chen from frontend engineering raised debugging concerns. With CRUD, you can inspect a row and see the current state. With event sourcing, you need tooling to replay events. Marcus committed to building a developer console that shows the event timeline for any aggregate. The CTO Dana suggested a hybrid approach: keep CRUD but add an event log table. Marcus argued this creates a consistency problem and showed a real example from the Q3 incident where exactly this kind of drift occurred. The team decided on full event sourcing with EventStoreDB. The migration will happen in three phases with rollback plans at each stage. Marcus and Priya will co-own the implementation. The decision was unanimous after the prototype demonstration addressed all concerns.'
+
+FIXTURE_2='After eighteen months of development and three beta releases, we have decided to discontinue the native iOS and Android apps for Meridian and go all-in on the progressive web app. The data forced our hand: 73 percent of our mobile users access Meridian through the mobile browser, not the native app. Of the 27 percent who installed the native app, daily active usage dropped 40 percent after the first week. Tom from product analytics presented a cohort analysis showing PWA users had 2.3x higher 90-day retention than native app users. Jessica from mobile engineering pushed back strongly, arguing push notifications on iOS still require a native app for reliability, the native offline mode is superior, and abandoning native signals to enterprise customers that we are not serious. Rafael confirmed iOS 17.4 Web Push improvements have closed most of the reliability gap at 97.3 percent delivery rate on PWA vs 99.1 percent on native. Tom showed only 4 percent of sessions involve offline usage. Rachel from sales confirmed three enterprise prospects asked about native apps but none listed it as a dealbreaker — their actual requirements were biometric authentication via WebAuthn, MDM compatibility, and offline document viewing, all achievable on PWA. Wei evaluated React Native wrappers and concluded they would introduce abstraction bugs without meaningful benefit since app store organic discovery accounts for less than 2 percent of signups. The decision: sunset native apps over 90 days, migrate four mobile engineers to the web platform team, invest freed capacity into PWA enhancements. Jessica will lead the PWA mobile experience squad with a standing invitation to trigger re-evaluation if the approach hits a wall she predicted.'
+
+FIXTURE_3='After analyzing churn patterns for two quarters, we are moving Arclight from per-seat licensing at 45 dollars per user per month to usage-based pricing tied to API calls and compute minutes. The catalyst was losing four mid-market accounts in Q4, all citing the same reason: paying for 200-plus seats but actual monthly active users averaged 60-80. Nadia from customer success interviewed all four churned accounts and every one said they would have stayed on a usage model. DataForge, our third-largest customer at 108K ARR, explicitly said they would return. CFO Martin modeled three scenarios: status quo projecting 12 percent annual churn at 4.2M ARR, usage-based with initial drop to 3.6M but recovery to 4.8M within 18 months as churn falls to 5 percent, and a hybrid base-plus-usage at 3.9M. Martin recommends pure usage-based because it is simpler to explain and bill. Lucas from sales raised revenue predictability concerns and proposed committed-use discounts — customers committing to minimum monthly spend get 20 percent off overages. Martin agreed and the improved model projects 5.1M ARR at 18 months. Samira from engineering estimated 8-10 weeks for metering infrastructure but recommended Metronome as billing engine to cut timeline to 4-5 weeks at 2,400 dollars per month. Vikram from research noted competitors like Segment, Datadog, and Snowflake have already moved to usage-based pricing and saw 15-25 percentage point NRR improvements. The decision: adopt pure usage-based with committed-use discounts. Samira leads Metronome integration next sprint. Success criteria: net revenue retention above 110 percent by month 6 and churn below 6 percent annualized by month 9 with a pre-committed rollback plan if NRR drops below 95 percent.'
+
+ENTRY_IDS=()
+
+submit_entry() {
+  local content="$1"
+  local label="$2"
+  local result
+  result=$(curl -s --max-time 15 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"log_entry\",\"arguments\":{\"content\":$(echo "$content" | jq -Rs .),\"source\":\"uat\"}}}" \
+    "$MCP_URL" 2>/dev/null)
+  local resp=$(echo "$result" | parse_sse)
+
+  if echo "$resp" | jq -e '.result' >/dev/null 2>&1; then
+    local text=$(echo "$resp" | jq -r '.result.content[0].text // ""')
+    local entry_key=$(echo "$text" | grep -oP 'entry[0-9A-Z]{26}' || echo "")
+    if [ -n "$entry_key" ]; then
+      ENTRY_IDS+=("$entry_key")
+      pass "MCP log_entry ($label) → $entry_key"
+    else
+      pass "MCP log_entry ($label) → response OK (no key extracted)"
+      ENTRY_IDS+=("unknown")
+    fi
+  else
+    local is_error=$(echo "$resp" | jq -r '.result.isError // false' 2>/dev/null)
+    if [ "$is_error" = "true" ]; then
+      fail "MCP log_entry ($label) → error: $(echo "$resp" | jq -r '.result.content[0].text // "unknown"')"
+    else
+      fail "MCP log_entry ($label) → unexpected response: ${resp:0:200}"
+    fi
+  fi
+}
+
+submit_entry "$FIXTURE_1" "event-sourcing"
+submit_entry "$FIXTURE_2" "native-app-sunset"
+submit_entry "$FIXTURE_3" "usage-pricing"
+
+echo ""
+
+# --- 4. Poll until entries are processed (max 360s) ---
+echo "  ⟳ polling entry ingest status (max 360s)..."
+
+ENTRIES_DONE=0
+ELAPSED=0
+MAX_WAIT=360
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $ENTRIES_DONE -lt ${#ENTRY_IDS[@]} ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  ENTRIES_DONE=0
+
+  for eid in "${ENTRY_IDS[@]}"; do
+    [ "$eid" = "unknown" ] && { ENTRIES_DONE=$((ENTRIES_DONE + 1)); continue; }
+    STATUS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$eid" 2>/dev/null | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ] || [ "$STATUS" = "failed" ]; then
+      ENTRIES_DONE=$((ENTRIES_DONE + 1))
+    fi
+  done
+
+  echo "    ${ELAPSED}s — $ENTRIES_DONE/${#ENTRY_IDS[@]} entries terminal"
+done
+
+if [ $ENTRIES_DONE -ge ${#ENTRY_IDS[@]} ]; then
+  pass "all ${#ENTRY_IDS[@]} entries reached terminal state in ${ELAPSED}s"
+else
+  fail "only $ENTRIES_DONE/${#ENTRY_IDS[@]} entries finished after ${MAX_WAIT}s"
+fi
+
+# Report per-entry final status
+for eid in "${ENTRY_IDS[@]}"; do
+  [ "$eid" = "unknown" ] && continue
+  FINAL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/entries/$eid" 2>/dev/null | jq -r '.ingestStatus // .state // "unknown"')
+  if [ "$FINAL" = "processed" ] || [ "$FINAL" = "RESOLVED" ]; then
+    pass "entry $eid → $FINAL"
+  else
+    fail "entry $eid → $FINAL"
+  fi
+done
+
+echo ""
+
+# --- 5. Report fragments ---
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created ($FRAG_COUNT total)"
+  echo "    fragment titles:"
+  echo "$FRAGS" | jq -r '.fragments[:10][] | "      - \(.title // .slug)"' 2>/dev/null
+else
+  fail "no fragments found after pipeline"
+fi
+
+echo ""
+
+# --- 6. Report people ---
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people?limit=100")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT total)"
+  echo "    people:"
+  echo "$PEOPLE" | jq -r '.people[:15][] | "      - \(.name // .canonicalName)"' 2>/dev/null
+else
+  skip "no people extracted (may be expected if entity extraction is disabled)"
+fi
+
+echo ""
+
+# --- 7. Report edges ---
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has edges ($EDGE_COUNT edges, $NODE_COUNT nodes)"
+
+  # Break down edge types
+  echo "    edge type breakdown:"
+  echo "$GRAPH" | jq -r '[.edges[].edgeType] | group_by(.) | map({type: .[0], count: length}) | .[] | "      - \(.type): \(.count)"' 2>/dev/null
+else
+  fail "no edges in graph after pipeline"
+fi
+
+echo ""
+
+# --- 8. Trigger regen on each decision wiki ---
+for i in 0 1 2; do
+  WIKI_KEY="${WIKI_KEYS[$i]}"
+
+  # Enable regen if disabled
+  curl -s -o /dev/null -X PATCH \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/$WIKI_KEY/regenerate"
+
+  REGEN_HTTP=$(curl -s -o /tmp/uat-decision-regen-$i.json -w "%{http_code}" \
+    -X POST -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$WIKI_KEY/regenerate")
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    REGEN_FRAGS=$(jq '.fragmentCount // 0' /tmp/uat-decision-regen-$i.json 2>/dev/null)
+    pass "POST /wikis/$WIKI_KEY/regenerate → 200 ($REGEN_FRAGS fragments)"
+  elif [ "$REGEN_HTTP" = "400" ]; then
+    # Regen disabled or no fragments linked — not a test failure, report it
+    REGEN_ERR=$(jq -r '.error // "unknown"' /tmp/uat-decision-regen-$i.json 2>/dev/null)
+    skip "regen wiki $i → 400: $REGEN_ERR"
+  elif [ "$REGEN_HTTP" = "500" ]; then
+    REGEN_ERR=$(jq -r '.error // .detail // "unknown"' /tmp/uat-decision-regen-$i.json 2>/dev/null)
+    fail "regen wiki $i → 500: $REGEN_ERR"
+  else
+    fail "regen wiki $i → HTTP $REGEN_HTTP"
+  fi
+done
+
+echo ""
+
+# --- 9. Report final wiki state ---
+echo "  --- Final Wiki State ---"
+for i in 0 1 2; do
+  WIKI_KEY="${WIKI_KEYS[$i]}"
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$WIKI_KEY")
+
+  WIKI_NAME=$(echo "$DETAIL" | jq -r '.name // "?"')
+  WIKI_TYPE=$(echo "$DETAIL" | jq -r '.type // "?"')
+  WIKI_STATE=$(echo "$DETAIL" | jq -r '.state // "?"')
+  WIKI_REBUILT=$(echo "$DETAIL" | jq -r '.lastRebuiltAt // "never"')
+  CONTENT_LEN=$(echo "$DETAIL" | jq -r '.content // ""' | wc -c)
+
+  echo "    [$i] $WIKI_NAME"
+  echo "        type=$WIKI_TYPE  state=$WIKI_STATE  rebuilt=$WIKI_REBUILT  content=${CONTENT_LEN} chars"
+
+  # Validate type stayed decision
+  [ "$WIKI_TYPE" = "decision" ] && pass "wiki $i final type=decision" || fail "wiki $i final type=$WIKI_TYPE"
+
+  # Check content was generated (if regen ran)
+  if [ "$CONTENT_LEN" -gt 50 ] 2>/dev/null; then
+    pass "wiki $i has generated content ($CONTENT_LEN chars)"
+
+    # Verify decision document structure (look for expected section headers)
+    HAS_DECISION_HEADER=$(echo "$DETAIL" | jq -r '.content // ""' | grep -ci 'decision\|the decision\|what was decided' || true)
+    HAS_CONTEXT=$(echo "$DETAIL" | jq -r '.content // ""' | grep -ci 'context' || true)
+    HAS_ALTERNATIVES=$(echo "$DETAIL" | jq -r '.content // ""' | grep -ci 'alternative' || true)
+
+    if [ "$HAS_DECISION_HEADER" -gt 0 ] && [ "$HAS_CONTEXT" -gt 0 ]; then
+      pass "wiki $i has decision document structure"
+    else
+      skip "wiki $i content does not match expected decision structure (may vary by LLM)"
+    fi
+  else
+    skip "wiki $i has no/minimal content (regen may not have linked fragments)"
+  fi
+  echo ""
+done
+
+# --- 10. Cleanup: delete test wikis ---
+echo "  --- Cleanup ---"
+for i in 0 1 2; do
+  DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "200" ]; then
+    pass "cleanup: deleted wiki $i"
+  else
+    skip "cleanup: wiki $i delete → HTTP $DEL_HTTP"
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```

--- a/.uat/plans/wiki-types/wiki-objective.md
+++ b/.uat/plans/wiki-types/wiki-objective.md
@@ -1,0 +1,550 @@
+# Wiki Type UAT — Objective
+
+## What it proves
+End-to-end objective wiki lifecycle: create 3 objective-typed wikis, ingest
+realistic OKR/strategic-objective content via MCP `log_entry`, poll until
+the pipeline extracts fragments and people, verify edges, trigger wiki
+regeneration, and confirm the generated wiki content follows the objective
+document structure (The Objective, Key Results, Progress, Course Corrections).
+
+## Prerequisites
+- `OPENROUTER_API_KEY` set (LLM calls for extraction + wiki generation)
+- Server running at `SERVER_URL` (default `http://localhost:3000`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` seeded
+
+## Fixtures
+
+### Fixture 1 — Q3 Revenue Growth Objective (company-level OKR)
+
+> We set the Q3 revenue growth objective in the June leadership offsite after
+> reviewing the first half results. Net revenue retention had been hovering at
+> 105% for four consecutive quarters, and the board wanted to see us push past
+> 115% before the Series C raise. Marcus Huang, our VP of Sales, presented
+> analysis showing that our largest accounts were expanding at 12% annualized
+> but mid-market accounts were nearly flat. He argued that the biggest lever
+> was not new logos but upsell motion within the existing mid-market segment.
+>
+> The objective we landed on: "Accelerate net revenue retention to fund
+> Series C at a position of strength." We defined three key results. KR1:
+> increase net revenue retention from 105% to 118% by end of Q3. KR2: grow
+> average mid-market account expansion rate from 3% to 10% quarter-over-quarter.
+> KR3: close at least 8 upsell deals above $50K ACV within the mid-market
+> cohort. Elena Vasquez from Customer Success flagged that churn in the
+> mid-market was running at 4% monthly, so any upsell gains would be offset
+> unless we simultaneously reduced churn. We added a health metric: keep
+> mid-market gross churn below 2% monthly throughout Q3.
+>
+> By mid-July, the early signals were mixed. Marcus reported that the sales
+> team had closed 3 of the 8 target upsell deals, but the average deal size
+> was $38K rather than the $50K threshold. Elena's team had reduced churn to
+> 2.8% through a dedicated onboarding sprint for the 40 highest-risk accounts.
+> NRR had ticked up to 109%, which was progress but well short of the 118%
+> target.
+>
+> In the August check-in, Marcus proposed a course correction: bundle the
+> analytics add-on with the core platform at a 20% discount for annual
+> commitments. This had worked in enterprise but had never been tested
+> mid-market. The CFO, Priya Sharma, was skeptical about margin impact but
+> agreed to a 30-day pilot with 15 accounts. By end of August, 11 of the 15
+> pilot accounts converted, with an average upsell of $62K. That single
+> motion moved the upsell count from 5 to 16 (exceeding KR3) and pushed NRR
+> to 114%.
+>
+> At the Q3 close, final numbers were: NRR 114% (missed the 118% target but
+> a 9-point jump from baseline), mid-market expansion rate at 8.5% (short of
+> 10% but a near-triple from 3%), upsell deals closed at 16 (doubled the
+> target), and mid-market churn at 2.1% (just above the 2% guardrail). The
+> board considered this a strong enough trajectory to proceed with Series C
+> diligence.
+>
+> In the post-quarter retro, Marcus and Elena jointly presented the lessons
+> learned. The bundling motion was clearly the breakout tactic and should have
+> been tested in Q2 rather than waiting until August. Elena emphasized that
+> the onboarding sprint, while not directly tied to a key result, was the
+> enabling condition for the upsell motion — accounts that went through
+> the sprint had 3x higher conversion on the bundle offer. Priya noted
+> that the bundle's margin impact was actually positive because annual
+> commitments reduced payment processing costs and improved cash flow
+> predictability. The CFO team modeled the bundle at scale and projected
+> an incremental $2.4M ARR contribution if extended to the full mid-market
+> cohort. For Q4, Marcus is proposing we formalize the bundle as a permanent
+> SKU, extend the playbook to the SMB segment, and hire two dedicated
+> expansion account executives to run the motion full-time. Elena wants
+> to make the onboarding sprint a standard part of the customer lifecycle
+> rather than a reactive churn-prevention measure.
+
+### Fixture 2 — Platform Reliability Objective (engineering OKR)
+
+> This quarter the engineering leadership — CTO Amara Osei and VP Engineering
+> David Chen — set a reliability objective after the April incident review
+> revealed that we had 14 Sev-1 incidents in Q2, each costing an average of
+> $23K in SLA credits and an estimated 340 engineering hours in firefighting.
+> The P99 latency for our core API had crept from 180ms to 420ms over six
+> months as feature work took priority over infrastructure.
+>
+> The objective: "Make the platform rock-solid so customers stop worrying
+> about reliability and start trusting us for mission-critical workflows."
+> The key results: KR1: reduce Sev-1 incidents from 14/quarter to fewer
+> than 3. KR2: bring P99 API latency below 200ms. KR3: achieve 99.95%
+> uptime (measured externally by Datadog synthetic monitors). KR4: reduce
+> mean time to recovery (MTTR) from 47 minutes to under 15 minutes.
+>
+> David allocated a dedicated reliability squad of 4 engineers: Tomoko
+> Ishikawa (SRE lead), Rashid Al-Farsi (backend), Lin Wei (observability),
+> and Jakub Nowak (database). In the first two weeks, Tomoko led a
+> dependency audit and discovered that 9 of the 14 Sev-1 incidents traced
+> back to two root causes: an unbounded query in the analytics aggregation
+> pipeline and a connection pool exhaustion pattern in the payment service.
+>
+> By mid-quarter, the squad had shipped three changes: (1) query pagination
+> with cursor-based limits on the analytics pipeline, reducing its worst-case
+> execution from 12 seconds to 180ms; (2) connection pool resizing with
+> circuit breakers on the payment service; and (3) structured alerting rules
+> in PagerDuty that cut MTTR from 47 to 22 minutes. Sev-1 count for the
+> first 6 weeks was 1 incident (a DNS propagation issue outside our control).
+>
+> Rashid identified a further optimization: moving the heaviest read path
+> (dashboard summary) to a materialized view refreshed every 60 seconds. This
+> dropped P99 from 420ms to 165ms — overshooting the 200ms target. Lin set up
+> a public status page backed by Datadog synthetics showing real-time uptime.
+> Through the first 10 weeks, uptime measured 99.97%.
+>
+> At the end-of-quarter review, final numbers: Sev-1 incidents = 2 (DNS
+> issue + one deploy rollback caught in canary — both under 10 minutes), P99
+> latency = 165ms, uptime = 99.96%, MTTR = 11 minutes. All four KRs met or
+> exceeded. Amara noted that the reliability squad model worked because it
+> had dedicated headcount and explicit permission to say no to feature
+> requests. David is proposing to make the squad permanent and rotate
+> membership quarterly. The SLA credit spend dropped from $322K annualized
+> to under $40K projected, which Finance flagged as a material margin
+> improvement. Jakub recommended investing next quarter in chaos engineering
+> (GameDay exercises) to proactively find failure modes rather than waiting
+> for incidents.
+>
+> In the retrospective, the team identified several structural takeaways.
+> First, the root-cause concentration was striking — two bugs caused 64% of
+> all Sev-1 incidents, which meant the highest-ROI reliability work was
+> targeted debugging rather than broad infrastructure investment. Second,
+> the materialized view pattern that Rashid introduced is now being adopted
+> by two other teams (billing and reporting) for their own heavy read paths.
+> Lin Wei's observability work produced a side benefit: the structured
+> alerting rules surfaced 3 near-miss incidents that would have escalated
+> to Sev-1 under the old system, effectively preventing future outages.
+> Tomoko estimated that the squad's work will save approximately 1,200
+> engineering hours per year in incident response alone. David is drafting
+> a proposal to rotate one engineer from each product team through the
+> reliability squad on a quarterly basis, both to spread knowledge and
+> to ensure the squad stays connected to real product workloads. Amara
+> wants the chaos engineering initiative to start with a tabletop exercise
+> in the first two weeks of next quarter before moving to automated fault
+> injection in week four.
+
+### Fixture 3 — Personal Career Growth Objective (individual OKR)
+
+> I set this objective for myself at the start of the year after my skip-level
+> with VP Engineering Rosa Martinez. Rosa told me that the gap between my
+> current Senior Engineer role and the Staff Engineer promotion wasn't
+> technical depth — she said my systems design and code quality were already
+> at staff level. The gap was influence: I needed to demonstrate that I could
+> drive outcomes beyond my immediate team, mentor others effectively, and
+> shape technical direction across the organization.
+>
+> My objective: "Expand my engineering influence beyond my team to
+> demonstrate staff-level impact." I defined four key results. KR1: author
+> and get approval for 2 cross-team RFCs that ship to production. KR2:
+> mentor 3 engineers and have at least 2 of them complete a stretch project.
+> KR3: present at 2 internal tech talks with an average audience rating of
+> 4.0+/5.0. KR4: receive "strong" or "exceeds" on the influence dimension
+> in the next 360 review.
+>
+> For KR1, I identified two areas where cross-team alignment was weak: our
+> API versioning strategy (which had caused 3 breaking changes in the last
+> year) and our approach to feature flags (every team had a different
+> implementation). I drafted RFC-0047: Unified API Versioning Strategy in
+> February and circulated it to the platform, payments, and growth teams.
+> James Okonkwo from the platform team pushed back on my header-based
+> versioning proposal, arguing that URL-path versioning was simpler for
+> external consumers. We went through two rounds of revision and landed on
+> a hybrid approach: URL-path for major versions, header-based for minor.
+> The RFC was approved in March and the platform team shipped the versioning
+> middleware by end of April.
+>
+> My second RFC — RFC-0052: Centralized Feature Flag Service — took longer.
+> I interviewed 6 team leads to understand their requirements, and the scope
+> kept expanding. Nadia Petrov from the data team wanted analytics
+> integration, while Leo Chang from mobile needed offline flag evaluation.
+> I scoped the RFC to the core service and explicitly deferred those
+> extensions to follow-up RFCs. Approved in May, implementation started
+> in June with a target ship date of end of Q3.
+>
+> For KR2, I started mentoring three engineers: Aisha Patel (mid-level,
+> backend), Soren Lindqvist (mid-level, frontend), and Maya Torres (junior,
+> full-stack). Aisha's stretch project was leading the migration of our
+> notification service from polling to WebSockets — she shipped it in April
+> with a 60% reduction in notification latency. Soren took on building the
+> new design system component library; he's on track to ship v1 by end of
+> Q2. Maya's stretch project is smaller scope — building the internal CLI
+> tool for database migrations — and she's making steady progress with
+> weekly pairing sessions.
+>
+> For KR3, I gave my first tech talk in March on "Lessons from 3 Years of
+> Event-Driven Architecture" to about 45 engineers. The feedback survey
+> averaged 4.3/5.0 with comments praising the real-world failure examples.
+> My second talk is scheduled for July on the API versioning RFC journey.
+>
+> Mid-year check-in with Rosa went well. She said the RFC work was exactly
+> the kind of influence signal the promotion committee looks for, and the
+> mentoring outcomes (especially Aisha's WebSocket migration) demonstrated
+> multiplier effect. She flagged one gap: I hadn't yet contributed to
+> hiring — she suggested I join the interview panel for the Staff SRE role
+> to round out my profile. I've since done 4 technical interviews and
+> written detailed scorecards for each. The 360 review cycle is in
+> September; I'm cautiously optimistic about KR4 based on the informal
+> feedback I've received from peers on the platform and growth teams.
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Objective"
+echo ""
+
+# Guard: OPENROUTER_API_KEY required for LLM pipeline
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping objective wiki UAT"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── Sign in ───────────────────────────────────────────────────────────
+curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" >/dev/null
+
+# ── Get MCP token ─────────────────────────────────────────────────────
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL" ] || [ "$MCP_URL" = "null" ]; then
+  fail "mcpEndpointUrl not available — cannot run MCP tests"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token acquired"
+
+# Helper: SSE data-line parser
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# Helper: MCP JSON-RPC call
+mcp_call() {
+  local id="$1" method="$2" params="$3"
+  curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}" \
+    "$MCP_URL" 2>/dev/null | parse_sse
+}
+
+# ── MCP initialize ────────────────────────────────────────────────────
+INIT_RESP=$(mcp_call 1 "initialize" '{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-objective","version":"1.0"}}')
+if echo "$INIT_RESP" | jq -e '.result' >/dev/null 2>&1; then
+  pass "MCP initialized"
+else
+  fail "MCP initialize failed: ${INIT_RESP:0:200}"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── 1. Seed wiki types ────────────────────────────────────────────────
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify objective type exists
+OBJ_TYPE_HTTP=$(curl -s -o /tmp/uat-obj-type.json -w "%{http_code}" \
+  -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/objective")
+if [ "$OBJ_TYPE_HTTP" = "200" ]; then
+  OBJ_LABEL=$(jq -r '.displayLabel // .name // ""' /tmp/uat-obj-type.json 2>/dev/null)
+  pass "objective wiki type exists (label=$OBJ_LABEL)"
+else
+  fail "GET /wiki-types/objective → HTTP $OBJ_TYPE_HTTP"
+fi
+
+# ── 2. Create 3 objective wikis ──────────────────────────────────────
+declare -a WIKI_KEYS=()
+declare -a WIKI_SLUGS=()
+WIKI_NAMES=("Q3 Revenue Growth" "Platform Reliability" "Staff Engineer Promotion")
+
+for i in 0 1 2; do
+  CREATE=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"${WIKI_NAMES[$i]}\",\"type\":\"objective\"}" \
+    "$SERVER_URL/wikis")
+  CREATE_HTTP=$(echo "$CREATE" | tail -1)
+  CREATE_BODY=$(echo "$CREATE" | sed '$d')
+  WK=$(echo "$CREATE_BODY" | jq -r '.lookupKey // .id // ""')
+  WS=$(echo "$CREATE_BODY" | jq -r '.slug // ""')
+
+  if [ "$CREATE_HTTP" = "201" ] && [ -n "$WK" ]; then
+    WIKI_KEYS+=("$WK")
+    WIKI_SLUGS+=("$WS")
+    pass "created wiki '${WIKI_NAMES[$i]}' → $WS (type=objective)"
+  else
+    fail "create wiki '${WIKI_NAMES[$i]}' → HTTP $CREATE_HTTP"
+    WIKI_KEYS+=("")
+    WIKI_SLUGS+=("")
+  fi
+done
+
+# Verify all three are type=objective
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  WTYPE=$(echo "$DETAIL" | jq -r '.type // ""')
+  [ "$WTYPE" = "objective" ] && pass "'${WIKI_NAMES[$i]}' type confirmed objective" || fail "'${WIKI_NAMES[$i]}' type is $WTYPE (expected objective)"
+done
+
+# ── 3. Submit 3 entries via MCP log_entry ─────────────────────────────
+# Each fixture maps to one of the wikis above. The pipeline should extract
+# fragments and route them. We submit via MCP to test the full ingest path.
+
+read -r -d '' FIXTURE_1 << 'FIXTURE_EOF'
+We set the Q3 revenue growth objective in the June leadership offsite after reviewing the first half results. Net revenue retention had been hovering at 105% for four consecutive quarters, and the board wanted to see us push past 115% before the Series C raise. Marcus Huang, our VP of Sales, presented analysis showing that our largest accounts were expanding at 12% annualized but mid-market accounts were nearly flat. He argued that the biggest lever was not new logos but upsell motion within the existing mid-market segment. The objective we landed on: accelerate net revenue retention to fund Series C at a position of strength. We defined three key results. KR1: increase net revenue retention from 105% to 118% by end of Q3. KR2: grow average mid-market account expansion rate from 3% to 10% quarter-over-quarter. KR3: close at least 8 upsell deals above 50K ACV within the mid-market cohort. Elena Vasquez from Customer Success flagged that churn in the mid-market was running at 4% monthly, so any upsell gains would be offset unless we simultaneously reduced churn. We added a health metric: keep mid-market gross churn below 2% monthly throughout Q3. By mid-July, the early signals were mixed. Marcus reported that the sales team had closed 3 of the 8 target upsell deals, but the average deal size was 38K rather than the 50K threshold. Elenas team had reduced churn to 2.8% through a dedicated onboarding sprint for the 40 highest-risk accounts. NRR had ticked up to 109%, which was progress but well short of the 118% target. In the August check-in, Marcus proposed a course correction: bundle the analytics add-on with the core platform at a 20% discount for annual commitments. The CFO Priya Sharma was skeptical about margin impact but agreed to a 30-day pilot with 15 accounts. By end of August, 11 of the 15 pilot accounts converted, with an average upsell of 62K. That single motion moved the upsell count from 5 to 16, exceeding KR3, and pushed NRR to 114%. At the Q3 close, final numbers were: NRR 114% (missed the 118% target but a 9-point jump from baseline), mid-market expansion rate at 8.5% (short of 10% but a near-triple from 3%), upsell deals closed at 16 (doubled the target), and mid-market churn at 2.1%. In the post-quarter retro, Marcus and Elena jointly presented the lessons learned. The bundling motion was clearly the breakout tactic and should have been tested in Q2 rather than waiting until August. Elena emphasized that the onboarding sprint, while not directly tied to a key result, was the enabling condition for the upsell motion as accounts that went through the sprint had 3x higher conversion on the bundle offer. Priya noted that the bundles margin impact was actually positive because annual commitments reduced payment processing costs and improved cash flow predictability. The CFO team modeled the bundle at scale and projected an incremental 2.4M ARR contribution if extended to the full mid-market cohort. For Q4, Marcus is proposing we formalize the bundle as a permanent SKU, extend the playbook to the SMB segment, and hire two dedicated expansion account executives to run the motion full-time. Elena wants to make the onboarding sprint a standard part of the customer lifecycle rather than a reactive churn-prevention measure.
+FIXTURE_EOF
+
+read -r -d '' FIXTURE_2 << 'FIXTURE_EOF'
+This quarter the engineering leadership set a reliability objective after the April incident review revealed that we had 14 Sev-1 incidents in Q2, each costing an average of 23K in SLA credits and an estimated 340 engineering hours in firefighting. CTO Amara Osei and VP Engineering David Chen led the effort. The P99 latency for our core API had crept from 180ms to 420ms over six months as feature work took priority over infrastructure. The objective: make the platform rock-solid so customers stop worrying about reliability and start trusting us for mission-critical workflows. The key results: KR1 reduce Sev-1 incidents from 14 per quarter to fewer than 3. KR2 bring P99 API latency below 200ms. KR3 achieve 99.95% uptime measured externally by Datadog synthetic monitors. KR4 reduce mean time to recovery from 47 minutes to under 15 minutes. David allocated a dedicated reliability squad of 4 engineers: Tomoko Ishikawa as SRE lead, Rashid Al-Farsi on backend, Lin Wei on observability, and Jakub Nowak on database. In the first two weeks, Tomoko led a dependency audit and discovered that 9 of the 14 Sev-1 incidents traced back to two root causes: an unbounded query in the analytics aggregation pipeline and a connection pool exhaustion pattern in the payment service. By mid-quarter, the squad shipped three changes: query pagination with cursor-based limits reducing worst-case execution from 12 seconds to 180ms, connection pool resizing with circuit breakers on the payment service, and structured alerting rules in PagerDuty that cut MTTR from 47 to 22 minutes. Sev-1 count for the first 6 weeks was 1 incident, a DNS propagation issue outside our control. Rashid identified a further optimization: moving the heaviest read path to a materialized view refreshed every 60 seconds, dropping P99 from 420ms to 165ms. Lin set up a public status page backed by Datadog synthetics showing real-time uptime. Through the first 10 weeks, uptime measured 99.97%. At the end-of-quarter review, final numbers: Sev-1 incidents equals 2 (DNS issue plus one deploy rollback caught in canary, both under 10 minutes), P99 latency equals 165ms, uptime equals 99.96%, MTTR equals 11 minutes. All four KRs met or exceeded. Amara noted that the reliability squad model worked because it had dedicated headcount and explicit permission to say no to feature requests. David is proposing to make the squad permanent and rotate membership quarterly. The SLA credit spend dropped from 322K annualized to under 40K projected, which Finance flagged as a material margin improvement. Jakub recommended investing next quarter in chaos engineering GameDay exercises to proactively find failure modes. In the retrospective, the team identified several structural takeaways. First, the root-cause concentration was striking: two bugs caused 64% of all Sev-1 incidents, which meant the highest-ROI reliability work was targeted debugging rather than broad infrastructure investment. Second, the materialized view pattern that Rashid introduced is now being adopted by two other teams (billing and reporting) for their own heavy read paths. Lin Weis observability work produced a side benefit: the structured alerting rules surfaced 3 near-miss incidents that would have escalated to Sev-1 under the old system, effectively preventing future outages. Tomoko estimated that the squads work will save approximately 1200 engineering hours per year in incident response alone.
+FIXTURE_EOF
+
+read -r -d '' FIXTURE_3 << 'FIXTURE_EOF'
+I set this career growth objective after my skip-level with VP Engineering Rosa Martinez. Rosa told me that the gap between my current Senior Engineer role and the Staff Engineer promotion was not technical depth but influence: I needed to demonstrate that I could drive outcomes beyond my immediate team, mentor others effectively, and shape technical direction across the organization. My objective: expand my engineering influence beyond my team to demonstrate staff-level impact. I defined four key results. KR1: author and get approval for 2 cross-team RFCs that ship to production. KR2: mentor 3 engineers and have at least 2 of them complete a stretch project. KR3: present at 2 internal tech talks with an average audience rating of 4.0 or higher out of 5.0. KR4: receive strong or exceeds on the influence dimension in the next 360 review. For KR1, I identified two areas where cross-team alignment was weak: our API versioning strategy which had caused 3 breaking changes in the last year, and our approach to feature flags where every team had a different implementation. I drafted RFC-0047 Unified API Versioning Strategy in February and circulated it to the platform, payments, and growth teams. James Okonkwo from the platform team pushed back on my header-based versioning proposal, arguing that URL-path versioning was simpler for external consumers. We went through two rounds of revision and landed on a hybrid approach. The RFC was approved in March and the platform team shipped the versioning middleware by end of April. My second RFC, RFC-0052 Centralized Feature Flag Service, took longer. I interviewed 6 team leads to understand their requirements. Nadia Petrov from the data team wanted analytics integration, while Leo Chang from mobile needed offline flag evaluation. Approved in May, implementation started in June. For KR2, I started mentoring three engineers: Aisha Patel on backend, Soren Lindqvist on frontend, and Maya Torres full-stack. Aishas stretch project was leading the migration of our notification service from polling to WebSockets and she shipped it in April with a 60% reduction in notification latency. Soren took on building the new design system component library. For KR3, I gave my first tech talk in March on Lessons from 3 Years of Event-Driven Architecture to about 45 engineers. The feedback survey averaged 4.3 out of 5.0. My second talk is scheduled for July on the API versioning RFC journey. Mid-year check-in with Rosa went well. She said the RFC work was exactly the kind of influence signal the promotion committee looks for, and the mentoring outcomes especially Aishas WebSocket migration demonstrated multiplier effect. She flagged one gap: I had not yet contributed to hiring. She suggested I join the interview panel for the Staff SRE role to round out my profile. I have since done 4 technical interviews and written detailed scorecards for each. The 360 review cycle is in September and I am cautiously optimistic about KR4 based on the informal feedback I have received from peers on the platform and growth teams. Soren is on track to ship the design system component library v1 by end of Q2. Mayas stretch project is building the internal CLI tool for database migrations and she is making steady progress with weekly pairing sessions. Two of three mentees will have completed stretch projects by end of quarter which meets the KR2 threshold.
+FIXTURE_EOF
+
+FIXTURES=("$FIXTURE_1" "$FIXTURE_2" "$FIXTURE_3")
+declare -a ENTRY_KEYS=()
+
+for i in 0 1 2; do
+  # JSON-escape the fixture content
+  ESCAPED=$(echo "${FIXTURES[$i]}" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')
+
+  CALL_RESP=$(mcp_call $((10+i)) "tools/call" "{\"name\":\"log_entry\",\"arguments\":{\"content\":$ESCAPED,\"source\":\"mcp\"}}")
+
+  if echo "$CALL_RESP" | jq -e '.result' >/dev/null 2>&1; then
+    RESULT_TEXT=$(echo "$CALL_RESP" | jq -r '.result.content[0].text // ""')
+    # Extract entry key from "Entry queued: entry01ABC..."
+    EKEY=$(echo "$RESULT_TEXT" | grep -oP 'entry[0-9A-Z]{26}' || echo "")
+    ENTRY_KEYS+=("$EKEY")
+    pass "MCP log_entry #$((i+1)) → queued ($EKEY)"
+  else
+    IS_ERROR=$(echo "$CALL_RESP" | jq -r '.result.isError // false')
+    ERROR_TEXT=$(echo "$CALL_RESP" | jq -r '.result.content[0].text // "unknown"' 2>/dev/null)
+    fail "MCP log_entry #$((i+1)) failed: $ERROR_TEXT"
+    ENTRY_KEYS+=("")
+  fi
+done
+
+# ── 4. Poll until entries are processed (max 360s) ───────────────────
+echo ""
+echo "  ⟳ polling entry pipeline (max 360s)..."
+ELAPSED=0
+MAX_WAIT=360
+PROCESSED=0
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $PROCESSED -lt 3 ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  PROCESSED=0
+
+  for i in 0 1 2; do
+    [ -z "${ENTRY_KEYS[$i]}" ] && continue
+    STATUS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/${ENTRY_KEYS[$i]}" 2>/dev/null \
+      | jq -r '.ingestStatus // .state // "unknown"')
+    [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ] && PROCESSED=$((PROCESSED+1))
+  done
+
+  echo "    ${ELAPSED}s — $PROCESSED/3 entries processed"
+done
+
+for i in 0 1 2; do
+  [ -z "${ENTRY_KEYS[$i]}" ] && continue
+  STATUS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/entries/${ENTRY_KEYS[$i]}" | jq -r '.ingestStatus // .state // "unknown"')
+  if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+    pass "entry #$((i+1)) reached $STATUS"
+  else
+    fail "entry #$((i+1)) stuck at $STATUS after ${MAX_WAIT}s"
+  fi
+done
+
+# ── 5. Report fragments ──────────────────────────────────────────────
+echo ""
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created ($FRAG_COUNT total)"
+  echo "    fragment titles:"
+  echo "$FRAGS" | jq -r '.fragments[:10][] | "      - \(.title // .slug)"' 2>/dev/null
+else
+  fail "no fragments found after pipeline"
+fi
+
+# ── 6. Report people extracted ────────────────────────────────────────
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people?limit=50")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT total)"
+  echo "    people names:"
+  echo "$PEOPLE" | jq -r '.people[:10][] | "      - \(.name // .canonicalName)"' 2>/dev/null
+else
+  skip "no people extracted (entity extraction may have failed-open)"
+fi
+
+# ── 7. Report edges ──────────────────────────────────────────────────
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has edges ($EDGE_COUNT edges, $NODE_COUNT nodes)"
+
+  # Count edge types
+  FRAG_IN_WIKI=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_IN_WIKI")] | length' 2>/dev/null || echo "0")
+  MENTIONS_PERSON=$(echo "$GRAPH" | jq '[.edges[] | select(.edgeType == "FRAGMENT_MENTIONS_PERSON")] | length' 2>/dev/null || echo "0")
+  echo "    FRAGMENT_IN_WIKI edges: $FRAG_IN_WIKI"
+  echo "    FRAGMENT_MENTIONS_PERSON edges: $MENTIONS_PERSON"
+else
+  fail "no edges in graph after pipeline"
+fi
+
+# ── 8. Check wiki detail (fragments + people attached) ────────────────
+echo ""
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  W_FRAGS=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  W_PEOPLE=$(echo "$DETAIL" | jq '.people | length' 2>/dev/null || echo "0")
+  W_STATE=$(echo "$DETAIL" | jq -r '.state // ""')
+  echo "  wiki '${WIKI_NAMES[$i]}': state=$W_STATE, fragments=$W_FRAGS, people=$W_PEOPLE"
+done
+
+# ── 9. Trigger regen on each wiki ────────────────────────────────────
+echo ""
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+
+  # Ensure regen is enabled
+  curl -s -o /dev/null -X PATCH -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}/regenerate"
+
+  REGEN_HTTP=$(curl -s -o /tmp/uat-regen-$i.json -w "%{http_code}" \
+    -X POST -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}/regenerate")
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    RFRAG_COUNT=$(jq -r '.fragmentCount // 0' /tmp/uat-regen-$i.json 2>/dev/null)
+    pass "regen '${WIKI_NAMES[$i]}' → 200 ($RFRAG_COUNT fragments)"
+  else
+    fail "regen '${WIKI_NAMES[$i]}' → HTTP $REGEN_HTTP"
+  fi
+done
+
+# ── 10. Report final wiki state ──────────────────────────────────────
+echo ""
+echo "  ── Final wiki state ──"
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  W_STATE=$(echo "$DETAIL" | jq -r '.state // ""')
+  W_CONTENT=$(echo "$DETAIL" | jq -r '.wikiContent // ""')
+  W_LEN=${#W_CONTENT}
+  W_FRAGS=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  W_PEOPLE=$(echo "$DETAIL" | jq '.people | length' 2>/dev/null || echo "0")
+
+  echo ""
+  echo "  wiki: ${WIKI_NAMES[$i]}"
+  echo "    key: ${WIKI_KEYS[$i]}"
+  echo "    slug: ${WIKI_SLUGS[$i]}"
+  echo "    state: $W_STATE"
+  echo "    content length: $W_LEN chars"
+  echo "    fragments: $W_FRAGS"
+  echo "    people: $W_PEOPLE"
+
+  if [ "$W_LEN" -gt 50 ]; then
+    pass "wiki '${WIKI_NAMES[$i]}' has generated content ($W_LEN chars)"
+
+    # Check for objective document structure sections
+    HAS_OBJ_SECTION=false
+    HAS_KR_SECTION=false
+    HAS_PROGRESS_SECTION=false
+    echo "$W_CONTENT" | grep -qi "objective\|the objective" && HAS_OBJ_SECTION=true
+    echo "$W_CONTENT" | grep -qi "key result" && HAS_KR_SECTION=true
+    echo "$W_CONTENT" | grep -qi "progress" && HAS_PROGRESS_SECTION=true
+
+    [ "$HAS_OBJ_SECTION" = true ] && pass "'${WIKI_NAMES[$i]}' has objective section" || skip "'${WIKI_NAMES[$i]}' objective section not detected"
+    [ "$HAS_KR_SECTION" = true ] && pass "'${WIKI_NAMES[$i]}' has key results section" || skip "'${WIKI_NAMES[$i]}' key results section not detected"
+    [ "$HAS_PROGRESS_SECTION" = true ] && pass "'${WIKI_NAMES[$i]}' has progress section" || skip "'${WIKI_NAMES[$i]}' progress section not detected"
+
+    # Print first 5 lines of content as preview
+    echo "    content preview:"
+    echo "$W_CONTENT" | head -5 | sed 's/^/      /'
+  else
+    fail "wiki '${WIKI_NAMES[$i]}' has no generated content"
+  fi
+done
+
+# ── 11. Cleanup ───────────────────────────────────────────────────────
+echo ""
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "200" ]; then
+    pass "cleanup: deleted '${WIKI_NAMES[$i]}'"
+  else
+    fail "cleanup: delete '${WIKI_NAMES[$i]}' → HTTP $DEL_HTTP"
+  fi
+done
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```

--- a/.uat/plans/wiki-types/wiki-principles.md
+++ b/.uat/plans/wiki-types/wiki-principles.md
@@ -1,0 +1,583 @@
+# Wiki Type UAT — Principles
+
+## What it proves
+End-to-end lifecycle of the **principles** wiki type: create wikis typed as
+`principles`, ingest realistic operating-principles content via MCP, verify
+pipeline processing (fragments, people, edges), trigger wiki regeneration, and
+confirm the generated wiki reflects the principles prompt structure.
+
+A Principles wiki is "a document of operating rules, values, and commitments
+that guide behavior."
+
+## Prerequisites
+- Server running at `$SERVER_URL` (default `http://localhost:3000`)
+- `OPENROUTER_API_KEY` set (for pipeline + regen LLM calls)
+- `core/.env` populated with `INITIAL_USERNAME`, `INITIAL_PASSWORD`
+
+## Fixtures
+
+Three realistic text inputs representing different domains of operating
+principles. Each is 500+ words of authentic content that exercises people
+extraction, rule identification, and commitment language.
+
+### Fixture A — Company Values Statement (Meridian Labs)
+
+> Meridian Labs was founded in 2019 by Elena Vasquez and James Okafor with a
+> shared conviction: the way a company operates matters as much as what it
+> builds. Over five years of scaling from twelve to three hundred people, we
+> have distilled the operating principles that define who we are. These are not
+> aspirational slogans — they are commitments we hold each other accountable to
+> every day.
+>
+> **Transparency by default.** We share information openly unless there is a
+> specific, articulable reason not to. Revenue numbers, board decks, incident
+> postmortems, and compensation bands are visible to every employee. Elena
+> learned this the hard way at her previous company, where a culture of
+> information hoarding led to duplicated effort and eroded trust. At Meridian,
+> we believe that people make better decisions when they have full context.
+> Withholding information requires justification; sharing it does not.
+>
+> **Ownership over territory.** We do not protect turf. When Marcus Chen in
+> engineering sees a customer support issue he can fix, he fixes it. When Priya
+> Sharma in design identifies a data pipeline problem, she files the ticket and
+> follows through. Titles describe your home base, not your boundaries. We
+> actively discourage the phrase "that's not my job." James often says that the
+> moment someone draws a line around their responsibilities is the moment the
+> company develops its first crack.
+>
+> **Disagree and commit.** Healthy conflict is a feature, not a bug. We expect
+> people to voice dissent clearly and early. But once a decision is made — and
+> we are explicit about when decisions are made — everyone rows in the same
+> direction. Sabotaging a decision you disagreed with is a fireable offense.
+> Supporting a decision you disagreed with is a sign of maturity. This
+> principle was tested during our 2022 pivot from enterprise to mid-market.
+> Several senior leaders opposed the move. They said so. The decision was made.
+> They executed it with full commitment. We grew forty percent that year.
+>
+> **Speed over perfection.** We ship early and iterate. A working prototype
+> that reaches customers on Monday teaches us more than a polished release that
+> ships on Friday. This does not mean we accept sloppy work — it means we
+> accept incomplete work that is correct as far as it goes. Rachel Torres, our
+> VP of Product, frames it as: "Would you rather be precisely wrong or
+> approximately right?" We choose approximately right every time.
+>
+> **Earn trust through consistency.** Trust at Meridian is not granted by title
+> or tenure. It is earned by doing what you say you will do, repeatedly, over
+> time. We value reliability over brilliance. A person who delivers solid work
+> on schedule earns more organizational trust than a person who occasionally
+> produces genius but cannot be counted on. This principle shapes our promotion
+> criteria, our peer review process, and how we assign critical projects.
+>
+> **No brilliant jerks.** Technical skill does not excuse interpersonal harm.
+> We have passed on exceptional candidates and parted ways with high performers
+> who treated colleagues with contempt. The cost of a brilliant jerk —
+> suppressed ideas, attrition of good people, cultural erosion — always exceeds
+> their individual contribution. This is non-negotiable.
+>
+> These six principles are reviewed annually by the full leadership team. They
+> evolve as we evolve. But their core — transparency, ownership, commitment,
+> speed, trust, and respect — has remained stable since our founding. Elena and
+> James believe that principles only matter when they cost you something. Every
+> one of these has cost us something. That is how we know they are real.
+
+### Fixture B — Personal Operating Principles (Software Engineer)
+
+> I wrote my first operating principles at twenty-four after reading Ray
+> Dalio's book and realizing I had no coherent framework for making decisions.
+> I am now thirty-one. These principles have been tested through two job
+> changes, a cross-country move, a failed startup, and a period of burnout
+> that lasted most of 2023. They are not abstract ideals — they are rules I
+> follow. When I violate one, I notice, and I course-correct.
+>
+> **Principle 1: Protect the morning.** My best thinking happens before noon.
+> I do not schedule meetings before 11am. I do not check Slack before I have
+> spent at least ninety minutes on deep work. My manager, David Park, agreed
+> to this arrangement when I showed him my output data — my morning PRs are
+> two-thirds less likely to need revision. I guard this time aggressively
+> because I know that if I give it up, everything downstream degrades.
+>
+> **Principle 2: Write before you build.** Before writing any code, I write a
+> design document. Not a formal RFC — a one-page doc that answers three
+> questions: What problem are we solving? What are two approaches? Why am I
+> picking this one? My colleague Anika Patel taught me this after I wasted two
+> weeks building the wrong abstraction on the Condor project. The document is
+> not for approval — it is for clarity. If I cannot explain the approach in
+> writing, I do not understand it well enough to build it.
+>
+> **Principle 3: Say no by default.** Every commitment I make reduces my
+> capacity for existing commitments. When someone asks me to take on something
+> new, my default answer is no unless I can identify what I will stop doing to
+> make room. My friend and mentor, Kenji Yamamoto, calls this "the budget
+> principle" — attention is a finite resource, and overspending it leads to
+> bankruptcy in every domain. I would rather do three things well than seven
+> things poorly.
+>
+> **Principle 4: Seek disconfirming evidence.** When I form an opinion, I
+> actively look for reasons I might be wrong. This is uncomfortable and slow.
+> It is also the only reliable way to avoid building on false assumptions. I
+> learned this from Lisa Chen during the Arbor incident, where we spent three
+> weeks debugging a performance regression that turned out to be a
+> configuration error. Everyone was so sure it was a code issue that nobody
+> checked the config. I never want to repeat that experience.
+>
+> **Principle 5: Health is infrastructure.** Sleep, exercise, and nutrition
+> are not optional — they are load-bearing systems. When I skip workouts or
+> sleep less than seven hours, my code quality drops, my patience decreases,
+> and my ability to hold complex problems in my head degrades measurably. I
+> treat my health the way I treat production infrastructure: with monitoring,
+> maintenance windows, and zero tolerance for "we'll fix it later."
+>
+> **Principle 6: Relationships are compounding.** I invest time in
+> professional relationships even when there is no immediate payoff. I respond
+> to messages. I make introductions. I remember what people are working on and
+> ask about it. My career has benefited more from relationships than from
+> technical skill. My current role came through a referral from Omar Hassan,
+> someone I had helped with a side project two years earlier with no
+> expectation of return.
+>
+> **Principle 7: Ship and iterate.** Perfectionism is a trap that masquerades
+> as quality. I set a "good enough" threshold before I start, and when I hit
+> it, I ship. I can always improve it in v2. The graveyard of side projects I
+> never launched taught me this lesson the hard way. Now I launch early, gather
+> feedback, and refine. The first version of my open-source linting tool had
+> embarrassing gaps. Version three is used by four thousand developers.
+>
+> These principles are mine. They reflect my personality, my failure modes, and
+> the lessons I have earned through experience. I review them every January and
+> update them when they no longer serve me. Principles that never change are
+> probably principles you never test.
+
+### Fixture C — Engineering Team Principles (Canopy Engineering)
+
+> The Canopy Engineering team operates under a shared set of principles that
+> define how we build software, make decisions, and treat each other. These
+> principles were developed collaboratively over six months by the founding
+> engineering team — Tomoko Nakamura, Ben Adeyemi, Sofia Reyes, and Chris
+> Whitfield — and are revisited at our annual offsite. Every new engineer
+> receives this document during onboarding and is expected to internalize it
+> within their first quarter.
+>
+> **We are problem solvers, not feature factories.** Our job is to solve user
+> problems, not to ship features. Before we write code, we validate that the
+> problem exists and that our proposed solution addresses it. Tomoko instituted
+> the "problem brief" requirement in 2021 after we shipped three consecutive
+> features that saw less than five percent adoption. Every feature now starts
+> with a one-page brief that includes the problem statement, evidence the
+> problem exists, and a success metric. If you cannot fill out the brief, the
+> feature is not ready for engineering.
+>
+> **Simplicity is a feature.** We prefer the simpler solution unless there is
+> a demonstrated reason the complex one is necessary. "But we might need it
+> later" is not a valid argument. Ben calls this "YAGNI with teeth." We have
+> deleted more code than most teams write because we ruthlessly remove
+> abstractions that served a past need but no longer earn their complexity
+> cost. Our codebase is smaller today than it was eighteen months ago, and it
+> does more.
+>
+> **Own your blast radius.** Every engineer is responsible for understanding
+> the downstream impact of their changes. If your PR touches the payment flow,
+> you own the risk. If your migration affects read latency, you watch the
+> dashboards. We do not throw code over a wall to QA and hope for the best.
+> Sofia built our blast-radius checklist after the March 2022 incident where a
+> seemingly minor schema change caused a four-hour outage in the billing
+> system. Now every PR over fifty lines includes an impact assessment.
+>
+> **Communicate through artifacts, not meetings.** We write RFCs, ADRs, and
+> runbooks. We record architectural decisions in version-controlled documents.
+> We do not convene a meeting to share information that could be a document.
+> Meetings are for discussion, debate, and decision-making — not for broadcast.
+> Chris tracks our meeting-to-document ratio and publishes it monthly. Teams
+> that trend toward more meetings and fewer documents are gently redirected.
+> This principle saves us an estimated fifteen hours per engineer per month.
+>
+> **Feedback is a gift, not an attack.** Code review is not adversarial. When
+> you leave a review comment, you are helping your colleague improve their
+> work. When you receive a comment, you are getting free mentorship. We use
+> conventional comment prefixes — "nit:", "question:", "suggestion:",
+> "blocker:" — so intent is never ambiguous. Personal attacks in code review
+> are treated as seriously as production incidents. Tomoko and Ben model this
+> by reviewing each other's code publicly and accepting criticism gracefully.
+>
+> **Incidents are learning opportunities.** We run blameless postmortems for
+> every incident above severity two. The goal is to understand what happened,
+> not who caused it. Every postmortem produces at least one concrete action
+> item with an owner and a deadline. We maintain a public incident log that
+> any employee can read. Our MTTR has dropped by sixty percent since we
+> adopted this practice because engineers are no longer afraid to surface
+> problems early. As Sofia says, "The only unforgivable incident is the one
+> we don't learn from."
+>
+> **Invest in developer experience.** Build times, test reliability, deploy
+> frequency, and onboarding speed are first-class metrics. We allocate twenty
+> percent of every sprint to tooling and infrastructure improvements. This is
+> not optional and it is not the first thing cut when deadlines tighten. Ben
+> demonstrated that every hour invested in CI speed returns four hours in
+> developer productivity across the team. Our deploy pipeline runs in under
+> three minutes. New engineers ship their first PR within forty-eight hours.
+>
+> **Balance autonomy with alignment.** Teams have broad latitude in how they
+> solve problems. They do not have latitude in what problems they solve. Our
+> quarterly planning process establishes the "what" — team-level objectives
+> tied to company goals. The "how" belongs entirely to the team. This means
+> an individual team can choose its own tech stack, testing strategy, and
+> release cadence, as long as it delivers on its objectives. Chris calls this
+> "freedom within a frame."
+>
+> These principles are living commitments. They cost us something: we have
+> rejected candidates who would not embrace them, slowed down releases to
+> honor them, and restructured teams around them. If a principle never causes
+> friction, it probably is not a real principle. Ours cause friction regularly.
+> That is how we know they are working.
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Principles"
+echo ""
+
+# Check OpenRouter key (required for pipeline + regen)
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping principles pipeline test"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── Sign in ──────────────────────────────────────────────────────────
+echo "── Sign in"
+SIGNIN=$(curl -s -c "$COOKIE_JAR" -w "\n%{http_code}" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+SIGNIN_HTTP=$(echo "$SIGNIN" | tail -1)
+[ "$SIGNIN_HTTP" = "200" ] && pass "sign-in → 200" || fail "sign-in → HTTP $SIGNIN_HTTP"
+
+# ── Get MCP token ────────────────────────────────────────────────────
+echo ""
+echo "── Get MCP token"
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+if [ -n "$MCP_URL" ] && [ "$MCP_URL" != "null" ]; then
+  MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+  MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+  pass "MCP token obtained"
+else
+  fail "mcpEndpointUrl missing from profile"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# SSE helper
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# MCP initialize (required before tool calls)
+curl -s --max-time 10 -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-principles","version":"1.0"}}}' \
+  "$MCP_URL" >/dev/null 2>&1
+
+# ── Seed wiki types ──────────────────────────────────────────────────
+echo ""
+echo "── Seed wiki types"
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify principles type exists
+TYPES_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/wiki-types")
+HAS_PRINCIPLES=$(echo "$TYPES_RESP" | jq '[.wikiTypes[].slug] | any(. == "principles")' 2>/dev/null)
+[ "$HAS_PRINCIPLES" = "true" ] && pass "principles wiki type present after seed" || fail "principles wiki type not found"
+
+# ── Create 3 principles wikis ────────────────────────────────────────
+echo ""
+echo "── Create principles wikis"
+
+WIKI_SLUGS=()
+WIKI_KEYS=()
+
+create_wiki() {
+  local name="$1" desc="$2"
+  local resp
+  resp=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"$name\",\"type\":\"principles\",\"prompt\":\"\"}" \
+    "$SERVER_URL/wikis")
+  local http=$(echo "$resp" | tail -1)
+  local body=$(echo "$resp" | sed '$d')
+  local key=$(echo "$body" | jq -r '.lookupKey // .id // ""')
+  local slug=$(echo "$body" | jq -r '.slug // ""')
+  local wtype=$(echo "$body" | jq -r '.type // ""')
+
+  if [ "$http" = "201" ] && [ -n "$key" ]; then
+    pass "POST /wikis → 201, slug=$slug, type=$wtype, key=${key:0:20}..."
+    WIKI_SLUGS+=("$slug")
+    WIKI_KEYS+=("$key")
+  else
+    fail "POST /wikis ($name) → HTTP $http"
+    WIKI_SLUGS+=("")
+    WIKI_KEYS+=("")
+  fi
+}
+
+create_wiki "Meridian Labs Operating Principles" "operating rules values and commitments for a company"
+create_wiki "Personal Operating Principles" "personal rules for decision-making and behavior"
+create_wiki "Canopy Engineering Principles" "engineering team operating principles for building software"
+
+# Verify all are type=principles
+for i in 0 1 2; do
+  if [ -n "${WIKI_KEYS[$i]}" ]; then
+    DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+    TYPE=$(echo "$DETAIL" | jq -r '.type // ""')
+    [ "$TYPE" = "principles" ] && pass "wiki ${WIKI_SLUGS[$i]} confirmed type=principles" || fail "wiki ${WIKI_SLUGS[$i]} type=$TYPE (expected principles)"
+  fi
+done
+
+# ── Submit 3 entries via MCP (log_entry) ─────────────────────────────
+echo ""
+echo "── Submit entries via MCP"
+
+ENTRY_KEYS=()
+
+# Fixture A — Meridian Labs
+FIXTURE_A='Meridian Labs was founded in 2019 by Elena Vasquez and James Okafor with a shared conviction: the way a company operates matters as much as what it builds. Over five years of scaling from twelve to three hundred people, we have distilled the operating principles that define who we are. These are not aspirational slogans — they are commitments we hold each other accountable to every day.\n\nTransparency by default. We share information openly unless there is a specific, articulable reason not to. Revenue numbers, board decks, incident postmortems, and compensation bands are visible to every employee. Elena learned this the hard way at her previous company, where a culture of information hoarding led to duplicated effort and eroded trust. At Meridian, we believe that people make better decisions when they have full context. Withholding information requires justification; sharing it does not.\n\nOwnership over territory. We do not protect turf. When Marcus Chen in engineering sees a customer support issue he can fix, he fixes it. When Priya Sharma in design identifies a data pipeline problem, she files the ticket and follows through. Titles describe your home base, not your boundaries. We actively discourage the phrase that is not my job. James often says that the moment someone draws a line around their responsibilities is the moment the company develops its first crack.\n\nDisagree and commit. Healthy conflict is a feature, not a bug. We expect people to voice dissent clearly and early. But once a decision is made — and we are explicit about when decisions are made — everyone rows in the same direction. Sabotaging a decision you disagreed with is a fireable offense. Supporting a decision you disagreed with is a sign of maturity. This principle was tested during our 2022 pivot from enterprise to mid-market. Several senior leaders opposed the move. They said so. The decision was made. They executed it with full commitment. We grew forty percent that year.\n\nSpeed over perfection. We ship early and iterate. A working prototype that reaches customers on Monday teaches us more than a polished release that ships on Friday. This does not mean we accept sloppy work — it means we accept incomplete work that is correct as far as it goes. Rachel Torres, our VP of Product, frames it as: Would you rather be precisely wrong or approximately right? We choose approximately right every time.\n\nEarn trust through consistency. Trust at Meridian is not granted by title or tenure. It is earned by doing what you say you will do, repeatedly, over time. We value reliability over brilliance. A person who delivers solid work on schedule earns more organizational trust than a person who occasionally produces genius but cannot be counted on. This principle shapes our promotion criteria, our peer review process, and how we assign critical projects.\n\nNo brilliant jerks. Technical skill does not excuse interpersonal harm. We have passed on exceptional candidates and parted ways with high performers who treated colleagues with contempt. The cost of a brilliant jerk — suppressed ideas, attrition of good people, cultural erosion — always exceeds their individual contribution. This is non-negotiable.\n\nThese six principles are reviewed annually by the full leadership team. They evolve as we evolve. But their core — transparency, ownership, commitment, speed, trust, and respect — has remained stable since our founding. Elena and James believe that principles only matter when they cost you something. Every one of these has cost us something. That is how we know they are real.'
+
+# Fixture B — Personal Operating Principles
+FIXTURE_B='I wrote my first operating principles at twenty-four after reading Ray Dalio book and realizing I had no coherent framework for making decisions. I am now thirty-one. These principles have been tested through two job changes, a cross-country move, a failed startup, and a period of burnout that lasted most of 2023. They are not abstract ideals — they are rules I follow. When I violate one, I notice, and I course-correct.\n\nPrinciple 1: Protect the morning. My best thinking happens before noon. I do not schedule meetings before 11am. I do not check Slack before I have spent at least ninety minutes on deep work. My manager, David Park, agreed to this arrangement when I showed him my output data — my morning PRs are two-thirds less likely to need revision. I guard this time aggressively because I know that if I give it up, everything downstream degrades.\n\nPrinciple 2: Write before you build. Before writing any code, I write a design document. Not a formal RFC — a one-page doc that answers three questions: What problem are we solving? What are two approaches? Why am I picking this one? My colleague Anika Patel taught me this after I wasted two weeks building the wrong abstraction on the Condor project. The document is not for approval — it is for clarity. If I cannot explain the approach in writing, I do not understand it well enough to build it.\n\nPrinciple 3: Say no by default. Every commitment I make reduces my capacity for existing commitments. When someone asks me to take on something new, my default answer is no unless I can identify what I will stop doing to make room. My friend and mentor, Kenji Yamamoto, calls this the budget principle — attention is a finite resource, and overspending it leads to bankruptcy in every domain. I would rather do three things well than seven things poorly.\n\nPrinciple 4: Seek disconfirming evidence. When I form an opinion, I actively look for reasons I might be wrong. This is uncomfortable and slow. It is also the only reliable way to avoid building on false assumptions. I learned this from Lisa Chen during the Arbor incident, where we spent three weeks debugging a performance regression that turned out to be a configuration error. Everyone was so sure it was a code issue that nobody checked the config. I never want to repeat that experience.\n\nPrinciple 5: Health is infrastructure. Sleep, exercise, and nutrition are not optional — they are load-bearing systems. When I skip workouts or sleep less than seven hours, my code quality drops, my patience decreases, and my ability to hold complex problems in my head degrades measurably. I treat my health the way I treat production infrastructure: with monitoring, maintenance windows, and zero tolerance for we will fix it later.\n\nPrinciple 6: Relationships are compounding. I invest time in professional relationships even when there is no immediate payoff. I respond to messages. I make introductions. I remember what people are working on and ask about it. My career has benefited more from relationships than from technical skill. My current role came through a referral from Omar Hassan, someone I had helped with a side project two years earlier with no expectation of return.\n\nPrinciple 7: Ship and iterate. Perfectionism is a trap that masquerades as quality. I set a good enough threshold before I start, and when I hit it, I ship. I can always improve it in v2. The graveyard of side projects I never launched taught me this lesson the hard way. Now I launch early, gather feedback, and refine. The first version of my open-source linting tool had embarrassing gaps. Version three is used by four thousand developers.\n\nThese principles are mine. They reflect my personality, my failure modes, and the lessons I have earned through experience. I review them every January and update them when they no longer serve me. Principles that never change are probably principles you never test.'
+
+# Fixture C — Canopy Engineering Principles
+FIXTURE_C='The Canopy Engineering team operates under a shared set of principles that define how we build software, make decisions, and treat each other. These principles were developed collaboratively over six months by the founding engineering team — Tomoko Nakamura, Ben Adeyemi, Sofia Reyes, and Chris Whitfield — and are revisited at our annual offsite. Every new engineer receives this document during onboarding and is expected to internalize it within their first quarter.\n\nWe are problem solvers, not feature factories. Our job is to solve user problems, not to ship features. Before we write code, we validate that the problem exists and that our proposed solution addresses it. Tomoko instituted the problem brief requirement in 2021 after we shipped three consecutive features that saw less than five percent adoption. Every feature now starts with a one-page brief that includes the problem statement, evidence the problem exists, and a success metric. If you cannot fill out the brief, the feature is not ready for engineering.\n\nSimplicity is a feature. We prefer the simpler solution unless there is a demonstrated reason the complex one is necessary. But we might need it later is not a valid argument. Ben calls this YAGNI with teeth. We have deleted more code than most teams write because we ruthlessly remove abstractions that served a past need but no longer earn their complexity cost. Our codebase is smaller today than it was eighteen months ago, and it does more.\n\nOwn your blast radius. Every engineer is responsible for understanding the downstream impact of their changes. If your PR touches the payment flow, you own the risk. If your migration affects read latency, you watch the dashboards. We do not throw code over a wall to QA and hope for the best. Sofia built our blast-radius checklist after the March 2022 incident where a seemingly minor schema change caused a four-hour outage in the billing system. Now every PR over fifty lines includes an impact assessment.\n\nCommunicate through artifacts, not meetings. We write RFCs, ADRs, and runbooks. We record architectural decisions in version-controlled documents. We do not convene a meeting to share information that could be a document. Meetings are for discussion, debate, and decision-making — not for broadcast. Chris tracks our meeting-to-document ratio and publishes it monthly. Teams that trend toward more meetings and fewer documents are gently redirected. This principle saves us an estimated fifteen hours per engineer per month.\n\nFeedback is a gift, not an attack. Code review is not adversarial. When you leave a review comment, you are helping your colleague improve their work. When you receive a comment, you are getting free mentorship. We use conventional comment prefixes — nit, question, suggestion, blocker — so intent is never ambiguous. Personal attacks in code review are treated as seriously as production incidents. Tomoko and Ben model this by reviewing each others code publicly and accepting criticism gracefully.\n\nIncidents are learning opportunities. We run blameless postmortems for every incident above severity two. The goal is to understand what happened, not who caused it. Every postmortem produces at least one concrete action item with an owner and a deadline. We maintain a public incident log that any employee can read. Our MTTR has dropped by sixty percent since we adopted this practice because engineers are no longer afraid to surface problems early. As Sofia says, The only unforgivable incident is the one we do not learn from.\n\nInvest in developer experience. Build times, test reliability, deploy frequency, and onboarding speed are first-class metrics. We allocate twenty percent of every sprint to tooling and infrastructure improvements. This is not optional and it is not the first thing cut when deadlines tighten. Ben demonstrated that every hour invested in CI speed returns four hours in developer productivity across the team. Our deploy pipeline runs in under three minutes. New engineers ship their first PR within forty-eight hours.\n\nBalance autonomy with alignment. Teams have broad latitude in how they solve problems. They do not have latitude in what problems they solve. Our quarterly planning process establishes the what — team-level objectives tied to company goals. The how belongs entirely to the team. This means an individual team can choose its own tech stack, testing strategy, and release cadence, as long as it delivers on its objectives. Chris calls this freedom within a frame.\n\nThese principles are living commitments. They cost us something: we have rejected candidates who would not embrace them, slowed down releases to honor them, and restructured teams around them. If a principle never causes friction, it probably is not a real principle. Ours cause friction regularly. That is how we know they are working.'
+
+submit_entry() {
+  local fixture_var="$1" label="$2"
+  local content
+  content=$(printf '%b' "$fixture_var")
+
+  # Escape content for JSON
+  local json_content
+  json_content=$(jq -Rs '.' <<< "$content")
+
+  local raw
+  raw=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$(date +%s%N | cut -c1-10),\"method\":\"tools/call\",\"params\":{\"name\":\"log_entry\",\"arguments\":{\"content\":$json_content,\"source\":\"mcp\"}}}" \
+    "$MCP_URL" 2>/dev/null)
+  local resp
+  resp=$(echo "$raw" | parse_sse)
+
+  local has_result
+  has_result=$(echo "$resp" | jq -e '.result' 2>/dev/null && echo "yes" || echo "no")
+
+  if [ "$has_result" = "yes" ]; then
+    local text
+    text=$(echo "$resp" | jq -r '.result.content[0].text // ""')
+    local entry_key
+    entry_key=$(echo "$text" | grep -oP 'entry[A-Z0-9]{26}' || echo "")
+    if [ -n "$entry_key" ]; then
+      pass "MCP log_entry ($label) → entry queued: ${entry_key:0:20}..."
+      ENTRY_KEYS+=("$entry_key")
+    else
+      pass "MCP log_entry ($label) → responded (key not parsed: ${text:0:60})"
+      ENTRY_KEYS+=("")
+    fi
+  else
+    fail "MCP log_entry ($label) → no result (${resp:0:120})"
+    ENTRY_KEYS+=("")
+  fi
+}
+
+submit_entry "$FIXTURE_A" "Meridian Labs"
+submit_entry "$FIXTURE_B" "Personal Principles"
+submit_entry "$FIXTURE_C" "Canopy Engineering"
+
+# ── Poll entries until processed (max 360s) ──────────────────────────
+echo ""
+echo "── Poll entry processing (max 360s)"
+
+PROCESSED=0
+ELAPSED=0
+MAX_WAIT=360
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $PROCESSED -lt ${#ENTRY_KEYS[@]} ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  PROCESSED=0
+
+  for i in "${!ENTRY_KEYS[@]}"; do
+    key="${ENTRY_KEYS[$i]}"
+    if [ -z "$key" ]; then
+      PROCESSED=$((PROCESSED + 1))
+      continue
+    fi
+    resp=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$key" 2>/dev/null)
+    status=$(echo "$resp" | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$status" = "processed" ] || [ "$status" = "RESOLVED" ] || [ "$status" = "failed" ]; then
+      PROCESSED=$((PROCESSED + 1))
+    fi
+  done
+
+  echo "    ${ELAPSED}s — $PROCESSED/${#ENTRY_KEYS[@]} entries done"
+done
+
+# Report final status of each entry
+for i in "${!ENTRY_KEYS[@]}"; do
+  key="${ENTRY_KEYS[$i]}"
+  if [ -z "$key" ]; then continue; fi
+  resp=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/entries/$key" 2>/dev/null)
+  status=$(echo "$resp" | jq -r '.ingestStatus // .state // "unknown"')
+  if [ "$status" = "processed" ] || [ "$status" = "RESOLVED" ]; then
+    pass "entry $i ($key) → $status"
+  elif [ "$status" = "failed" ]; then
+    err=$(echo "$resp" | jq -r '.lastError // "unknown"')
+    fail "entry $i ($key) → failed: $err"
+  else
+    fail "entry $i ($key) → stuck at $status after ${MAX_WAIT}s"
+  fi
+done
+
+# ── Report fragments ─────────────────────────────────────────────────
+echo ""
+echo "── Fragments"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created: $FRAG_COUNT total"
+  # Show first 5 fragment titles
+  echo "$FRAGS" | jq -r '.fragments[:5][] | "    → \(.title // .slug)"' 2>/dev/null
+else
+  fail "no fragments found after pipeline"
+fi
+
+# ── Report people ────────────────────────────────────────────────────
+echo ""
+echo "── People"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people?limit=50")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted: $PEOPLE_COUNT total"
+  echo "$PEOPLE" | jq -r '.people[:10][] | "    → \(.name // .canonicalName // .slug)"' 2>/dev/null
+else
+  skip "no people extracted (entity extraction may have failed gracefully)"
+fi
+
+# ── Report edges ─────────────────────────────────────────────────────
+echo ""
+echo "── Edges (fragment-wiki + fragment-person)"
+
+# Check each wiki for linked fragments
+for i in 0 1 2; do
+  key="${WIKI_KEYS[$i]:-}"
+  slug="${WIKI_SLUGS[$i]:-wiki-$i}"
+  if [ -z "$key" ]; then continue; fi
+  detail=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$key")
+  frag_count=$(echo "$detail" | jq '.fragments | length' 2>/dev/null || echo "0")
+  people_count=$(echo "$detail" | jq '.people | length' 2>/dev/null || echo "0")
+  echo "    $slug: $frag_count fragments, $people_count people"
+  if [ "$frag_count" -gt 0 ] 2>/dev/null; then
+    pass "$slug has $frag_count linked fragments"
+  else
+    skip "$slug has 0 linked fragments (pipeline may not have classified to this wiki)"
+  fi
+done
+
+# ── Trigger regen on each wiki ───────────────────────────────────────
+echo ""
+echo "── Trigger wiki regeneration"
+
+for i in 0 1 2; do
+  key="${WIKI_KEYS[$i]:-}"
+  slug="${WIKI_SLUGS[$i]:-wiki-$i}"
+  if [ -z "$key" ]; then continue; fi
+
+  # Enable regeneration first
+  curl -s -o /dev/null -X PATCH -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/$key/regenerate"
+
+  # Trigger regen
+  REGEN=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$key/regenerate")
+  REGEN_HTTP=$(echo "$REGEN" | tail -1)
+  REGEN_BODY=$(echo "$REGEN" | sed '$d')
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    fcount=$(echo "$REGEN_BODY" | jq -r '.fragmentCount // 0')
+    pass "POST /wikis/$slug/regenerate → 200 ($fcount fragments)"
+  elif [ "$REGEN_HTTP" = "400" ]; then
+    detail=$(echo "$REGEN_BODY" | jq -r '.error // ""')
+    skip "regen $slug → 400: $detail"
+  else
+    fail "regen $slug → HTTP $REGEN_HTTP"
+  fi
+done
+
+# ── Report final wiki state ──────────────────────────────────────────
+echo ""
+echo "── Final wiki state"
+
+for i in 0 1 2; do
+  key="${WIKI_KEYS[$i]:-}"
+  slug="${WIKI_SLUGS[$i]:-wiki-$i}"
+  if [ -z "$key" ]; then continue; fi
+
+  detail=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$key")
+  state=$(echo "$detail" | jq -r '.state // "unknown"')
+  wtype=$(echo "$detail" | jq -r '.type // "unknown"')
+  content_len=$(echo "$detail" | jq -r '.wikiContent // "" | length')
+  frag_count=$(echo "$detail" | jq '.fragments | length' 2>/dev/null || echo "0")
+  people_count=$(echo "$detail" | jq '.people | length' 2>/dev/null || echo "0")
+
+  echo "    $slug:"
+  echo "      type=$wtype, state=$state"
+  echo "      content=${content_len} chars, fragments=$frag_count, people=$people_count"
+
+  # Verify type stayed principles
+  [ "$wtype" = "principles" ] && pass "$slug type=principles preserved" || fail "$slug type changed to $wtype"
+
+  # Check if content was generated
+  if [ "$content_len" -gt 100 ] 2>/dev/null; then
+    pass "$slug has generated content ($content_len chars)"
+    # Show first 200 chars of wiki content
+    echo "$detail" | jq -r '.wikiContent // "" | .[0:200]' 2>/dev/null | sed 's/^/      > /'
+    echo ""
+  else
+    skip "$slug has no/minimal content (regen may have had 0 fragments)"
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════"
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```

--- a/.uat/plans/wiki-types/wiki-project.md
+++ b/.uat/plans/wiki-types/wiki-project.md
@@ -1,0 +1,568 @@
+# Wiki Type UAT — Project
+
+## What it proves
+End-to-end Project wiki lifecycle: create 3 project wikis, seed wiki types,
+submit 3 realistic project-update entries via MCP, poll until the pipeline
+processes them into fragments, verify fragments/people/edges, trigger regen,
+and report final wiki state.
+
+A **Project** wiki is "a living document tracking an active initiative, its
+goals, progress, and status."
+
+## Prerequisites
+- `OPENROUTER_API_KEY` set (LLM calls for extraction + regen)
+- Server running at `SERVER_URL` (default `http://localhost:3000`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` env vars for auth
+
+## Fixtures
+
+### Fixture 1 — Platform Migration Status Update
+
+> A cross-team infrastructure migration report covering progress, blockers,
+> and upcoming milestones for moving from a legacy monolith to microservices.
+
+```
+We're now six weeks into the Helios platform migration and I want to give
+everyone a clear picture of where things stand. The goal of this initiative is
+to decompose the legacy Rails monolith into independently deployable
+microservices behind an API gateway, with zero customer-facing downtime during
+the transition.
+
+As of this week, four of the nine planned services have been extracted and are
+running in production behind the new Kong gateway. The authentication service
+went live on March 3 and has been stable — Priya Sharma's team handled the
+session migration and we saw zero auth failures during cutover. The billing
+service followed on March 10, though we discovered a timezone bug in invoice
+generation that Marcus Chen patched within 48 hours. The notification service
+and user-profile service both shipped last week after passing load testing at
+3x current traffic.
+
+The remaining five services — catalog, search, order-management,
+inventory-sync, and reporting — are in various stages of extraction. Elena
+Vasquez is leading the catalog service work and estimates it will be ready for
+staging by April 1. Search is the most complex: it depends on a shared
+Elasticsearch cluster that currently serves both the monolith and the new
+services, and James Okafor flagged a concern about query routing during the
+transition window. We're scheduling a design review for next Tuesday to nail
+down the approach.
+
+The biggest blocker right now is the shared database. The monolith and the
+extracted services are still reading from the same Postgres instance, which
+means schema changes require coordination across teams. David Park proposed a
+strangler-fig pattern where new services get their own schemas first, then we
+migrate data incrementally. We agreed to pilot this with the catalog service.
+
+On the infrastructure side, our Kubernetes cluster utilization is at 68% and
+we've pre-provisioned headroom for the remaining services. The CI/CD pipeline
+changes are done — each service has its own Buildkite pipeline with automated
+canary deployments. Sarah Lin from DevOps built a traffic-splitting dashboard
+so we can monitor canary health in real time.
+
+Timeline-wise, we're about one week behind the original schedule. The billing
+timezone bug cost us three days and the Elasticsearch design question will
+likely push search extraction by a week. I've updated the Gantt chart and
+shared it in the project channel. Current target for full migration completion
+is May 15, revised from the original May 8.
+
+On the monitoring front, we've set up Datadog dashboards for each extracted
+service. The auth service is averaging 12ms p99 latency, which is actually
+faster than the monolith endpoint it replaced. Billing is at 45ms p99, which
+is within our SLA but higher than expected — Marcus Chen suspects it's the
+extra network hop to the payment gateway and is investigating connection
+pooling. We've also configured PagerDuty alerts for each service independently
+so on-call rotation can respond to the right team instead of routing everything
+to the monolith on-call.
+
+One process improvement worth noting: we started doing weekly migration
+stand-ups on Thursdays with one representative from each extraction team. This
+has cut down on cross-team Slack noise and made it easier to surface shared
+blockers early. Priya Sharma suggested we add a shared risk register, which
+we're now maintaining in Confluence.
+
+Next steps: finalize the search service design (owner: James Okafor, due April
+2), begin catalog service staging deployment (owner: Elena Vasquez, due April
+5), and start the database strangler-fig pilot (owner: David Park, due April
+8). I'll send the next update in two weeks unless something urgent comes up.
+```
+
+### Fixture 2 — Sprint 14 Retrospective and Planning Brief
+
+> An engineering team's sprint wrap-up covering velocity, completed stories,
+> carry-over items, retro takeaways, and sprint 15 planning.
+
+```
+Sprint 14 wrapped yesterday and here's the full picture for the Athena
+recommendation engine project. This is the fourth sprint in the build phase
+and we're tracking toward the beta release milestone at end of April.
+
+Velocity came in at 34 story points against a planned 38. The shortfall was
+mostly from one story — the collaborative filtering warm-start task — which
+turned out to be significantly more complex than the original estimate. Rachel
+Kim spent most of the sprint on it and got it to 80% complete, but the matrix
+factorization step needs GPU-accelerated inference that our current staging
+environment doesn't support. We're carrying it into sprint 15 and Tomás Rivera
+is provisioning an A100 node on our GCP cluster to unblock it.
+
+Completed work this sprint: the content-based feature pipeline is fully
+operational and processing the live catalog nightly. We're generating
+embeddings for roughly 2.3 million items using the fine-tuned BERT model that
+Wei Zhang trained last month. The A/B testing framework is wired up — we can
+now split traffic between the existing heuristic recommender and the new
+ML-based pipeline at any percentage. Nadia Petrov handled the feature-flag
+integration with LaunchDarkly and it's clean: one toggle flips the entire
+recommendation stack for a given user cohort.
+
+The API contract between the recommendation service and the product page
+frontend is finalized. Liam O'Brien and the frontend team confirmed they can
+consume the new response shape without breaking existing clients, since we're
+adding fields rather than changing existing ones. The response now includes a
+confidence score, explanation snippet, and diversity rank alongside the
+original item ID and relevance score.
+
+Retro highlights from yesterday's session. What went well: pair programming
+between Rachel and Wei on the embedding pipeline caught three subtle
+normalization bugs before they reached staging. The team consensus was that
+more cross-pair sessions would help knowledge sharing. What didn't go well: the
+GPU provisioning delay — we should have requested the hardware in sprint 13
+when the story was groomed, not when implementation started. Action item: add a
+"infrastructure prerequisites" checkbox to our story template so hardware needs
+surface during refinement. Also, our daily standups have been running 20
+minutes instead of 15. We're going to try a strict round-robin format with a
+visible timer starting Monday.
+
+Sprint 15 plan: finish the collaborative filtering warm-start (carry-over, 8
+points), implement the re-ranking diversity algorithm (5 points), build the
+real-time event ingestion pipeline for click-through tracking (8 points), and
+begin integration testing with the product page (5 points). Total planned: 26
+points, deliberately lower than our average to account for the GPU environment
+setup. Rachel Kim owns the warm-start completion, Wei Zhang takes re-ranking,
+Tomás Rivera handles the event pipeline, and Nadia Petrov leads integration
+testing.
+
+Beta release criteria remain: 95th-percentile latency under 200ms,
+recommendation relevance score above 0.72 on the held-out test set, and zero
+P0 bugs in the A/B test cohort for 72 continuous hours. We're currently at
+p95 latency of 180ms on content-based only, so the collaborative filtering
+addition is the main risk to the latency target.
+```
+
+### Fixture 3 — Quarterly Initiative Review: Customer Onboarding Redesign
+
+> A product-led initiative review covering OKR progress, cross-functional
+> workstreams, customer research findings, and go-to-market readiness.
+
+```
+This is the Q1 end-of-quarter review for the customer onboarding redesign
+initiative, codenamed Project Compass. The initiative launched on January 8
+with the goal of reducing time-to-first-value for new customers from 14 days
+to under 5 days, and increasing 30-day activation rate from 41% to 60%.
+
+OKR status as of March 31: time-to-first-value is currently at 8.2 days in
+the test cohort, down from 14 days at baseline. That's meaningful progress
+but still above our 5-day target. The 30-day activation rate in the test
+cohort hit 53%, up from 41%. Both metrics are moving in the right direction
+but neither has reached the stretch goal. Hannah Dreyfus, our product analyst,
+attributes the remaining gap primarily to the integration setup step — 62% of
+users who drop off do so while configuring their first data source connection.
+
+Workstream updates across three tracks:
+
+Track 1 — Guided Setup Wizard. Amir Hassani led the design and frontend team
+through three iterations of the setup wizard. V1 launched in February with a
+linear step-by-step flow. User testing showed that technical users found it
+patronizing while non-technical users still got stuck at the API key step.
+V2, launched March 5, introduced adaptive branching: the wizard detects
+whether the user has developer experience (based on their signup role
+selection) and adjusts the flow accordingly. Developer-track users see a
+streamlined CLI-first flow with copy-paste commands, while business users get
+a visual point-and-click integration builder. V2 improved completion rate
+from 34% to 51%. V3 is in design now and adds a "connect a sample dataset"
+escape hatch so users can experience the product with demo data before
+committing to a real integration. Marta Kowalski is building the sample
+dataset service and expects it in staging by April 10.
+
+Track 2 — In-App Education. Yuki Tanaka's team built a contextual help system
+that surfaces short tutorial videos and tooltips based on where the user is
+in the setup flow. The system uses a simple state machine: it tracks which
+setup steps are complete and which features the user has interacted with, then
+serves the next most relevant piece of education. Early results are promising
+— users who engage with at least two tutorial modules complete setup 40%
+faster than those who skip them. The team is now working on a "guided tour"
+overlay that activates on first login and walks through the three core screens.
+Jorge Medina wrote the tour script after reviewing 30 customer onboarding
+calls recorded by the success team.
+
+Track 3 — Proactive Success Outreach. Caroline Fischer on the customer success
+side implemented automated email sequences triggered by onboarding milestones.
+If a user creates an account but doesn't start setup within 48 hours, they get
+a personalized email with a calendar link to book a 15-minute setup session.
+If they start setup but stall at the integration step, they get a targeted
+email with a video walkthrough for their specific integration type. Open rates
+on these emails are 47%, click-through is 12%, and booked-session rate is 8%.
+Caroline's team has handled 142 setup sessions this quarter and reports that
+the most common friction point is OAuth token scoping — users don't understand
+which permissions they're granting and get anxious about security.
+
+Cross-functional dependencies resolved this quarter: legal approved the sample
+dataset terms of use (no customer PII in demo data), security completed the
+OAuth scope audit and we now show plain-language permission descriptions
+instead of raw scope strings, and the data engineering team (led by Raj
+Patel) built the sandbox environment that lets trial users process up to
+10,000 records without hitting billing.
+
+Go-to-market readiness: marketing has updated the website onboarding page
+with the new flow screenshots, and Ben Nakamura on content created six
+integration-specific quick-start guides. The sales team completed enablement
+training last week — they can now demo the new wizard live in calls.
+
+Key risks for Q2: the sample dataset service depends on a new S3 bucket
+policy that IT hasn't approved yet, the guided tour overlay needs
+accessibility review before launch (WCAG 2.1 AA compliance), and we're
+hearing from the sales team that enterprise customers want SSO-gated
+onboarding which isn't on the roadmap until H2.
+
+Next quarter priorities: ship wizard V3 with sample data, launch the guided
+tour, build an onboarding analytics dashboard so product and success can
+monitor cohort progress in real time, and run a formal A/B test comparing
+the old and new flows at 50/50 traffic split for statistical significance.
+```
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Project"
+echo ""
+
+# ── prerequisite check ──────────────────────────────────────────────
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping project wiki UAT"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── sign in ─────────────────────────────────────────────────────────
+curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" >/dev/null
+
+# ── get MCP token ───────────────────────────────────────────────────
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/users/profile")
+MCP_URL_RAW=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL_RAW" ] || [ "$MCP_URL_RAW" = "null" ]; then
+  fail "mcpEndpointUrl empty — cannot run MCP-based UAT"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL_RAW" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token acquired"
+
+# Helper: call an MCP tool and return the result text
+mcp_call() {
+  local TOOL_NAME="$1"
+  local ARGS_JSON="$2"
+  local RAW
+  RAW=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL_NAME\",\"arguments\":$ARGS_JSON}}" \
+    "$MCP_URL" 2>/dev/null)
+  echo "$RAW" | grep '^data: ' | head -1 | sed 's/^data: //'
+}
+
+# Helper: parse SSE for initialize/tools
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# ── MCP initialize (required before tool calls) ────────────────────
+INIT_RAW=$(curl -s --max-time 10 -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-project","version":"1.0"}}}' \
+  "$MCP_URL" 2>/dev/null)
+INIT_RESP=$(echo "$INIT_RAW" | parse_sse)
+if echo "$INIT_RESP" | jq -e '.result' >/dev/null 2>&1; then
+  pass "MCP initialized"
+else
+  fail "MCP initialize failed: ${INIT_RESP:0:200}"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── 1. Seed wiki types ──────────────────────────────────────────────
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify project type exists
+WT_LIST=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types")
+HAS_PROJECT=$(echo "$WT_LIST" | jq '[.wikiTypes[].slug] | any(. == "project")' 2>/dev/null)
+[ "$HAS_PROJECT" = "true" ] && pass "project wiki type present" || fail "project wiki type missing after seed"
+
+# ── 2. Create 3 project wikis ──────────────────────────────────────
+declare -a WIKI_KEYS=()
+declare -a WIKI_SLUGS=()
+WIKI_NAMES=("Helios Platform Migration" "Athena Recommendation Engine" "Project Compass Onboarding")
+
+for i in 0 1 2; do
+  CREATE=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"${WIKI_NAMES[$i]}\",\"type\":\"project\",\"prompt\":\"\"}" \
+    "$SERVER_URL/wikis")
+  CREATE_HTTP=$(echo "$CREATE" | tail -1)
+  CREATE_BODY=$(echo "$CREATE" | sed '$d')
+  WK=$(echo "$CREATE_BODY" | jq -r '.lookupKey // .id // ""')
+  WS=$(echo "$CREATE_BODY" | jq -r '.slug // ""')
+
+  if [ "$CREATE_HTTP" = "201" ] && [ -n "$WK" ]; then
+    WIKI_KEYS+=("$WK")
+    WIKI_SLUGS+=("$WS")
+    pass "created wiki ${WIKI_NAMES[$i]} → $WK"
+  else
+    fail "create wiki ${WIKI_NAMES[$i]} → HTTP $CREATE_HTTP"
+    WIKI_KEYS+=("")
+    WIKI_SLUGS+=("")
+  fi
+done
+
+# ── 3. Enable regen on all 3 wikis ─────────────────────────────────
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  REGEN_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X PATCH -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}/regenerate")
+  [ "$REGEN_HTTP" = "200" ] && pass "regen enabled: ${WIKI_NAMES[$i]}" || fail "regen toggle ${WIKI_NAMES[$i]} → HTTP $REGEN_HTTP"
+done
+
+# ── 4. Submit 3 entries via MCP log_entry ───────────────────────────
+# Fixture 1 — Platform Migration Status Update
+read -r -d '' FIXTURE_1 << 'FIXTURE_EOF'
+We're now six weeks into the Helios platform migration and I want to give everyone a clear picture of where things stand. The goal of this initiative is to decompose the legacy Rails monolith into independently deployable microservices behind an API gateway, with zero customer-facing downtime during the transition. As of this week, four of the nine planned services have been extracted and are running in production behind the new Kong gateway. The authentication service went live on March 3 and has been stable — Priya Sharma's team handled the session migration and we saw zero auth failures during cutover. The billing service followed on March 10, though we discovered a timezone bug in invoice generation that Marcus Chen patched within 48 hours. The notification service and user-profile service both shipped last week after passing load testing at 3x current traffic. The remaining five services — catalog, search, order-management, inventory-sync, and reporting — are in various stages of extraction. Elena Vasquez is leading the catalog service work and estimates it will be ready for staging by April 1. Search is the most complex: it depends on a shared Elasticsearch cluster that currently serves both the monolith and the new services, and James Okafor flagged a concern about query routing during the transition window. The biggest blocker right now is the shared database. The monolith and the extracted services are still reading from the same Postgres instance, which means schema changes require coordination across teams. David Park proposed a strangler-fig pattern where new services get their own schemas first, then we migrate data incrementally. On the infrastructure side, our Kubernetes cluster utilization is at 68% and we've pre-provisioned headroom for the remaining services. Sarah Lin from DevOps built a traffic-splitting dashboard so we can monitor canary health in real time. Timeline-wise, we're about one week behind the original schedule. Current target for full migration completion is May 15, revised from the original May 8. On the monitoring front, we've set up Datadog dashboards for each extracted service. The auth service is averaging 12ms p99 latency, which is actually faster than the monolith endpoint it replaced. Billing is at 45ms p99, which is within our SLA but higher than expected — Marcus Chen suspects it's the extra network hop to the payment gateway and is investigating connection pooling. We've also configured PagerDuty alerts for each service independently so on-call rotation can respond to the right team instead of routing everything to the monolith on-call. One process improvement worth noting: we started doing weekly migration stand-ups on Thursdays with one representative from each extraction team. This has cut down on cross-team Slack noise and made it easier to surface shared blockers early. Priya Sharma suggested we add a shared risk register, which we're now maintaining in Confluence. Next steps: finalize the search service design (owner: James Okafor), begin catalog service staging deployment (owner: Elena Vasquez), and start the database strangler-fig pilot (owner: David Park).
+FIXTURE_EOF
+
+# Fixture 2 — Sprint 14 Retrospective and Planning Brief
+read -r -d '' FIXTURE_2 << 'FIXTURE_EOF'
+Sprint 14 wrapped yesterday and here's the full picture for the Athena recommendation engine project. This is the fourth sprint in the build phase and we're tracking toward the beta release milestone at end of April. Velocity came in at 34 story points against a planned 38. The shortfall was mostly from one story — the collaborative filtering warm-start task — which turned out to be significantly more complex than the original estimate. Rachel Kim spent most of the sprint on it and got it to 80% complete, but the matrix factorization step needs GPU-accelerated inference that our current staging environment doesn't support. We're carrying it into sprint 15 and Tomás Rivera is provisioning an A100 node on our GCP cluster to unblock it. Completed work this sprint: the content-based feature pipeline is fully operational and processing the live catalog nightly. We're generating embeddings for roughly 2.3 million items using the fine-tuned BERT model that Wei Zhang trained last month. The A/B testing framework is wired up — we can now split traffic between the existing heuristic recommender and the new ML-based pipeline at any percentage. Nadia Petrov handled the feature-flag integration with LaunchDarkly and it's clean. The API contract between the recommendation service and the product page frontend is finalized. Liam O'Brien and the frontend team confirmed they can consume the new response shape without breaking existing clients. Retro highlights: pair programming between Rachel and Wei on the embedding pipeline caught three subtle normalization bugs before they reached staging. What didn't go well: the GPU provisioning delay — we should have requested the hardware in sprint 13 when the story was groomed. Sprint 15 plan: finish the collaborative filtering warm-start (8 points), implement the re-ranking diversity algorithm (5 points), build the real-time event ingestion pipeline for click-through tracking (8 points), and begin integration testing with the product page (5 points). Total planned: 26 points, deliberately lower than our average. Beta release criteria: 95th-percentile latency under 200ms, recommendation relevance score above 0.72 on the held-out test set, and zero P0 bugs in the A/B test cohort for 72 continuous hours.
+FIXTURE_EOF
+
+# Fixture 3 — Quarterly Initiative Review: Customer Onboarding Redesign
+read -r -d '' FIXTURE_3 << 'FIXTURE_EOF'
+This is the Q1 end-of-quarter review for the customer onboarding redesign initiative, codenamed Project Compass. The initiative launched on January 8 with the goal of reducing time-to-first-value for new customers from 14 days to under 5 days, and increasing 30-day activation rate from 41% to 60%. OKR status as of March 31: time-to-first-value is currently at 8.2 days in the test cohort, down from 14 days at baseline. The 30-day activation rate in the test cohort hit 53%, up from 41%. Hannah Dreyfus, our product analyst, attributes the remaining gap primarily to the integration setup step — 62% of users who drop off do so while configuring their first data source connection. Track 1 — Guided Setup Wizard: Amir Hassani led the design and frontend team through three iterations. V2, launched March 5, introduced adaptive branching and improved completion rate from 34% to 51%. V3 is in design now and adds a connect-a-sample-dataset escape hatch. Marta Kowalski is building the sample dataset service and expects it in staging by April 10. Track 2 — In-App Education: Yuki Tanaka's team built a contextual help system that surfaces tutorial videos and tooltips based on setup progress. Users who engage with at least two tutorial modules complete setup 40% faster. Jorge Medina wrote the guided tour script after reviewing 30 customer onboarding calls. Track 3 — Proactive Success Outreach: Caroline Fischer implemented automated email sequences triggered by onboarding milestones. Open rates are 47%, click-through is 12%, and booked-session rate is 8%. Her team handled 142 setup sessions this quarter. The most common friction point is OAuth token scoping — users don't understand which permissions they're granting. Cross-functional dependencies resolved: legal approved sample dataset terms, security completed the OAuth scope audit, and Raj Patel's data engineering team built the sandbox environment for trial users. Go-to-market readiness: Ben Nakamura created six integration-specific quick-start guides. Key risks for Q2: sample dataset S3 bucket policy pending IT approval, guided tour needs WCAG 2.1 AA accessibility review, and enterprise SSO-gated onboarding isn't on the roadmap until H2.
+FIXTURE_EOF
+
+declare -a ENTRY_KEYS=()
+FIXTURES=("$FIXTURE_1" "$FIXTURE_2" "$FIXTURE_3")
+FIXTURE_LABELS=("Platform Migration" "Sprint 14 Retro" "Compass Q1 Review")
+
+for i in 0 1 2; do
+  # Escape the fixture for JSON embedding
+  ESCAPED=$(printf '%s' "${FIXTURES[$i]}" | jq -Rs .)
+  RESP=$(mcp_call "log_entry" "{\"content\":$ESCAPED,\"source\":\"mcp\"}")
+  ENTRY_TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // ""' 2>/dev/null)
+  IS_ERR=$(echo "$RESP" | jq -r '.result.isError // false' 2>/dev/null)
+
+  if [ "$IS_ERR" = "true" ]; then
+    fail "MCP log_entry ${FIXTURE_LABELS[$i]}: $ENTRY_TEXT"
+    ENTRY_KEYS+=("")
+  else
+    # Extract entry key from "Entry queued: entry01ABC..." response
+    EK=$(echo "$ENTRY_TEXT" | grep -oP 'entry[0-9A-Z]{26}' || echo "")
+    ENTRY_KEYS+=("$EK")
+    pass "MCP log_entry ${FIXTURE_LABELS[$i]} → $EK"
+  fi
+done
+
+# ── 5. Poll entries until processed (max 360s) ─────────────────────
+echo ""
+echo "  ⟳ polling entry pipeline (max 360s)..."
+ELAPSED=0
+MAX_WAIT=360
+ALL_DONE=false
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  DONE_COUNT=0
+
+  for i in 0 1 2; do
+    [ -z "${ENTRY_KEYS[$i]}" ] && continue
+    STATUS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/${ENTRY_KEYS[$i]}" 2>/dev/null \
+      | jq -r '.ingestStatus // .state // "unknown"')
+    echo "    ${ELAPSED}s — ${FIXTURE_LABELS[$i]}: $STATUS"
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+      DONE_COUNT=$((DONE_COUNT + 1))
+    elif [ "$STATUS" = "failed" ]; then
+      fail "entry ${FIXTURE_LABELS[$i]} failed"
+    fi
+  done
+
+  if [ "$DONE_COUNT" -ge 3 ]; then
+    ALL_DONE=true
+    break
+  fi
+done
+
+if [ "$ALL_DONE" = "true" ]; then
+  pass "all 3 entries processed in ${ELAPSED}s"
+else
+  fail "not all entries processed after ${MAX_WAIT}s"
+fi
+
+# ── 6. Report fragments ────────────────────────────────────────────
+echo ""
+echo "  ── fragment report ──"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+echo "    total fragments: $FRAG_COUNT"
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created ($FRAG_COUNT)"
+  # Show first 5 fragment titles
+  echo "$FRAGS" | jq -r '.fragments[:5][] | "    - \(.title // .slug)"' 2>/dev/null
+else
+  fail "no fragments created by pipeline"
+fi
+
+# ── 7. Report people ───────────────────────────────────────────────
+echo ""
+echo "  ── people report ──"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people?limit=100")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+echo "    total people: $PEOPLE_COUNT"
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT)"
+  echo "$PEOPLE" | jq -r '.people[:10][] | "    - \(.name)"' 2>/dev/null
+else
+  skip "no people extracted (extraction may be async or model-dependent)"
+fi
+
+# ── 8. Report edges (graph) ────────────────────────────────────────
+echo ""
+echo "  ── edge report ──"
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+echo "    nodes: $NODE_COUNT, edges: $EDGE_COUNT"
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph edges present ($EDGE_COUNT)"
+  # Show edge type distribution
+  echo "$GRAPH" | jq -r '[.edges[].edgeType] | group_by(.) | map("\(.[0]): \(length)") | .[]' 2>/dev/null \
+    | while read -r line; do echo "    $line"; done
+else
+  skip "no edges yet (pipeline may still be linking)"
+fi
+
+# ── 9. Check wiki detail (fragments + people on each wiki) ─────────
+echo ""
+echo "  ── wiki detail check ──"
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  W_FRAG_COUNT=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  W_PEOPLE_COUNT=$(echo "$DETAIL" | jq '.people | length' 2>/dev/null || echo "0")
+  W_TYPE=$(echo "$DETAIL" | jq -r '.type // ""' 2>/dev/null)
+  echo "    ${WIKI_NAMES[$i]}: type=$W_TYPE, fragments=$W_FRAG_COUNT, people=$W_PEOPLE_COUNT"
+  [ "$W_TYPE" = "project" ] && pass "wiki type=project: ${WIKI_NAMES[$i]}" || fail "wiki type=$W_TYPE (expected project)"
+done
+
+# ── 10. Trigger regen on each wiki ─────────────────────────────────
+echo ""
+echo "  ── wiki regen ──"
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  REGEN_RESP=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}/regenerate")
+  REGEN_HTTP=$(echo "$REGEN_RESP" | tail -1)
+  REGEN_BODY=$(echo "$REGEN_RESP" | sed '$d')
+  REGEN_FRAGS=$(echo "$REGEN_BODY" | jq -r '.fragmentCount // "?"' 2>/dev/null)
+
+  if [ "$REGEN_HTTP" = "200" ]; then
+    pass "regen ${WIKI_NAMES[$i]} → 200, fragments=$REGEN_FRAGS"
+  else
+    # 400 = no fragments linked yet (regen disabled or empty), 500 = LLM error
+    REGEN_ERR=$(echo "$REGEN_BODY" | jq -r '.error // ""' 2>/dev/null)
+    fail "regen ${WIKI_NAMES[$i]} → HTTP $REGEN_HTTP ($REGEN_ERR)"
+  fi
+done
+
+# ── 11. Report final wiki state ────────────────────────────────────
+echo ""
+echo "  ── final wiki state ──"
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  FINAL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  W_STATE=$(echo "$FINAL" | jq -r '.state // ""' 2>/dev/null)
+  W_CONTENT_LEN=$(echo "$FINAL" | jq -r '.wikiContent | length' 2>/dev/null || echo "0")
+  W_FRAG_COUNT=$(echo "$FINAL" | jq '.fragments | length' 2>/dev/null || echo "0")
+  W_PEOPLE_COUNT=$(echo "$FINAL" | jq '.people | length' 2>/dev/null || echo "0")
+  echo "    ${WIKI_NAMES[$i]}:"
+  echo "      state=$W_STATE, content=${W_CONTENT_LEN} chars, fragments=$W_FRAG_COUNT, people=$W_PEOPLE_COUNT"
+
+  if [ "$W_CONTENT_LEN" -gt 0 ] 2>/dev/null; then
+    pass "wiki has generated content: ${WIKI_NAMES[$i]} (${W_CONTENT_LEN} chars)"
+    # Show first 200 chars of generated wiki content
+    echo "$FINAL" | jq -r '.wikiContent[:200]' 2>/dev/null | sed 's/^/      /'
+    echo "      ..."
+  else
+    skip "wiki content empty after regen: ${WIKI_NAMES[$i]} (fragments may not be linked yet)"
+  fi
+done
+
+# ── 12. Cleanup — soft-delete test wikis ────────────────────────────
+echo ""
+echo "  ── cleanup ──"
+for i in 0 1 2; do
+  [ -z "${WIKI_KEYS[$i]}" ] && continue
+  DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "200" ]; then
+    pass "deleted ${WIKI_NAMES[$i]}"
+  else
+    fail "delete ${WIKI_NAMES[$i]} → HTTP $DEL_HTTP"
+  fi
+done
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```

--- a/.uat/plans/wiki-types/wiki-research.md
+++ b/.uat/plans/wiki-types/wiki-research.md
@@ -1,0 +1,518 @@
+# Wiki Type UAT — Research
+
+## What it proves
+End-to-end Research wiki lifecycle: create research-typed wikis, ingest realistic
+research content via MCP log_entry, verify the AI pipeline extracts fragments and
+files them into the correct wikis via FRAGMENT_IN_WIKI edges, and confirm
+regeneration produces a coherent wiki document.
+
+A Research wiki is "a living document tracking an active investigation, its
+methods, findings, and conclusions."
+
+## Prerequisites
+Requires OPENROUTER_API_KEY for LLM calls. Requires a running Robin server with
+the env-seeded user available for sign-in.
+
+## Fixtures
+Three real-world research scenarios:
+
+1. **Spaced Repetition and Long-Term Retention** — A literature review summarizing
+   cognitive science findings on spaced repetition systems (Ebbinghaus, Leitner,
+   Pimsleur), their efficacy across domains, and open questions about optimal
+   scheduling algorithms.
+
+2. **Urban Heat Island Mitigation Strategies** — A technical investigation into
+   how cities combat the urban heat island effect, covering cool roofs, urban
+   forestry, permeable pavements, and district cooling — with quantitative
+   findings from published case studies.
+
+3. **Gut Microbiome and Mental Health** — A research synthesis on the gut-brain
+   axis, reviewing clinical evidence for microbiome-based interventions in
+   depression and anxiety, including FMT trials, probiotic RCTs, and metabolomic
+   biomarker discovery.
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Research"
+echo ""
+
+# Check OpenRouter key
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping research wiki type test"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── Sign in ────────────────────────────────────────────────────────────────
+
+curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" >/dev/null
+
+# ── Get MCP token ──────────────────────────────────────────────────────────
+
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL" ] || [ "$MCP_URL" = "null" ]; then
+  fail "mcpEndpointUrl is empty — cannot run MCP tests"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token acquired"
+
+# Helper: extract JSON from SSE "data:" line
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# MCP initialize (required before tool calls)
+curl -s --max-time 10 -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-research","version":"1.0"}}}' \
+  "$MCP_URL" >/dev/null 2>&1
+
+# ── 1. Seed wiki types ─────────────────────────────────────────────────────
+
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed → HTTP $SEED_HTTP"
+
+# ── 2. Create 3 research wikis ────────────────────────────────────────────
+
+TS=$(date +%s)
+
+create_wiki() {
+  local name="$1"
+  local resp
+  resp=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"$name\",\"type\":\"research\"}" \
+    "$SERVER_URL/wikis")
+  local http=$(echo "$resp" | tail -1)
+  local body=$(echo "$resp" | sed '$d')
+  local id=$(echo "$body" | jq -r '.lookupKey // .id // ""')
+  if [ "$http" = "201" ] && [ -n "$id" ]; then
+    pass "created wiki: $name (id=$id)"
+    echo "$id"
+  else
+    fail "create wiki '$name' → HTTP $http"
+    echo ""
+  fi
+}
+
+WIKI_ID_1=$(create_wiki "Spaced Repetition and Long-Term Retention [$TS]")
+WIKI_ID_2=$(create_wiki "Urban Heat Island Mitigation Strategies [$TS]")
+WIKI_ID_3=$(create_wiki "Gut Microbiome and Mental Health [$TS]")
+
+# Verify all created
+CREATED_COUNT=0
+[ -n "$WIKI_ID_1" ] && CREATED_COUNT=$((CREATED_COUNT+1))
+[ -n "$WIKI_ID_2" ] && CREATED_COUNT=$((CREATED_COUNT+1))
+[ -n "$WIKI_ID_3" ] && CREATED_COUNT=$((CREATED_COUNT+1))
+[ "$CREATED_COUNT" = "3" ] && pass "all 3 research wikis created" || fail "only $CREATED_COUNT/3 wikis created"
+
+# ── 3. Submit entries via MCP log_entry ────────────────────────────────────
+
+ENTRY_IDS=()
+
+mcp_log_entry() {
+  local content="$1"
+  local escaped
+  escaped=$(echo "$content" | jq -Rs '.')
+  local payload="{\"jsonrpc\":\"2.0\",\"id\":$((RANDOM)),\"method\":\"tools/call\",\"params\":{\"name\":\"log_entry\",\"arguments\":{\"content\":$escaped,\"source\":\"mcp\"}}}"
+
+  local raw
+  raw=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "$payload" \
+    "$MCP_URL" 2>/dev/null)
+  local resp
+  resp=$(echo "$raw" | parse_sse)
+
+  if echo "$resp" | jq -e '.result' >/dev/null 2>&1; then
+    local text
+    text=$(echo "$resp" | jq -r '.result.content[0].text // ""')
+    local entry_key
+    entry_key=$(echo "$text" | grep -oP 'entry[0-9A-Z]{26}' || echo "")
+    echo "$entry_key"
+  else
+    echo ""
+  fi
+}
+
+echo ""
+echo "  Submitting fixture 1: Spaced Repetition research..."
+FIXTURE_1=$(cat <<'FIXTURE'
+Spaced Repetition and Long-Term Retention: A Literature Review
+
+Background and Historical Context
+
+The study of memory retention and optimal learning schedules has a rich history stretching back to Hermann Ebbinghaus's pioneering work in 1885. Ebbinghaus demonstrated the exponential nature of forgetting through his famous forgetting curve experiments, establishing that newly learned information decays rapidly within the first hours and days unless actively reviewed. His self-experimentation with nonsense syllables revealed that approximately 56% of learned material is forgotten within one hour, 66% within one day, and 75% within six days.
+
+Sebastian Leitner built on this foundation in 1972 with his flashcard box system, which introduced a mechanical approach to spaced review. Cards answered correctly advance to boxes with longer review intervals, while incorrect cards return to the first box. This simple algorithm encodes the core insight: items that are easier to recall need less frequent review.
+
+The Pimsleur graduated-interval recall method, developed for language learning in the 1960s, proposed a specific schedule of expanding intervals: 5 seconds, 25 seconds, 2 minutes, 10 minutes, 1 hour, 5 hours, 1 day, 5 days, 25 days, 4 months, and 2 years. Pimsleur's claim was that these intervals approximate the natural pattern by which memories consolidate.
+
+Modern Computational Approaches
+
+SuperMemo's SM-2 algorithm, published by Piotr Wozniak in 1987, was the first computer-based spaced repetition algorithm to gain widespread use. SM-2 assigns each item an "easiness factor" that modulates inter-repetition intervals. Items rated as difficult receive shorter intervals and lower easiness factors, while easy items accumulate longer gaps between reviews. The algorithm initializes with intervals of 1 day, then 6 days, then multiplies the previous interval by the easiness factor for subsequent reviews.
+
+Anki, released in 2006 by Damien Elmes, adapted SM-2 with modifications for practical use. Anki introduced the concept of "learning steps" — sub-day intervals for newly introduced cards — and added a configurable "new interval" percentage applied after a lapse. Anki's open-source nature has made it the dominant platform for medical education, language learning, and bar exam preparation.
+
+The FSRS (Free Spaced Repetition Scheduler) algorithm, developed by Jarrett Ye starting in 2022, represents a significant departure from SM-2-family algorithms. FSRS uses a four-parameter model of memory (stability, difficulty, retrievability, and elapsed days) and fits these parameters to each user's review history using machine learning. Published comparisons show FSRS reduces daily review load by 20-30% compared to SM-2 while maintaining equivalent retention rates.
+
+Efficacy Across Domains
+
+A 2019 meta-analysis by Latimier et al. examined 29 studies (N=3,171) comparing spaced versus massed practice. The overall effect size favored spaced practice (Hedges' g = 0.72), with particularly strong effects in vocabulary learning (g = 0.85) and factual recall (g = 0.70). Effects were smaller but still significant for conceptual learning (g = 0.42).
+
+Medical education has produced some of the strongest evidence. Kerfoot et al. (2010) randomized 311 urology residents to spaced versus bolus review of clinical content and found that spaced repetition produced 52% higher retention at two years with no additional study time. Schmidmaier et al. (2011) replicated these findings with clinical reasoning cases, showing 35% improvement in diagnostic accuracy.
+
+Language acquisition studies show mixed results depending on the outcome measure. Nakata (2015) found large effects for receptive vocabulary knowledge (d = 0.94) but smaller effects for productive use (d = 0.38), suggesting that spaced repetition may be better suited for recognition than production. A 2020 longitudinal study of Duolingo learners by Settles and Meeder found that the half-life regression model used by Duolingo predicted recall probability with R-squared of 0.84 across 12 languages.
+
+Open Questions and Current Research Directions
+
+The optimal spacing function remains debated. Should intervals expand exponentially, or is a more gradual expansion preferable? Cepeda et al. (2008) found that the optimal gap between study sessions depended heavily on the retention interval — the desired delay before the final test. For a one-week retention interval, the optimal spacing gap was one day. For a one-year retention interval, the optimal gap jumped to three to five weeks. This has profound implications for algorithm design: a single expanding schedule may not serve all learning goals equally.
+
+Interleaving effects present another complication. Rohrer and Taylor (2007) demonstrated that interleaving different problem types during practice — rather than blocking them — improved retention even when spacing was held constant. Whether spaced repetition systems should incorporate category interleaving as a first-class feature remains an active area of investigation.
+
+The role of retrieval difficulty is increasingly studied. Bjork's "desirable difficulties" framework suggests that harder retrieval attempts produce stronger memory traces. This implies that optimal spacing should target a specific retrieval difficulty level rather than maximize ease of recall. FSRS attempts to operationalize this by targeting 90% retrievability rather than near-perfect recall, but the optimal target may vary by domain, learner, and item type.
+FIXTURE
+)
+ENTRY_1=$(mcp_log_entry "$FIXTURE_1")
+if [ -n "$ENTRY_1" ]; then
+  pass "fixture 1 submitted: $ENTRY_1"
+  ENTRY_IDS+=("$ENTRY_1")
+else
+  fail "fixture 1 submission failed"
+fi
+
+echo "  Submitting fixture 2: Urban Heat Island research..."
+FIXTURE_2=$(cat <<'FIXTURE'
+Urban Heat Island Mitigation Strategies: A Technical Investigation
+
+The urban heat island effect — where built-up areas experience temperatures 1-3 degrees Celsius higher than surrounding rural areas during the day, and up to 12 degrees Celsius higher at night — represents one of the most significant environmental challenges facing cities worldwide. As urbanization intensifies and climate change amplifies heat extremes, cities are deploying an expanding portfolio of mitigation strategies. This investigation reviews the evidence base for the leading approaches.
+
+Cool Roofs: Albedo Engineering at Scale
+
+Cool roofs increase the solar reflectance (albedo) of building surfaces from the conventional 0.05-0.25 range to 0.60-0.85. The Lawrence Berkeley National Laboratory has led research in this area since the early 2000s. Akbari, Menon, and Rosenfeld (2009) estimated that converting all roofs and pavements in tropical and temperate regions to cool surfaces would produce a global cooling effect equivalent to offsetting 44 gigatons of CO2 emissions.
+
+In practice, the measured effects are substantial but context-dependent. A 2016 field study in Hyderabad, India, by the Administrative Staff College of India covered 300 buildings with white reflective coating and measured indoor temperature reductions of 2-5 degrees Celsius in top-floor rooms. Peak cooling energy demand dropped by 20-25%. New York City's CoolRoofs initiative has coated over 10 million square feet since 2009, with infrared surveys confirming surface temperature reductions of 15-30 degrees Celsius on treated roofs compared to adjacent dark roofs.
+
+However, cool roofs face a wintertime penalty in heating-dominated climates. Researchers at Oak Ridge National Laboratory found that in heating-dominated zones like Minneapolis, the winter heating penalty offsets 10-30% of summer cooling savings. The break-even point falls at approximately 35 degrees north latitude for commercial buildings and 40 degrees for residential buildings, depending on insulation levels.
+
+Urban Forestry: Shade and Evapotranspiration
+
+Urban trees reduce temperatures through two mechanisms: direct shading of surfaces and evapotranspiration. Mature trees can intercept 80-95% of incoming solar radiation, and a single large tree can transpire up to 400 liters of water per day, absorbing approximately 930 megajoules of thermal energy — equivalent to the cooling output of five average room air conditioners.
+
+Melbourne, Australia has pursued what is arguably the most ambitious urban forest strategy. The city's Urban Forest Strategy (2012-2032) targets increasing canopy cover from 22% to 40%. A 2018 assessment by Coutts et al. used microclimate modeling to predict that achieving this target would reduce maximum ambient air temperatures by 0.5-2.0 degrees Celsius across the city, with localized reductions of up to 5 degrees Celsius under tree canopies.
+
+Singapore's approach integrates vertical and rooftop greenery alongside street-level planting. The Skyrise Greenery Incentive Scheme has added over 200 hectares of green space to building facades and rooftops since 2009. Wong et al. (2010) measured rooftop garden temperatures at the National University of Singapore and found surface temperatures up to 30 degrees Celsius lower than exposed concrete, with air temperatures at 300mm above the surface reduced by 4 degrees Celsius.
+
+Permeable Pavements and Cool Streets
+
+Conventional asphalt has an albedo of 0.05-0.10 and retains heat effectively, reaching surface temperatures of 60-70 degrees Celsius on summer afternoons. Permeable pavements — including porous asphalt, pervious concrete, and interlocking concrete pavers — address this through both increased reflectance and evaporative cooling from stored subsurface moisture.
+
+The City of Chicago installed permeable pavement on a 3-block section of West Cermak Road in 2008 as part of a controlled study. Infrared thermography showed the permeable section ran 5-8 degrees Celsius cooler than adjacent conventional pavement during dry conditions, increasing to 10-14 degrees during wet periods when evaporative cooling was active.
+
+Los Angeles launched the CoolSeal pilot program in 2017, applying a high-albedo sealant to 15 city blocks. The Bureau of Street Services reported surface temperature reductions of 5-7 degrees Celsius. A follow-up study by Arizona State University found that while surface temperatures dropped significantly, pedestrian-level mean radiant temperature actually increased in some scenarios due to reflected radiation — a finding that highlights the complexity of urban thermal environments.
+
+District Cooling and Waste Heat Recovery
+
+District cooling systems — where chilled water is produced centrally and distributed via underground piping — can achieve dramatically higher efficiency than distributed air conditioning. The coefficient of performance for large centrifugal chillers (COP 6-7) is approximately double that of split-system air conditioners (COP 2.5-3.5).
+
+Dubai's Empower operates the world's largest district cooling system, serving over 1,300 buildings across 1.48 million refrigeration tons of capacity. The company reports energy savings of 40-50% compared to conventional cooling, translating to approximately 500,000 tons of avoided CO2 emissions annually. The system uses treated sewage effluent for cooling tower makeup water, reducing freshwater consumption by 35 million cubic meters per year.
+
+Combined Strategy Recommendations
+
+No single intervention is sufficient. The most effective approaches combine strategies synergistically. A 2020 modeling study by Santamouris et al. simulated a combined cool-roofs, urban-trees, and permeable-pavement scenario for Darwin, Australia, and predicted a 3-4 degree Celsius reduction in peak urban temperatures — approximately double the effect of any single strategy. The study estimated a benefit-cost ratio of 7:1 over a 30-year period, driven primarily by reduced energy costs and avoided heat-related mortality.
+FIXTURE
+)
+ENTRY_2=$(mcp_log_entry "$FIXTURE_2")
+if [ -n "$ENTRY_2" ]; then
+  pass "fixture 2 submitted: $ENTRY_2"
+  ENTRY_IDS+=("$ENTRY_2")
+else
+  fail "fixture 2 submission failed"
+fi
+
+echo "  Submitting fixture 3: Gut Microbiome research..."
+FIXTURE_3=$(cat <<'FIXTURE'
+Gut Microbiome and Mental Health: A Research Synthesis
+
+The Gut-Brain Axis: Mechanisms and Pathways
+
+The bidirectional communication network between the gastrointestinal tract and the central nervous system — termed the gut-brain axis — has emerged as one of the most productive research frontiers in psychiatry and neuroscience over the past decade. The microbiome component of this axis involves approximately 100 trillion microorganisms residing in the human gut, collectively encoding 3.3 million genes compared to approximately 23,000 in the human genome.
+
+Three primary communication channels mediate gut-brain signaling. The vagus nerve provides a direct neural pathway: Bravo et al. (2011) demonstrated that the anxiolytic effects of Lactobacillus rhamnosus in mice were completely abolished by vagotomy, establishing vagal signaling as necessary for at least some probiotic effects. The immune-mediated pathway involves microbial modulation of systemic inflammation via toll-like receptors and cytokine cascades. Increased intestinal permeability ("leaky gut") permits translocation of bacterial endotoxins, particularly lipopolysaccharide, which activates peripheral and central inflammatory pathways. The metabolic pathway involves microbial production of neuroactive compounds, including 95% of the body's serotonin (synthesized by enterochromaffin cells under microbial influence), gamma-aminobutyric acid (produced by Lactobacillus and Bifidobacterium species), and short-chain fatty acids (particularly butyrate, propionate, and acetate) that cross the blood-brain barrier and influence brain function.
+
+Clinical Evidence: Depression
+
+Epidemiological data consistently show altered gut microbiome composition in individuals with major depressive disorder. Zheng et al. (2016) performed 16S rRNA sequencing on fecal samples from 46 patients with MDD and 30 healthy controls and found significantly increased Actinobacteria and decreased Bacteroidetes in the depressed group. Crucially, when germ-free mice were colonized with fecal microbiota from MDD patients, they developed depressive-like behaviors (reduced sucrose preference, increased immobility in the forced swim test), while mice colonized with healthy donor microbiota did not — establishing a causal rather than merely correlational relationship.
+
+Fecal microbiota transplantation trials in humans are emerging. A 2023 randomized controlled trial by Green et al. at the University of Sydney enrolled 60 participants with treatment-resistant depression and randomized them to active FMT or placebo (autologous stool transplant). At 8 weeks, 32% of the active FMT group met response criteria (50% reduction in MADRS score) versus 11% in the placebo group (p=0.04). The effect was partially mediated by changes in fecal butyrate concentration, supporting the short-chain fatty acid hypothesis.
+
+Probiotic interventions ("psychobiotics") have accumulated a substantial evidence base. A 2019 meta-analysis by Liu et al. included 34 randomized controlled trials (N=2,102) examining probiotics for depressive symptoms. The pooled effect size was modest but significant (SMD = -0.24, 95% CI: -0.36 to -0.12, p < 0.001). Subgroup analyses revealed that multi-strain formulations were more effective than single-strain products (SMD = -0.31 vs -0.15), and that treatment durations exceeding 8 weeks produced larger effects than shorter courses. The most commonly effective strains were Lactobacillus helveticus R0052 and Bifidobacterium longum R0175, which Messaoudi et al. (2011) had earlier shown to reduce cortisol and self-reported psychological distress in healthy volunteers.
+
+Clinical Evidence: Anxiety
+
+The evidence for microbiome-based interventions in anxiety disorders is smaller but growing. Yang et al. (2019) conducted a systematic review of 21 studies (14 probiotic, 7 non-probiotic microbiome interventions) and found that 52% of studies showed a statistically significant reduction in anxiety symptoms. Interestingly, non-probiotic interventions (dietary modification, prebiotic supplementation) showed higher efficacy rates (86%) than probiotics alone (45%), suggesting that broad microbiome remodeling may be more effective than targeted strain supplementation.
+
+A notable finding comes from Tillisch et al. (2013), who used functional MRI to demonstrate that 4 weeks of fermented milk product consumption altered brain activity in regions controlling central processing of emotion and sensation. Specifically, participants consuming the fermented product showed reduced reactivity in the insula and somatosensory cortex in response to emotional face-matching tasks, providing direct neuroimaging evidence for gut-to-brain signaling in humans.
+
+Generalized anxiety disorder has received specific attention. A 2022 trial by Zhang et al. randomized 120 GAD patients to Lactobacillus plantarum PS128 or placebo for 12 weeks. The probiotic group showed significantly greater reductions in Hamilton Anxiety Rating Scale scores at weeks 8 and 12, with concurrent decreases in serum cortisol and interleukin-6 levels, suggesting both HPA axis and inflammatory pathway modulation.
+
+Metabolomic Biomarker Discovery
+
+The field is moving toward identifying microbiome-derived metabolic biomarkers that could guide treatment selection. Valles-Colomer et al. (2019) analyzed microbiome data from the Flemish Gut Flora Project (N=1,054) and identified Coprococcus and Dialister as consistently depleted in depression, even after controlling for antidepressant use. These bacteria are notable producers of the dopamine metabolite DOPAC and butyrate, respectively.
+
+Targeted metabolomics studies have identified several candidate biomarkers. Indole-3-propionic acid, a tryptophan metabolite produced exclusively by Clostridium sporogenes, shows neuroprotective properties and is reduced in MDD. Trimethylamine N-oxide, produced by microbial metabolism of dietary choline, is elevated in anxiety and correlates with amygdala reactivity on fMRI.
+
+The Clinical and Translational Neuroscience Laboratory at University College Cork has proposed a "microbiome signature" panel combining 16S abundance ratios (Firmicutes:Bacteroidetes, Coprococcus abundance), short-chain fatty acid profiles (butyrate:propionate ratio), and inflammatory markers (fecal calprotectin, serum IL-6) as a composite predictor of treatment response. Preliminary validation in a cohort of 200 patients showed an area under the receiver operating characteristic curve of 0.78 for predicting SSRI response, which if replicated could fundamentally change psychiatric treatment selection.
+
+Open Questions
+
+Several critical questions remain unresolved. The dose-response relationship for psychobiotics is poorly characterized — most trials use arbitrary doses of 1-10 billion colony-forming units without systematic dose-finding studies. The durability of effects after discontinuation is largely unstudied. The interaction between psychobiotics and conventional psychiatric medications needs systematic investigation, as early evidence suggests that SSRIs themselves alter gut microbiome composition, creating potential for both synergy and interference. Finally, individual variation in microbiome composition means that a one-size-fits-all probiotic approach may be fundamentally limited, pointing toward personalized microbiome-based therapies as the long-term direction for the field.
+FIXTURE
+)
+ENTRY_3=$(mcp_log_entry "$FIXTURE_3")
+if [ -n "$ENTRY_3" ]; then
+  pass "fixture 3 submitted: $ENTRY_3"
+  ENTRY_IDS+=("$ENTRY_3")
+else
+  fail "fixture 3 submission failed"
+fi
+
+SUBMITTED=${#ENTRY_IDS[@]}
+[ "$SUBMITTED" = "3" ] && pass "all 3 entries submitted via MCP" || fail "only $SUBMITTED/3 entries submitted"
+
+# ── 4. Poll entries until processed (max 360s) ────────────────────────────
+
+echo ""
+echo "  ⟳ polling entry states (max 360s)..."
+MAX_WAIT=360
+ELAPSED=0
+RESOLVED=0
+
+while [ $ELAPSED -lt $MAX_WAIT ] && [ $RESOLVED -lt $SUBMITTED ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  RESOLVED=0
+
+  for eid in "${ENTRY_IDS[@]}"; do
+    RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$eid" 2>/dev/null)
+    STATUS=$(echo "$RESP" | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+      RESOLVED=$((RESOLVED + 1))
+    elif [ "$STATUS" = "failed" ]; then
+      LAST_ERROR=$(echo "$RESP" | jq -r '.lastError // "unknown"')
+      echo "    ${ELAPSED}s — $eid FAILED: $LAST_ERROR"
+    fi
+  done
+
+  echo "    ${ELAPSED}s — $RESOLVED/$SUBMITTED resolved"
+done
+
+if [ "$RESOLVED" -eq "$SUBMITTED" ]; then
+  pass "all $SUBMITTED entries reached processed state in ${ELAPSED}s"
+else
+  fail "$RESOLVED/$SUBMITTED entries processed after ${MAX_WAIT}s"
+fi
+
+# ── 5. Report: fragment count, people count, edges ────────────────────────
+
+echo ""
+echo "  Querying knowledge graph state..."
+
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=200")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+
+PEOPLE_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people")
+PEOPLE_COUNT=$(echo "$PEOPLE_RESP" | jq '.people | length' 2>/dev/null || echo "0")
+
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+
+echo "  Fragment count: $FRAG_COUNT"
+echo "  People count:   $PEOPLE_COUNT"
+echo "  Graph nodes:    $NODE_COUNT"
+echo "  Graph edges:    $EDGE_COUNT"
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments extracted ($FRAG_COUNT total)"
+else
+  fail "no fragments found after pipeline processing"
+fi
+
+# ── 6. Check FRAGMENT_IN_WIKI edges for created wikis ─────────────────────
+
+echo ""
+echo "  Checking FRAGMENT_IN_WIKI edges per wiki..."
+
+check_wiki_edges() {
+  local wiki_id="$1"
+  local wiki_name="$2"
+
+  local wiki_graph
+  wiki_graph=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/graph?wikiId=$wiki_id")
+  local wiki_edges
+  wiki_edges=$(echo "$wiki_graph" | jq '.edges | length' 2>/dev/null || echo "0")
+  local wiki_nodes
+  wiki_nodes=$(echo "$wiki_graph" | jq '.nodes | length' 2>/dev/null || echo "0")
+
+  echo "  $wiki_name: $wiki_edges edges, $wiki_nodes nodes"
+
+  # Observe — fragment-to-wiki filing is probabilistic
+  if [ "$wiki_edges" -gt 0 ] 2>/dev/null; then
+    pass "FRAGMENT_IN_WIKI edges exist for '$wiki_name' ($wiki_edges edges)"
+  else
+    echo "  ⊘ no FRAGMENT_IN_WIKI edges yet for '$wiki_name' (probabilistic — not a failure)"
+  fi
+}
+
+[ -n "$WIKI_ID_1" ] && check_wiki_edges "$WIKI_ID_1" "Spaced Repetition"
+[ -n "$WIKI_ID_2" ] && check_wiki_edges "$WIKI_ID_2" "Urban Heat Island"
+[ -n "$WIKI_ID_3" ] && check_wiki_edges "$WIKI_ID_3" "Gut Microbiome"
+
+# Count total FRAGMENT_IN_WIKI edges across all research wikis
+TOTAL_FILING=0
+for wid in "$WIKI_ID_1" "$WIKI_ID_2" "$WIKI_ID_3"; do
+  [ -z "$wid" ] && continue
+  WG=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/graph?wikiId=$wid")
+  WE=$(echo "$WG" | jq '.edges | length' 2>/dev/null || echo "0")
+  TOTAL_FILING=$((TOTAL_FILING + WE))
+done
+
+echo ""
+echo "  Total FRAGMENT_IN_WIKI edges across research wikis: $TOTAL_FILING"
+
+# ── 7. Trigger regeneration ───────────────────────────────────────────────
+
+echo ""
+echo "  Triggering wiki regeneration..."
+
+regen_wiki() {
+  local wiki_id="$1"
+  local wiki_name="$2"
+
+  # Enable regen first (may already be enabled)
+  curl -s -o /dev/null -X PATCH -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d '{"regenerate":true}' \
+    "$SERVER_URL/wikis/$wiki_id/regenerate"
+
+  # Seed minimal content so regen has something to work with
+  curl -s -o /dev/null -X PUT -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"content\":\"Seed content for $wiki_name research wiki.\"}" \
+    "$SERVER_URL/api/content/wiki/$wiki_id"
+
+  local regen_resp
+  regen_resp=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$wiki_id/regenerate")
+  local regen_http=$(echo "$regen_resp" | tail -1)
+  local regen_body=$(echo "$regen_resp" | sed '$d')
+
+  if [ "$regen_http" = "200" ]; then
+    local frag_count
+    frag_count=$(echo "$regen_body" | jq -r '.fragmentCount // 0')
+    pass "regenerated '$wiki_name' → 200 (fragmentCount=$frag_count)"
+  else
+    local err_detail
+    err_detail=$(echo "$regen_body" | jq -r '.error // .detail // "unknown"' 2>/dev/null)
+    fail "regenerate '$wiki_name' → HTTP $regen_http ($err_detail)"
+  fi
+}
+
+[ -n "$WIKI_ID_1" ] && regen_wiki "$WIKI_ID_1" "Spaced Repetition"
+[ -n "$WIKI_ID_2" ] && regen_wiki "$WIKI_ID_2" "Urban Heat Island"
+[ -n "$WIKI_ID_3" ] && regen_wiki "$WIKI_ID_3" "Gut Microbiome"
+
+# ── 8. Report final wiki state ────────────────────────────────────────────
+
+echo ""
+echo "  Final wiki state:"
+
+report_wiki() {
+  local wiki_id="$1"
+  local wiki_name="$2"
+  [ -z "$wiki_id" ] && return
+
+  local detail
+  detail=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$wiki_id")
+
+  local name type state frag_count people_count has_content
+  name=$(echo "$detail" | jq -r '.name // "?"')
+  type=$(echo "$detail" | jq -r '.type // "?"')
+  state=$(echo "$detail" | jq -r '.state // "?"')
+  frag_count=$(echo "$detail" | jq -r '.fragments | length // 0' 2>/dev/null || echo "0")
+  people_count=$(echo "$detail" | jq -r '.people | length // 0' 2>/dev/null || echo "0")
+  has_content=$(echo "$detail" | jq -r 'if .content and (.content | length > 0) then "yes" else "no" end' 2>/dev/null)
+
+  echo ""
+  echo "  ┌─ $wiki_name"
+  echo "  │  id:         $wiki_id"
+  echo "  │  type:       $type"
+  echo "  │  state:      $state"
+  echo "  │  fragments:  $frag_count"
+  echo "  │  people:     $people_count"
+  echo "  │  content:    $has_content"
+  echo "  └─"
+
+  # Verify type is research
+  if [ "$type" = "research" ]; then
+    pass "wiki type is 'research' for '$wiki_name'"
+  else
+    fail "wiki type is '$type', expected 'research' for '$wiki_name'"
+  fi
+}
+
+report_wiki "$WIKI_ID_1" "Spaced Repetition"
+report_wiki "$WIKI_ID_2" "Urban Heat Island"
+report_wiki "$WIKI_ID_3" "Gut Microbiome"
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Research Wiki Type UAT Summary"
+echo "  $PASS passed, $FAIL failed, $SKIP skipped"
+echo "  Fragments: $FRAG_COUNT | People: $PEOPLE_COUNT | Edges: $EDGE_COUNT"
+echo "  FRAGMENT_IN_WIKI filing edges: $TOTAL_FILING"
+echo "════════════════════════════════════════════"
+```

--- a/.uat/plans/wiki-types/wiki-skill.md
+++ b/.uat/plans/wiki-types/wiki-skill.md
@@ -1,0 +1,459 @@
+# Wiki Type UAT — Skill
+
+## What it proves
+End-to-end lifecycle of the **skill** wiki type: create 3 skill wikis via API,
+seed wiki types, submit 3 realistic entries via MCP `log_entry`, poll until
+the pipeline processes them, report extracted fragments/people/edges, trigger
+on-demand wiki regeneration, and report final wiki state.
+
+A Skill wiki is "a knowledge base documenting a capability being developed or
+maintained." The 3 fixtures below represent realistic learning journals: Rust
+programming notes, sourdough baking technique, and fingerstyle guitar practice.
+
+## Prerequisites
+- Server running at `$SERVER_URL`
+- `OPENROUTER_API_KEY` set (for LLM extraction + regen)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` env vars
+
+## Fixtures
+
+### Fixture 1 — Learning Rust: Ownership and Borrowing
+
+> A programmer's study notes after their first month with Rust, covering
+> ownership semantics, the borrow checker, and early patterns learned.
+
+```
+I have been working through the Rust Book for about four weeks now, and the ownership system is finally starting to click. The first two weeks were rough. I kept fighting the borrow checker like it was an adversary instead of understanding that it is a collaborator trying to prevent me from writing memory-unsafe code.
+
+The core rule is deceptively simple: each value in Rust has exactly one owner, and when that owner goes out of scope, the value is dropped. But the implications cascade into every design decision. When I pass a String to a function, ownership moves unless I explicitly borrow with an ampersand reference. This tripped me up constantly in week one because in Python and JavaScript I never had to think about who "owns" data — everything is reference counted or garbage collected behind the scenes.
+
+Borrowing comes in two flavors and the distinction matters. An immutable borrow (&T) lets you read data without taking ownership, and you can have as many of these as you want simultaneously. A mutable borrow (&mut T) gives you exclusive write access, but the compiler enforces that no other references — mutable or immutable — exist at the same time. My mentor Sarah explained it as the "readers-writer lock" pattern baked into the type system. Once I internalized that analogy, the compiler errors went from cryptic to obvious.
+
+Lifetimes were the next hurdle. The compiler needs to know how long each reference is valid so it can guarantee no dangling pointers. Most of the time lifetime elision rules handle this automatically, but when you write functions that return references, you sometimes need explicit lifetime annotations like 'a. The syntax looks alien at first — fn longest<'a>(x: &'a str, y: &'a str) -> &'a str — but it is really just telling the compiler "the returned reference lives at least as long as both inputs."
+
+Pattern matching with match and if let has become one of my favorite features. Combined with Rust's enum system (especially Option and Result), it eliminates entire categories of null pointer bugs. I refactored a small CLI tool I had written in Python, and the Rust version caught three edge cases at compile time that the Python version only caught via runtime exceptions in production. Dr. James Chen from our systems reading group pointed out that this is exactly why Mozilla invested in Rust for Firefox — the browser engine cannot afford null dereference crashes.
+
+Practical patterns I have adopted so far: I clone liberally when prototyping (the Rust community calls this "clone-driven development") and then optimize ownership later once the logic is correct. I use .as_ref() and .as_deref() to convert between owned and borrowed types without unnecessary copying. I have started writing smaller functions that take references rather than owned values, which makes the borrow checker happier and keeps the call sites flexible.
+
+The cargo ecosystem is remarkable. Coming from npm, the fact that cargo handles building, testing, dependency management, and documentation in one tool feels luxurious. I set up cargo-watch for hot reloading during development, and clippy catches style issues that would take a senior Rust developer to spot. My colleague Marcus Rivera recommended the rust-analyzer LSP integration for VS Code, and it has been transformative — inline type hints and real-time borrow checker feedback make the learning curve much gentler.
+
+Next month I plan to tackle async Rust with tokio, which everyone warns is a significant step up in complexity. The Pin and Future traits apparently require a solid understanding of ownership to make sense, so I am glad I spent this month building that foundation.
+```
+
+### Fixture 2 — Sourdough Bread: Fermentation and Scoring Technique
+
+> A home baker's accumulated knowledge on sourdough fermentation timing,
+> dough shaping, and scoring patterns after six months of weekly bakes.
+
+```
+Six months of weekly sourdough bakes and I finally feel like I understand what the dough is telling me. The biggest lesson has nothing to do with recipes — it is about learning to read fermentation by touch and sight rather than by clock. Every kitchen is different. My apartment runs cool in winter (around 66 degrees Fahrenheit) and warm in summer (78 degrees), and that twenty-degree swing changes bulk fermentation time by three to four hours.
+
+The starter is everything. I maintain a 100% hydration starter (equal parts flour and water by weight) that I feed every twelve hours when baking and once a week when dormant in the fridge. The critical indicator of readiness is the float test — a spoonful of starter dropped in water should float within four hours of feeding. My baker friend Tomoko Hayashi taught me that the smell matters too: ripe starter smells like overripe fruit with a slight vinegar tang. If it smells like nail polish remover (ethyl acetate), it has over-fermented and needs a couple of back-to-back feedings to recover.
+
+Bulk fermentation is where most beginners go wrong, myself included. The dough needs to increase in volume by roughly 50 to 75 percent — not double, which is the old advice from commercial yeast recipes. I use a straight-sided clear container with a rubber band marking the starting level. Stretch-and-fold sets every thirty minutes for the first two hours build gluten structure without the heavy kneading that traditional bread requires. After the folds, I leave the dough alone and check it every hour. The signs of readiness: the dough is domed on top, jiggles when you shake the container, and you can see bubbles along the sides and bottom.
+
+Cold retard in the refrigerator is the secret weapon. After shaping, I put the dough in a banneton lined with rice flour and refrigerate it for 12 to 18 hours. This slows fermentation dramatically while allowing enzymes to break down starches into sugars, which produces better flavor complexity and a darker, more caramelized crust. The cold also firms up the dough, making it much easier to score cleanly. Chef Antonio Rossi at the community baking workshop emphasized that professional bakeries retard overnight specifically for scoring control, not just scheduling convenience.
+
+Shaping is a two-stage process. First comes the pre-shape: gently tip the dough onto an unfloured surface, use a bench scraper to fold it into a rough round, and let it rest for 20 to 30 minutes covered with a damp towel. The bench rest lets the gluten relax so the final shape does not fight back. For the final shape, I flour the top of the dough, flip it, and pull the edges toward the center like folding an envelope. Then I flip it seam-side down and use the bench scraper to drag it toward me on the unfloured surface, building surface tension. The dough should feel taut, like a filled water balloon. If it tears, the gluten was not developed enough during bulk.
+
+Scoring is both functional and artistic. The functional purpose is to control where the bread expands during the initial oven spring — without a score, the loaf will burst unpredictably along its weakest seam. I use a double-edged razor blade (lame) held at roughly 45 degrees to the surface. A shallow angle creates the coveted "ear" — that crispy flap of crust that lifts during baking. A perpendicular cut gives a more open, rustic split. My go-to pattern is a single curved slash off-center, about a quarter inch deep. For decorative loaves I add wheat stalk designs using a fine-tipped blade, though these are purely cosmetic cuts (very shallow, about an eighth of an inch) that do not affect oven spring.
+
+The bake itself follows a two-phase approach. Phase one: 20 minutes at 500 degrees Fahrenheit in a preheated Dutch oven with the lid on. The trapped steam keeps the crust pliable so the bread can expand fully. Phase two: remove the lid, drop to 450 degrees, and bake another 20 to 25 minutes until the crust is deeply caramelized — darker than you think is right. I learned from Lucia Fernandez, who runs a micro-bakery in our neighborhood, that the internal temperature should hit 208 to 210 degrees Fahrenheit. Below that and the crumb will be gummy. I let the loaf cool on a wire rack for at least two hours before cutting. The crumb is still setting during cooling and cutting too early compresses the structure.
+```
+
+### Fixture 3 — Fingerstyle Guitar: Practice Log and Technique Notes
+
+> A guitarist's practice journal tracking their progression from basic
+> fingerpicking patterns through Travis picking to arrangement work.
+
+```
+Three months into dedicated fingerstyle practice after playing with a pick for six years. The transition has been humbling but deeply rewarding. My right hand is essentially relearning how to interact with the strings, and the independence required between thumb and fingers is a completely different motor skill than flatpicking.
+
+The foundation is the PIMA system: P (pulgar) for the thumb covering bass strings (E, A, D), I (indice) index finger on the G string, M (medio) middle finger on the B string, and A (anular) ring finger on the high E string. My teacher Robert Nakamura insists on strict assignment during the first month — no cheating by letting fingers drift to adjacent strings. The discipline pays off because once the default assignments are automatic, you can break the rules intentionally for musical effect rather than out of sloppiness.
+
+The first exercise that really built my foundation was a simple arpeggiated pattern in 4/4 time: P-I-M-A-M-I repeated over basic open chords (C, Am, G, Em). I practiced this with a metronome at 60 BPM for two weeks before increasing to 72, then 80. The key insight from my practice: speed comes from relaxation, not effort. When I tense my right hand trying to go faster, the tone gets thin and scratchy. When I focus on a loose wrist and letting each finger fall naturally into the string with just enough force, the tone is warm and full, and paradoxically the tempo increases on its own.
+
+Travis picking was the first major milestone. Named after Merle Travis, this pattern uses an alternating bass note on the thumb (typically root-fifth or root-octave) while the fingers pick a melody or fill pattern on the treble strings. The thumb becomes a metronome — steady alternating bass regardless of what the fingers are doing above. I spent three weeks just on the thumb pattern alone, walking bass lines over chord changes without adding any finger melody. My practice partner Elena Kowalski, who has been playing fingerstyle for ten years, told me that most people rush this step and it shows in their playing forever. The bass needs to be rock solid before layering anything on top.
+
+The independence between thumb and fingers is the core technical challenge. I use a practice technique where I play the thumb pattern and sing a simple melody simultaneously — if I can sing independently of the thumb, my brain has truly separated the two motor tasks. Then I transfer the sung melody to the fingers. This approach was slower initially but produced much more reliable independence than trying to coordinate both hands from the start.
+
+Nail maintenance has become surprisingly important. I keep my right hand fingernails about 1 to 2 millimeters past the fingertip, shaped with a fine-grit nail file into a smooth ramp that follows the natural curve of each finger's attack angle. The tone difference between well-maintained nails and ragged ones is dramatic — smooth nails produce a clear, bell-like tone while rough edges create a scratchy, unfocused sound. I file after every practice session and apply a nail hardener weekly. My luthier, David Park, mentioned that classical guitarists are equally obsessive about their nails and some even carry emergency nail repair kits to performances.
+
+Current repertoire work focuses on three arrangements that cover different technical demands. First is "Dust in the Wind" by Kansas, which is essentially a Travis picking etude with a moving melody — good for cementing the alternating bass habit. Second is an arrangement of "Hallelujah" by Leonard Cohen that requires barre chords with fingerpicking, which is a left-hand stamina challenge since you cannot relax the barre between notes the way you can between strums. Third is Chet Atkins' arrangement of "Mr. Sandman," which is the aspirational piece — full chord melody with walking bass, harmonics, and position shifts. I can play about 60 percent of it at tempo but the B section still falls apart when the bass line becomes chromatic.
+
+Practice structure that works for me: 10 minutes of PIMA warm-up patterns across all positions, 15 minutes of isolated technical work (currently focused on hammer-ons and pull-offs within fingerpicking patterns — my teacher calls these "ornaments"), 20 minutes of repertoire practice with a metronome, and 5 minutes of free improvisation over a simple chord loop to keep the creativity alive. Total of 50 minutes daily, six days a week with one rest day. The consistency matters more than the duration according to virtually every resource I have consulted.
+```
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Skill"
+echo ""
+
+# Check OpenRouter key (needed for pipeline + regen)
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping skill wiki type test"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── 0. Sign in ────────────────────────────────────────────────
+curl -s -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"${INITIAL_USERNAME:-}\",\"password\":\"${INITIAL_PASSWORD:-}\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" >/dev/null
+
+# ── 1. Get MCP token from profile ────────────────────────────
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -z "$MCP_URL" ] || [ "$MCP_URL" = "null" ]; then
+  fail "mcpEndpointUrl not in profile — cannot continue"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+pass "MCP token retrieved"
+
+# Helper: MCP JSON-RPC call → parse SSE data: line
+mcp_call() {
+  local payload="$1"
+  local raw
+  raw=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "$payload" \
+    "$MCP_URL" 2>/dev/null)
+  echo "$raw" | grep '^data: ' | head -1 | sed 's/^data: //'
+}
+
+# MCP initialize (required before tool calls)
+mcp_call '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-skill","version":"1.0"}}}' >/dev/null
+
+# ── 2. Seed wiki types ───────────────────────────────────────
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "wiki-types seed → HTTP $SEED_HTTP"
+
+# Verify 'skill' type exists
+TYPES=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/wiki-types")
+HAS_SKILL=$(echo "$TYPES" | jq '[.wikiTypes[].slug] | any(. == "skill")' 2>/dev/null)
+[ "$HAS_SKILL" = "true" ] && pass "skill wiki type present" || fail "skill wiki type missing after seed"
+
+# ── 3. Create 3 skill wikis via API ──────────────────────────
+declare -a WIKI_KEYS=()
+declare -a WIKI_SLUGS=()
+TS=$(date +%s)
+
+create_skill_wiki() {
+  local name="$1"
+  local desc="$2"
+  local result
+  result=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"$name\",\"type\":\"skill\",\"prompt\":\"\"}" \
+    "$SERVER_URL/wikis")
+  local http=$(echo "$result" | tail -1)
+  local body=$(echo "$result" | sed '$d')
+  local key=$(echo "$body" | jq -r '.lookupKey // .id // ""')
+  local slug=$(echo "$body" | jq -r '.slug // ""')
+  if [ "$http" = "201" ] && [ -n "$key" ]; then
+    pass "POST /wikis → 201 ($name), key=$key"
+    WIKI_KEYS+=("$key")
+    WIKI_SLUGS+=("$slug")
+  else
+    fail "POST /wikis ($name) → HTTP $http"
+  fi
+}
+
+create_skill_wiki "Learning Rust $TS" "A knowledge base for building capability in Rust programming, covering ownership, borrowing, lifetimes"
+create_skill_wiki "Sourdough Baking $TS" "A knowledge base for developing sourdough bread baking capability, fermentation and scoring technique"
+create_skill_wiki "Fingerstyle Guitar $TS" "A knowledge base for building fingerstyle guitar capability, practice patterns and technique"
+
+if [ "${#WIKI_KEYS[@]}" -lt 3 ]; then
+  fail "could not create all 3 skill wikis — aborting"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# ── 4. Submit 3 entries via MCP log_entry ─────────────────────
+
+# Fixture 1: Rust ownership and borrowing
+read -r -d '' FIXTURE_RUST << 'FIXTURE_EOF'
+I have been working through the Rust Book for about four weeks now, and the ownership system is finally starting to click. The first two weeks were rough. I kept fighting the borrow checker like it was an adversary instead of understanding that it is a collaborator trying to prevent me from writing memory-unsafe code. The core rule is deceptively simple: each value in Rust has exactly one owner, and when that owner goes out of scope, the value is dropped. But the implications cascade into every design decision. When I pass a String to a function, ownership moves unless I explicitly borrow with an ampersand reference. This tripped me up constantly in week one because in Python and JavaScript I never had to think about who owns data — everything is reference counted or garbage collected behind the scenes.
+
+Borrowing comes in two flavors and the distinction matters. An immutable borrow lets you read data without taking ownership, and you can have as many of these as you want simultaneously. A mutable borrow gives you exclusive write access, but the compiler enforces that no other references — mutable or immutable — exist at the same time. My mentor Sarah explained it as the readers-writer lock pattern baked into the type system. Once I internalized that analogy, the compiler errors went from cryptic to obvious.
+
+Lifetimes were the next hurdle. The compiler needs to know how long each reference is valid so it can guarantee no dangling pointers. Most of the time lifetime elision rules handle this automatically, but when you write functions that return references, you sometimes need explicit lifetime annotations like the tick-a syntax. It looks alien at first but it is really just telling the compiler that the returned reference lives at least as long as both inputs.
+
+Pattern matching with match and if let has become one of my favorite features. Combined with the enum system, especially Option and Result, it eliminates entire categories of null pointer bugs. I refactored a small CLI tool I had written in Python, and the Rust version caught three edge cases at compile time that the Python version only caught via runtime exceptions in production. Dr. James Chen from our systems reading group pointed out that this is exactly why Mozilla invested in Rust for Firefox — the browser engine cannot afford null dereference crashes.
+
+Practical patterns I have adopted so far: I clone liberally when prototyping (the Rust community calls this clone-driven development) and then optimize ownership later once the logic is correct. I use as_ref and as_deref to convert between owned and borrowed types without unnecessary copying. I have started writing smaller functions that take references rather than owned values, which makes the borrow checker happier and keeps the call sites flexible.
+
+The cargo ecosystem is remarkable. Coming from npm, the fact that cargo handles building, testing, dependency management, and documentation in one tool feels luxurious. I set up cargo-watch for hot reloading during development, and clippy catches style issues that would take a senior Rust developer to spot. My colleague Marcus Rivera recommended the rust-analyzer LSP integration for VS Code, and it has been transformative — inline type hints and real-time borrow checker feedback make the learning curve much gentler.
+
+Next month I plan to tackle async Rust with tokio, which everyone warns is a significant step up in complexity. The Pin and Future traits apparently require a solid understanding of ownership to make sense, so I am glad I spent this month building that foundation.
+FIXTURE_EOF
+
+# Fixture 2: Sourdough fermentation and scoring
+read -r -d '' FIXTURE_BREAD << 'FIXTURE_EOF'
+Six months of weekly sourdough bakes and I finally feel like I understand what the dough is telling me. The biggest lesson has nothing to do with recipes — it is about learning to read fermentation by touch and sight rather than by clock. Every kitchen is different. My apartment runs cool in winter around 66 degrees Fahrenheit and warm in summer at 78 degrees, and that twenty-degree swing changes bulk fermentation time by three to four hours.
+
+The starter is everything. I maintain a 100 percent hydration starter (equal parts flour and water by weight) that I feed every twelve hours when baking and once a week when dormant in the fridge. The critical indicator of readiness is the float test — a spoonful of starter dropped in water should float within four hours of feeding. My baker friend Tomoko Hayashi taught me that the smell matters too: ripe starter smells like overripe fruit with a slight vinegar tang. If it smells like nail polish remover (ethyl acetate), it has over-fermented and needs a couple of back-to-back feedings to recover.
+
+Bulk fermentation is where most beginners go wrong, myself included. The dough needs to increase in volume by roughly 50 to 75 percent — not double, which is the old advice from commercial yeast recipes. I use a straight-sided clear container with a rubber band marking the starting level. Stretch-and-fold sets every thirty minutes for the first two hours build gluten structure without the heavy kneading that traditional bread requires. After the folds, I leave the dough alone and check it every hour. The signs of readiness: the dough is domed on top, jiggles when you shake the container, and you can see bubbles along the sides and bottom.
+
+Cold retard in the refrigerator is the secret weapon. After shaping, I put the dough in a banneton lined with rice flour and refrigerate it for 12 to 18 hours. This slows fermentation dramatically while allowing enzymes to break down starches into sugars, which produces better flavor complexity and a darker, more caramelized crust. The cold also firms up the dough, making it much easier to score cleanly. Chef Antonio Rossi at the community baking workshop emphasized that professional bakeries retard overnight specifically for scoring control, not just scheduling convenience.
+
+Shaping is a two-stage process. First comes the pre-shape: gently tip the dough onto an unfloured surface, use a bench scraper to fold it into a rough round, and let it rest for 20 to 30 minutes covered with a damp towel. The bench rest lets the gluten relax so the final shape does not fight back. For the final shape, I flour the top of the dough, flip it, and pull the edges toward the center like folding an envelope. Then I flip it seam-side down and use the bench scraper to drag it toward me on the unfloured surface, building surface tension. The dough should feel taut, like a filled water balloon. If it tears, the gluten was not developed enough during bulk.
+
+Scoring is both functional and artistic. The functional purpose is to control where the bread expands during the initial oven spring — without a score, the loaf will burst unpredictably along its weakest seam. I use a double-edged razor blade held at roughly 45 degrees to the surface. A shallow angle creates the coveted ear — that crispy flap of crust that lifts during baking. A perpendicular cut gives a more open, rustic split. My go-to pattern is a single curved slash off-center, about a quarter inch deep.
+
+The bake itself follows a two-phase approach. Phase one: 20 minutes at 500 degrees Fahrenheit in a preheated Dutch oven with the lid on. The trapped steam keeps the crust pliable so the bread can expand fully. Phase two: remove the lid, drop to 450 degrees, and bake another 20 to 25 minutes until the crust is deeply caramelized. I learned from Lucia Fernandez, who runs a micro-bakery in our neighborhood, that the internal temperature should hit 208 to 210 degrees Fahrenheit. Below that and the crumb will be gummy. I let the loaf cool on a wire rack for at least two hours before cutting.
+FIXTURE_EOF
+
+# Fixture 3: Fingerstyle guitar practice
+read -r -d '' FIXTURE_GUITAR << 'FIXTURE_EOF'
+Three months into dedicated fingerstyle practice after playing with a pick for six years. The transition has been humbling but deeply rewarding. My right hand is essentially relearning how to interact with the strings, and the independence required between thumb and fingers is a completely different motor skill than flatpicking.
+
+The foundation is the PIMA system: P (pulgar) for the thumb covering bass strings E, A, and D, I (indice) index finger on the G string, M (medio) middle finger on the B string, and A (anular) ring finger on the high E string. My teacher Robert Nakamura insists on strict assignment during the first month — no cheating by letting fingers drift to adjacent strings. The discipline pays off because once the default assignments are automatic, you can break the rules intentionally for musical effect rather than out of sloppiness.
+
+The first exercise that really built my foundation was a simple arpeggiated pattern in 4/4 time: P-I-M-A-M-I repeated over basic open chords (C, Am, G, Em). I practiced this with a metronome at 60 BPM for two weeks before increasing to 72, then 80. The key insight from my practice: speed comes from relaxation, not effort. When I tense my right hand trying to go faster, the tone gets thin and scratchy. When I focus on a loose wrist and letting each finger fall naturally into the string with just enough force, the tone is warm and full, and paradoxically the tempo increases on its own.
+
+Travis picking was the first major milestone. Named after Merle Travis, this pattern uses an alternating bass note on the thumb (typically root-fifth or root-octave) while the fingers pick a melody or fill pattern on the treble strings. The thumb becomes a metronome — steady alternating bass regardless of what the fingers are doing above. I spent three weeks just on the thumb pattern alone, walking bass lines over chord changes without adding any finger melody. My practice partner Elena Kowalski, who has been playing fingerstyle for ten years, told me that most people rush this step and it shows in their playing forever. The bass needs to be rock solid before layering anything on top.
+
+The independence between thumb and fingers is the core technical challenge. I use a practice technique where I play the thumb pattern and sing a simple melody simultaneously — if I can sing independently of the thumb, my brain has truly separated the two motor tasks. Then I transfer the sung melody to the fingers. This approach was slower initially but produced much more reliable independence than trying to coordinate both hands from the start.
+
+Nail maintenance has become surprisingly important. I keep my right hand fingernails about 1 to 2 millimeters past the fingertip, shaped with a fine-grit nail file into a smooth ramp that follows the natural curve of each finger's attack angle. The tone difference between well-maintained nails and ragged ones is dramatic — smooth nails produce a clear, bell-like tone while rough edges create a scratchy, unfocused sound. I file after every practice session and apply a nail hardener weekly. My luthier, David Park, mentioned that classical guitarists are equally obsessive about their nails and some even carry emergency nail repair kits to performances.
+
+Current repertoire work focuses on three arrangements that cover different technical demands. First is Dust in the Wind by Kansas, which is essentially a Travis picking etude with a moving melody — good for cementing the alternating bass habit. Second is an arrangement of Hallelujah by Leonard Cohen that requires barre chords with fingerpicking, which is a left-hand stamina challenge since you cannot relax the barre between notes the way you can between strums. Third is Chet Atkins arrangement of Mr. Sandman, which is the aspirational piece — full chord melody with walking bass, harmonics, and position shifts.
+
+Practice structure that works for me: 10 minutes of PIMA warm-up patterns across all positions, 15 minutes of isolated technical work (currently focused on hammer-ons and pull-offs within fingerpicking patterns), 20 minutes of repertoire practice with a metronome, and 5 minutes of free improvisation over a simple chord loop to keep the creativity alive. Total of 50 minutes daily, six days a week with one rest day. The consistency matters more than the duration according to virtually every resource I have consulted.
+FIXTURE_EOF
+
+declare -a ENTRY_KEYS=()
+
+submit_entry() {
+  local label="$1"
+  local content="$2"
+  local payload
+  payload=$(jq -n --arg c "$content" '{
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "log_entry",
+      arguments: { content: $c, source: "mcp" }
+    }
+  }')
+  local resp
+  resp=$(mcp_call "$payload")
+  local text
+  text=$(echo "$resp" | jq -r '.result.content[0].text // ""' 2>/dev/null)
+  local is_error
+  is_error=$(echo "$resp" | jq -r '.result.isError // false' 2>/dev/null)
+
+  if [ "$is_error" = "true" ]; then
+    fail "MCP log_entry ($label): $text"
+    return
+  fi
+
+  # Extract entry key from "Entry queued: entry01XXXX..."
+  local ekey
+  ekey=$(echo "$text" | grep -oP 'entry[0-9A-Z]{26}' | head -1)
+  if [ -n "$ekey" ]; then
+    pass "MCP log_entry ($label) → $ekey"
+    ENTRY_KEYS+=("$ekey")
+  else
+    fail "MCP log_entry ($label): no entry key in response: $text"
+  fi
+}
+
+submit_entry "Rust" "$FIXTURE_RUST"
+submit_entry "Sourdough" "$FIXTURE_BREAD"
+submit_entry "Guitar" "$FIXTURE_GUITAR"
+
+echo ""
+echo "  submitted ${#ENTRY_KEYS[@]} entries, polling pipeline..."
+
+# ── 5. Poll until all entries reach processed (max 360s) ──────
+ELAPSED=0
+MAX_WAIT=360
+RESOLVED_COUNT=0
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+  RESOLVED_COUNT=0
+
+  for ekey in "${ENTRY_KEYS[@]}"; do
+    STATUS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$ekey" 2>/dev/null | jq -r '.ingestStatus // .state // "unknown"')
+    if [ "$STATUS" = "processed" ] || [ "$STATUS" = "RESOLVED" ]; then
+      RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+    fi
+  done
+
+  echo "    ${ELAPSED}s — $RESOLVED_COUNT/${#ENTRY_KEYS[@]} entries processed"
+  if [ "$RESOLVED_COUNT" -ge "${#ENTRY_KEYS[@]}" ]; then
+    break
+  fi
+done
+
+if [ "$RESOLVED_COUNT" -ge "${#ENTRY_KEYS[@]}" ]; then
+  pass "all ${#ENTRY_KEYS[@]} entries processed in ${ELAPSED}s"
+else
+  fail "only $RESOLVED_COUNT/${#ENTRY_KEYS[@]} entries processed after ${MAX_WAIT}s"
+fi
+
+# ── 6. Report fragments ──────────────────────────────────────
+echo ""
+echo "  -- Fragment report --"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+echo "    total fragments: $FRAG_COUNT"
+
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments created ($FRAG_COUNT)"
+  # Show first 5 fragment titles
+  echo "$FRAGS" | jq -r '.fragments[:5][] | "    - \(.title // .slug)"' 2>/dev/null
+else
+  fail "no fragments after pipeline"
+fi
+
+# ── 7. Report people (entity extraction) ─────────────────────
+echo ""
+echo "  -- People report --"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+echo "    total people: $PEOPLE_COUNT"
+
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT)"
+  echo "$PEOPLE" | jq -r '.people[] | "    - \(.canonicalName // .name)"' 2>/dev/null
+else
+  # People extraction is fail-open; not a hard failure
+  skip "no people extracted (entity extraction may have been skipped)"
+fi
+
+# ── 8. Report edges (graph) ──────────────────────────────────
+echo ""
+echo "  -- Edge report --"
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+echo "    nodes: $NODE_COUNT, edges: $EDGE_COUNT"
+
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph edges exist ($EDGE_COUNT)"
+  # Break down edge types
+  echo "$GRAPH" | jq -r '[.edges[].edgeType] | group_by(.) | map("\(.[0]): \(length)") | .[]' 2>/dev/null | while read -r line; do
+    echo "    $line"
+  done
+else
+  fail "no edges in graph"
+fi
+
+# ── 9. Check skill wikis have fragments linked ───────────────
+echo ""
+echo "  -- Wiki-fragment linkage --"
+for i in 0 1 2; do
+  SLUG="${WIKI_SLUGS[$i]}"
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  WIKI_STATE=$(echo "$DETAIL" | jq -r '.state // "unknown"')
+  WIKI_FRAG_COUNT=$(echo "$DETAIL" | jq '.fragments | length // 0' 2>/dev/null || echo "0")
+  echo "    $SLUG: state=$WIKI_STATE, fragments=$WIKI_FRAG_COUNT"
+done
+
+# ── 10. Trigger on-demand regen for first skill wiki ─────────
+echo ""
+echo "  -- Regeneration --"
+REGEN_KEY="${WIKI_KEYS[0]}"
+REGEN_SLUG="${WIKI_SLUGS[0]}"
+
+# Enable regeneration
+curl -s -o /dev/null -X PATCH -b "$COOKIE_JAR" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d '{"regenerate":true}' \
+  "$SERVER_URL/wikis/$REGEN_KEY/regenerate"
+
+REGEN_HTTP=$(curl -s -o /tmp/uat-skill-regen.json -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wikis/$REGEN_KEY/regenerate")
+
+if [ "$REGEN_HTTP" = "200" ]; then
+  REGEN_FCOUNT=$(jq '.fragmentCount // 0' /tmp/uat-skill-regen.json 2>/dev/null)
+  pass "POST /wikis/:id/regenerate → 200 ($REGEN_SLUG, $REGEN_FCOUNT fragments)"
+else
+  fail "POST /wikis/:id/regenerate → HTTP $REGEN_HTTP"
+  jq '.' /tmp/uat-skill-regen.json 2>/dev/null
+fi
+
+# ── 11. Report final wiki state ──────────────────────────────
+echo ""
+echo "  -- Final wiki state --"
+for i in 0 1 2; do
+  DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/${WIKI_KEYS[$i]}")
+  WIKI_NAME=$(echo "$DETAIL" | jq -r '.name // "?"')
+  WIKI_STATE=$(echo "$DETAIL" | jq -r '.state // "unknown"')
+  WIKI_TYPE=$(echo "$DETAIL" | jq -r '.type // "unknown"')
+  WIKI_HAS_CONTENT=$(echo "$DETAIL" | jq 'if .content and (.content | length > 0) then "yes" else "no" end' 2>/dev/null)
+  CONTENT_LEN=$(echo "$DETAIL" | jq '.content | length // 0' 2>/dev/null || echo "0")
+  echo "    $WIKI_NAME: type=$WIKI_TYPE, state=$WIKI_STATE, hasContent=$WIKI_HAS_CONTENT (${CONTENT_LEN} chars)"
+
+  if [ "$WIKI_TYPE" = "skill" ]; then
+    pass "wiki type is skill ($WIKI_NAME)"
+  else
+    fail "wiki type is $WIKI_TYPE, expected skill ($WIKI_NAME)"
+  fi
+done
+
+# ── 12. Cleanup: delete test wikis ───────────────────────────
+echo ""
+echo "  -- Cleanup --"
+for key in "${WIKI_KEYS[@]}"; do
+  DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE -b "$COOKIE_JAR" \
+    -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis/$key")
+  if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "200" ]; then
+    pass "DELETE wiki $key"
+  else
+    fail "DELETE wiki $key → HTTP $DEL_HTTP"
+  fi
+done
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```

--- a/.uat/plans/wiki-types/wiki-voice.md
+++ b/.uat/plans/wiki-types/wiki-voice.md
@@ -1,0 +1,496 @@
+# Wiki Type UAT — Voice
+
+## What it proves
+End-to-end lifecycle for **voice** wikis: create 3 voice wikis, seed wiki types,
+submit 3 entries via MCP (one per wiki), poll until processed, report extracted
+fragments/people/edges, trigger regeneration, report final wiki state.
+
+Voice wikis are "a style guide capturing communication patterns, tone preferences,
+and voice identity."
+
+## Prerequisites
+- Server running at `$SERVER_URL` (default `http://localhost:3000`)
+- `core/.env` populated with auth credentials
+- `OPENROUTER_API_KEY` set in environment for LLM calls
+
+## Fixtures
+
+### Fixture 1 — Startup Product Voice Guide
+
+> A founder documents the communication voice for their early-stage SaaS product,
+> covering website copy, onboarding flows, error messages, and support channels.
+
+```
+Our product voice is the personality behind every word a user reads. We sound like a sharp friend who happens to be an expert — never a faceless corporation, never a condescending tutorial. Here is how we talk.
+
+Core voice attributes: We are confident but not arrogant. When we know something, we say it plainly. We do not hedge with phrases like "we think" or "it might be possible that" unless genuine uncertainty exists. We are warm but efficient. Every sentence earns its place. We cut filler words ruthlessly — "actually," "basically," "just," "really" — unless they serve rhythm. We are precise about technical concepts but relaxed in delivery. A user should feel like they are reading a well-edited Slack message from a senior engineer, not a legal document.
+
+Website copy guidelines: Headlines are active and specific. "Ship faster with automated deploys" beats "A solution for modern deployment workflows." Subheadings answer the question the headline raises. Body copy uses second person — "you" not "users" or "one." Feature descriptions lead with the outcome, not the mechanism. Wrong: "Our CI/CD pipeline integrates with GitHub Actions via webhook listeners." Right: "Push to main and your changes are live in ninety seconds." We never use superlatives we cannot prove. No "fastest," "most powerful," or "best-in-class" without a benchmark or citation.
+
+Onboarding flow voice: First-run copy is encouraging without being patronizing. We acknowledge the user made a choice by signing up and we respect their time. Progress indicators use concrete language — "3 steps left" not "almost there!" Error states during setup are honest and actionable. "We could not connect to your GitHub account. Check that the OAuth app has repo access, then try again." We avoid cute error messages during onboarding because confusion compounds when someone is already learning. Celebration moments are brief. A checkmark and "You're set up" is better than confetti and three paragraphs of congratulation.
+
+Error messages and system notifications: Every error message follows the pattern: what happened, why it matters, what to do next. We do not blame the user. "That API key is not valid" not "You entered an invalid API key." We distinguish between user-fixable problems and system problems. If the user cannot fix it, we say so: "Something went wrong on our end. We have been notified and are looking into it." Retry messaging includes expected wait times when possible. "Try again in a few minutes" beats "try again later." We never show raw error codes to users unless they are filing a support ticket, in which case we display them in a copyable format.
+
+Support channel tone: Support conversations are warmer than product copy but equally precise. We greet by name when available. We do not use canned responses verbatim — templates exist as starting points, not scripts. Empathy is shown through action, not performative phrases. Instead of "I completely understand your frustration," we say "Let me fix that for you right now" and then do it. We explain what we are doing and why, so the user learns something. Closing a ticket includes a concrete summary of what changed and what the user should expect going forward.
+
+Words we use: ship, build, connect, set up, check, update, deploy, configure. Words we avoid: leverage, utilize, facilitate, synergize, disrupt, innovative, cutting-edge, next-generation, seamless. Contractions are default: "we're," "you'll," "it's." Full forms are reserved for emphasis or legal contexts. Numbers under ten are spelled out in marketing copy, written as digits in product UI.
+```
+
+### Fixture 2 — Nonprofit Organization Communication Tone
+
+> A nonprofit's communications director documents voice standards for grant
+> proposals, donor outreach, social media, and internal team communications.
+
+```
+The Meridian Foundation speaks with one voice across every channel, from a grant application to an Instagram caption. That voice reflects who we are: practitioners first, advocates second, storytellers when it serves the mission. This document defines how we communicate and why those choices matter.
+
+Our foundational voice principles: We lead with evidence, not emotion. Our work creates real impact and we let the numbers and stories speak. We never manufacture urgency or guilt. A donor who gives because they feel informed and inspired will give again. A donor who gives because they feel manipulated will not. We are specific about outcomes. "Provided clean water access to 4,200 households in the Rift Valley" is stronger than "helped thousands of families." We name places, count people, and cite timelines. We respect the communities we serve by centering their agency. They are not passive recipients of our help. They are partners, collaborators, and leaders in their own development. We say "families who participate in the program" not "families we serve" or "beneficiaries."
+
+Grant proposal voice: Grant writing is precise, evidence-based, and forward-looking. We match the funder's vocabulary without losing our own voice. If a foundation uses "theory of change," we use it. If they prefer "logic model," we adapt. Proposals follow the structure the funder requests — creativity in structure is not appreciated. Every claim is sourced. We cite our own longitudinal data when available, third-party evaluations when they exist, and peer-reviewed research as context. Budget narratives read as clearly as program narratives. A program officer should understand exactly what each line item funds and why that amount is reasonable. We avoid jargon that obscures meaning. "Capacity building" only appears if we immediately define what capacity we are building and how.
+
+Donor communication guidelines: Annual reports tell stories that data alone cannot. Each report opens with a single person or community whose trajectory changed because of the work. That person is named, quoted, and photographed only with their informed consent and editorial approval. Appeal letters are honest about what money does. We break down costs concretely: "Your gift of one hundred fifty dollars trains one community health worker for six months." We never imply that a single donation can solve a systemic problem. Acknowledgment letters are sent within forty-eight hours. They are warm, specific about the gift amount and designation, and include a sentence about recent program impact. Tax receipt language is clear and separated from emotional content. Email subject lines are factual, not clickbait. "Q3 Impact Report: Rift Valley Water Project" not "You Won't Believe What Your Donation Did."
+
+Social media tone: Social media is where we are most conversational but never casual about the work. We post original photography with informed consent documentation on file. Stock photos are never used to represent communities or program participants. Captions lead with the most interesting fact or quote. Attribution is always included for quotes. We engage with comments thoughtfully and within twenty-four hours. We do not argue with critics publicly — we acknowledge, provide factual corrections if needed, and move substantive disagreements to direct messages. Hashtags are limited to three per post, all directly relevant to the content. We do not use trending hashtags that are unrelated to our mission. Humor is acceptable when it is self-deprecating or celebratory. We never joke about the problems we exist to address.
+
+Internal communication standards: Internal emails and Slack messages model the same clarity we expect in external communications. Meeting agendas are circulated twenty-four hours in advance with required pre-reads clearly marked. Decision memos follow the BLUF format: bottom line up front, then supporting context. Feedback is specific, timely, and directed at work product rather than character. "The budget narrative needs stronger justification for the staffing increase" is useful. "This section needs work" is not. We cc people intentionally, not defensively. When staff disagree about strategy, the conversation happens in a meeting with a decision-maker present, not in an email thread. Andrea Williams established these standards in 2019 and they were revised by Marcus Chen during the 2023 organizational review.
+```
+
+### Fixture 3 — Personal Writing Voice Journal
+
+> An individual writer journals about their evolving writing voice, capturing
+> lessons from mentors, editorial feedback, and self-observation about their prose
+> tendencies across blog posts, essays, and professional correspondence.
+
+```
+I have been thinking about voice as a writer for years but only recently started documenting what I actually do versus what I think I do. This is my attempt to pin down the patterns, good and bad, so I can be intentional about them instead of just hoping for consistency.
+
+What my voice sounds like at its best: When I am writing well, my sentences are medium-length and varied in rhythm. I tend toward a three-beat pattern — short, medium, long — and then reset. I use concrete nouns and active verbs. I reach for metaphors from physical craft: woodworking, cooking, building. My friend Dara once told me that my best writing sounds like I am explaining something at a dinner party, not giving a lecture. I want to keep that quality. The hallmark of my voice is that I take complicated ideas seriously without taking myself seriously. I will spend a paragraph carefully unpacking a philosophical concept and then undercut it with an honest admission that I am not sure I have it right. That humility is genuine and readers seem to trust it. My editor at The Loom, James Hayward, calls this "earned informality" — you have to demonstrate competence before you can afford to be casual.
+
+Patterns I am trying to break: I overuse em dashes. I use them as a crutch when I do not want to commit to a full aside or restructure a sentence. Limit is two per essay, maximum. I hedge too much in first drafts. "It seems like," "I think," "perhaps" — these are safety blankets that weaken claims. In revision, I audit every hedge and keep only the ones where genuine uncertainty exists. I have a habit of burying the most interesting idea three paragraphs in. My natural writing process is thinking-on-the-page, which means the first few paragraphs are often throat-clearing. In revision, I look for the sentence that would make someone stop scrolling and move it to the opening. Rachel Torres at the Brevity Workshop taught me to read my drafts backward paragraph by paragraph to find the buried lede. That technique alone improved my work more than any other single piece of advice.
+
+Blog post voice versus essay voice: Blog posts are conversational, present-tense, and structured with clear section breaks. I write to a reader who has the same interests but maybe less context. I explain references. I link to sources. I use "you" freely. Sentences are shorter on average. I aim for a readability score that a motivated fifteen-year-old could follow. Essays are more layered. I allow longer sentences, more subordinate clauses, more ambiguity. I trust the reader to sit with an idea without needing it resolved immediately. I use fewer links and more integrated citations. The pacing is slower because the reader has committed to the form. The voice is still mine in both, but the blog post version of me is the one leaning forward in the chair, and the essay version is the one sitting back.
+
+Professional correspondence voice: Emails to editors are warm but brief. I lead with gratitude, move to the ask, close with a timeline. I match their formality level after the first exchange — if they sign off with just their first name, I do too. Pitch letters are the one place I allow myself to sell. I lead with the hook, explain why now, and include a single relevant credential. No more than three hundred words. I learned this structure from Patricia Engel during a workshop residency in 2022, and every successful pitch I have landed since follows it. Emails to sources are careful about power dynamics. I explain exactly how I plan to use their words, offer quote approval before publication, and follow up to share the finished piece. These are relationships, not transactions.
+
+Voice inventory — the words and rhythms that are mine: I start paragraphs with "The thing about" more than I should but it works as a transition device when used sparingly. I end pieces by circling back to the opening image or question. I use parallel structure in threes, almost always. I prefer "and" to ampersands, dashes to semicolons, periods to exclamation points. My sentence endings tend to land on a stressed syllable, which gives them a feeling of weight. This is not something I planned but something I noticed when I started reading my drafts aloud, a practice my mentor Sarah Kessler insisted on during my MFA year. She was right. The ear catches what the eye misses.
+```
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-voice-cookies-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "Wiki Type UAT — Voice"
+echo ""
+
+# Guard: requires OPENROUTER_API_KEY for LLM pipeline
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  skip "OPENROUTER_API_KEY not set — skipping voice wiki UAT"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+########################################################################
+# 1. Sign in
+########################################################################
+echo "— Sign in"
+SIGNIN_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+[ "$SIGNIN_HTTP" = "200" ] && pass "sign-in → 200" || fail "sign-in → HTTP $SIGNIN_HTTP"
+
+########################################################################
+# 2. Get MCP token from profile
+########################################################################
+echo "— MCP token"
+PROFILE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // ""')
+
+if [ -n "$MCP_URL" ] && [ "$MCP_URL" != "null" ]; then
+  MCP_TOKEN=$(echo "$MCP_URL" | grep -oP 'token=\K.*')
+  MCP_URL="$SERVER_URL/mcp?token=$MCP_TOKEN"
+  pass "MCP token acquired"
+else
+  fail "mcpEndpointUrl is empty — cannot proceed"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 0
+fi
+
+# Helper: parse SSE response
+parse_sse() { grep '^data: ' | head -1 | sed 's/^data: //'; }
+
+# MCP initialize (required before tool calls)
+curl -s --max-time 10 -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"uat-voice","version":"1.0"}}}' \
+  "$MCP_URL" >/dev/null 2>&1
+
+########################################################################
+# 3. Seed wiki types
+########################################################################
+echo "— Seed wiki types"
+SEED_HTTP=$(curl -s -o /tmp/uat-voice-seed.json -w "%{http_code}" \
+  -X POST -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/setup")
+[ "$SEED_HTTP" = "200" ] && pass "POST /wiki-types/setup → 200" || fail "seed wiki types → HTTP $SEED_HTTP"
+
+# Verify voice type exists
+VOICE_EXISTS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wiki-types/voice" | jq -r '.slug // ""')
+[ "$VOICE_EXISTS" = "voice" ] && pass "voice wiki type exists" || fail "voice wiki type not found after seed"
+
+########################################################################
+# 4. Create 3 voice wikis
+########################################################################
+echo "— Create voice wikis"
+
+create_wiki() {
+  local name="$1"
+  local desc="$2"
+  local var_name="$3"
+  local result
+  result=$(curl -s -w "\n%{http_code}" -X POST \
+    -b "$COOKIE_JAR" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:3000" \
+    -d "{\"name\":\"$name\",\"type\":\"voice\",\"prompt\":\"$desc\"}" \
+    "$SERVER_URL/wikis")
+  local http_code
+  http_code=$(echo "$result" | tail -1)
+  local body
+  body=$(echo "$result" | sed '$d')
+  local wiki_id
+  wiki_id=$(echo "$body" | jq -r '.lookupKey // .id // ""')
+  local wiki_slug
+  wiki_slug=$(echo "$body" | jq -r '.slug // ""')
+
+  if [ "$http_code" = "201" ] && [ -n "$wiki_id" ]; then
+    pass "created wiki: $name (id=$wiki_id)"
+    eval "${var_name}_ID='$wiki_id'"
+    eval "${var_name}_SLUG='$wiki_slug'"
+  else
+    fail "create wiki '$name' → HTTP $http_code"
+    eval "${var_name}_ID=''"
+    eval "${var_name}_SLUG=''"
+  fi
+}
+
+create_wiki "Startup Product Voice" "Style guide for SaaS product communication" "WIKI1"
+create_wiki "Nonprofit Comms Tone" "Communication standards for nonprofit channels" "WIKI2"
+create_wiki "Personal Writing Voice" "Voice journal for an individual writer" "WIKI3"
+
+# Verify all created with type=voice
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  if [ -n "$WID" ]; then
+    WTYPE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$WID" | jq -r '.type // ""')
+    [ "$WTYPE" = "voice" ] && pass "$WIKI_VAR type=voice" || fail "$WIKI_VAR type=$WTYPE (expected voice)"
+  fi
+done
+
+# Enable regen on all 3 wikis
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  if [ -n "$WID" ]; then
+    REGEN_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -X PATCH -b "$COOKIE_JAR" \
+      -H "Content-Type: application/json" \
+      -H "Origin: http://localhost:3000" \
+      -d '{"regenerate":true}' \
+      "$SERVER_URL/wikis/$WID/regenerate")
+    [ "$REGEN_HTTP" = "200" ] && pass "$WIKI_VAR regen enabled" || fail "$WIKI_VAR regen toggle → HTTP $REGEN_HTTP"
+  fi
+done
+
+########################################################################
+# 5. Submit 3 entries via MCP (one per wiki, using log_entry)
+########################################################################
+echo "— Submit entries via MCP"
+
+TS=$(date +%s)
+
+# Fixture 1: startup product voice guide
+read -r -d '' FIXTURE1 << 'FIXTURE_EOF'
+Our product voice is the personality behind every word a user reads. We sound like a sharp friend who happens to be an expert — never a faceless corporation, never a condescending tutorial. Here is how we talk.\n\nCore voice attributes: We are confident but not arrogant. When we know something, we say it plainly. We do not hedge with phrases like \"we think\" or \"it might be possible that\" unless genuine uncertainty exists. We are warm but efficient. Every sentence earns its place. We cut filler words ruthlessly — \"actually,\" \"basically,\" \"just,\" \"really\" — unless they serve rhythm. We are precise about technical concepts but relaxed in delivery. A user should feel like they are reading a well-edited Slack message from a senior engineer, not a legal document.\n\nWebsite copy guidelines: Headlines are active and specific. \"Ship faster with automated deploys\" beats \"A solution for modern deployment workflows.\" Subheadings answer the question the headline raises. Body copy uses second person — \"you\" not \"users\" or \"one.\" Feature descriptions lead with the outcome, not the mechanism. Wrong: \"Our CI/CD pipeline integrates with GitHub Actions via webhook listeners.\" Right: \"Push to main and your changes are live in ninety seconds.\" We never use superlatives we cannot prove. No \"fastest,\" \"most powerful,\" or \"best-in-class\" without a benchmark or citation.\n\nOnboarding flow voice: First-run copy is encouraging without being patronizing. We acknowledge the user made a choice by signing up and we respect their time. Progress indicators use concrete language — \"3 steps left\" not \"almost there!\" Error states during setup are honest and actionable. \"We could not connect to your GitHub account. Check that the OAuth app has repo access, then try again.\" We avoid cute error messages during onboarding because confusion compounds when someone is already learning. Celebration moments are brief. A checkmark and \"You are set up\" is better than confetti and three paragraphs of congratulation.\n\nError messages and system notifications: Every error message follows the pattern: what happened, why it matters, what to do next. We do not blame the user. \"That API key is not valid\" not \"You entered an invalid API key.\" We distinguish between user-fixable problems and system problems. If the user cannot fix it, we say so: \"Something went wrong on our end. We have been notified and are looking into it.\" Retry messaging includes expected wait times when possible. \"Try again in a few minutes\" beats \"try again later.\" We never show raw error codes to users unless they are filing a support ticket, in which case we display them in a copyable format.\n\nSupport channel tone: Support conversations are warmer than product copy but equally precise. We greet by name when available. We do not use canned responses verbatim — templates exist as starting points, not scripts. Empathy is shown through action, not performative phrases. Instead of \"I completely understand your frustration,\" we say \"Let me fix that for you right now\" and then do it. We explain what we are doing and why, so the user learns something. Closing a ticket includes a concrete summary of what changed and what the user should expect going forward.\n\nWords we use: ship, build, connect, set up, check, update, deploy, configure. Words we avoid: leverage, utilize, facilitate, synergize, disrupt, innovative, cutting-edge, next-generation, seamless. Contractions are default. Numbers under ten are spelled out in marketing copy, written as digits in product UI.
+FIXTURE_EOF
+
+# Fixture 2: nonprofit communication tone
+read -r -d '' FIXTURE2 << 'FIXTURE_EOF'
+The Meridian Foundation speaks with one voice across every channel, from a grant application to an Instagram caption. That voice reflects who we are: practitioners first, advocates second, storytellers when it serves the mission. This document defines how we communicate and why those choices matter.\n\nOur foundational voice principles: We lead with evidence, not emotion. Our work creates real impact and we let the numbers and stories speak. We never manufacture urgency or guilt. A donor who gives because they feel informed and inspired will give again. A donor who gives because they feel manipulated will not. We are specific about outcomes. \"Provided clean water access to 4,200 households in the Rift Valley\" is stronger than \"helped thousands of families.\" We name places, count people, and cite timelines. We respect the communities we serve by centering their agency. They are not passive recipients of our help. They are partners, collaborators, and leaders in their own development. We say \"families who participate in the program\" not \"families we serve\" or \"beneficiaries.\"\n\nGrant proposal voice: Grant writing is precise, evidence-based, and forward-looking. We match the funder vocabulary without losing our own voice. If a foundation uses \"theory of change,\" we use it. If they prefer \"logic model,\" we adapt. Proposals follow the structure the funder requests — creativity in structure is not appreciated. Every claim is sourced. We cite our own longitudinal data when available, third-party evaluations when they exist, and peer-reviewed research as context. Budget narratives read as clearly as program narratives. A program officer should understand exactly what each line item funds and why that amount is reasonable. We avoid jargon that obscures meaning. \"Capacity building\" only appears if we immediately define what capacity we are building and how.\n\nDonor communication guidelines: Annual reports tell stories that data alone cannot. Each report opens with a single person or community whose trajectory changed because of the work. That person is named, quoted, and photographed only with their informed consent and editorial approval. Appeal letters are honest about what money does. We break down costs concretely: \"Your gift of one hundred fifty dollars trains one community health worker for six months.\" We never imply that a single donation can solve a systemic problem. Acknowledgment letters are sent within forty-eight hours. They are warm, specific about the gift amount and designation, and include a sentence about recent program impact. Tax receipt language is clear and separated from emotional content. Email subject lines are factual, not clickbait. \"Q3 Impact Report: Rift Valley Water Project\" not \"You Won't Believe What Your Donation Did.\"\n\nSocial media tone: Social media is where we are most conversational but never casual about the work. We post original photography with informed consent documentation on file. Stock photos are never used to represent communities or program participants. Captions lead with the most interesting fact or quote. Attribution is always included for quotes. We engage with comments thoughtfully and within twenty-four hours. We do not argue with critics publicly — we acknowledge, provide factual corrections if needed, and move substantive disagreements to direct messages. Hashtags are limited to three per post, all directly relevant to the content. We do not use trending hashtags unrelated to our mission.\n\nInternal communication standards: Internal emails and Slack messages model the same clarity we expect in external communications. Meeting agendas are circulated twenty-four hours in advance with required pre-reads clearly marked. Decision memos follow the BLUF format: bottom line up front, then supporting context. Feedback is specific, timely, and directed at work product rather than character. \"The budget narrative needs stronger justification for the staffing increase\" is useful. \"This section needs work\" is not. We cc people intentionally, not defensively. When staff disagree about strategy, the conversation happens in a meeting with a decision-maker present, not in an email thread. Andrea Williams established these standards in 2019 and they were revised by Marcus Chen during the 2023 organizational review.
+FIXTURE_EOF
+
+# Fixture 3: personal writing voice journal
+read -r -d '' FIXTURE3 << 'FIXTURE_EOF'
+I have been thinking about voice as a writer for years but only recently started documenting what I actually do versus what I think I do. This is my attempt to pin down the patterns, good and bad, so I can be intentional about them instead of just hoping for consistency.\n\nWhat my voice sounds like at its best: When I am writing well, my sentences are medium-length and varied in rhythm. I tend toward a three-beat pattern — short, medium, long — and then reset. I use concrete nouns and active verbs. I reach for metaphors from physical craft: woodworking, cooking, building. My friend Dara once told me that my best writing sounds like I am explaining something at a dinner party, not giving a lecture. I want to keep that quality. The hallmark of my voice is that I take complicated ideas seriously without taking myself seriously. I will spend a paragraph carefully unpacking a philosophical concept and then undercut it with an honest admission that I am not sure I have it right. That humility is genuine and readers seem to trust it. My editor at The Loom, James Hayward, calls this \"earned informality\" — you have to demonstrate competence before you can afford to be casual.\n\nPatterns I am trying to break: I overuse em dashes. I use them as a crutch when I do not want to commit to a full aside or restructure a sentence. Limit is two per essay, maximum. I hedge too much in first drafts. \"It seems like,\" \"I think,\" \"perhaps\" — these are safety blankets that weaken claims. In revision, I audit every hedge and keep only the ones where genuine uncertainty exists. I have a habit of burying the most interesting idea three paragraphs in. My natural writing process is thinking-on-the-page, which means the first few paragraphs are often throat-clearing. In revision, I look for the sentence that would make someone stop scrolling and move it to the opening. Rachel Torres at the Brevity Workshop taught me to read my drafts backward paragraph by paragraph to find the buried lede. That technique alone improved my work more than any other single piece of advice.\n\nBlog post voice versus essay voice: Blog posts are conversational, present-tense, and structured with clear section breaks. I write to a reader who has the same interests but maybe less context. I explain references. I link to sources. I use \"you\" freely. Sentences are shorter on average. I aim for a readability score that a motivated fifteen-year-old could follow. Essays are more layered. I allow longer sentences, more subordinate clauses, more ambiguity. I trust the reader to sit with an idea without needing it resolved immediately. I use fewer links and more integrated citations. The pacing is slower because the reader has committed to the form. The voice is still mine in both, but the blog post version of me is the one leaning forward in the chair, and the essay version is the one sitting back.\n\nProfessional correspondence voice: Emails to editors are warm but brief. I lead with gratitude, move to the ask, close with a timeline. I match their formality level after the first exchange — if they sign off with just their first name, I do too. Pitch letters are the one place I allow myself to sell. I lead with the hook, explain why now, and include a single relevant credential. No more than three hundred words. I learned this structure from Patricia Engel during a workshop residency in 2022, and every successful pitch I have landed since follows it. Emails to sources are careful about power dynamics. I explain exactly how I plan to use their words, offer quote approval before publication, and follow up to share the finished piece. These are relationships, not transactions.\n\nVoice inventory — the words and rhythms that are mine: I start paragraphs with \"The thing about\" more than I should but it works as a transition device when used sparingly. I end pieces by circling back to the opening image or question. I use parallel structure in threes, almost always. I prefer \"and\" to ampersands, dashes to semicolons, periods to exclamation points. My sentence endings tend to land on a stressed syllable, which gives them a feeling of weight. This is not something I planned but something I noticed when I started reading my drafts aloud, a practice my mentor Sarah Kessler insisted on during my MFA year. She was right. The ear catches what the eye misses.
+FIXTURE_EOF
+
+submit_entry_mcp() {
+  local content="$1"
+  local label="$2"
+  local raw
+  raw=$(curl -s --max-time 30 -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$((RANDOM % 9000 + 1000)),\"method\":\"tools/call\",\"params\":{\"name\":\"log_entry\",\"arguments\":{\"content\":\"$content\",\"source\":\"mcp\"}}}" \
+    "$MCP_URL" 2>/dev/null)
+  local resp
+  resp=$(echo "$raw" | parse_sse)
+
+  if echo "$resp" | jq -e '.result' >/dev/null 2>&1; then
+    local text
+    text=$(echo "$resp" | jq -r '.result.content[0].text // ""')
+    local is_err
+    is_err=$(echo "$resp" | jq -r '.result.isError // false')
+    if [ "$is_err" = "true" ]; then
+      fail "MCP log_entry ($label): $text"
+      echo ""
+    else
+      pass "MCP log_entry ($label): $text"
+      # Extract entry key from "Entry queued: entry01ABC..." response
+      echo "$text" | grep -oP 'entry[0-9A-Z]{26}' || echo ""
+    fi
+  else
+    fail "MCP log_entry ($label): no result (raw: ${raw:0:200})"
+    echo ""
+  fi
+}
+
+ENTRY1_KEY=$(submit_entry_mcp "$FIXTURE1" "startup voice")
+ENTRY2_KEY=$(submit_entry_mcp "$FIXTURE2" "nonprofit tone")
+ENTRY3_KEY=$(submit_entry_mcp "$FIXTURE3" "personal voice")
+
+########################################################################
+# 6. Poll entries until processed (max 360s)
+########################################################################
+echo "— Poll entry processing (max 360s)"
+
+poll_entry() {
+  local entry_key="$1"
+  local label="$2"
+  if [ -z "$entry_key" ]; then
+    fail "no entry key for $label — skipping poll"
+    return
+  fi
+
+  local elapsed=0
+  local max_wait=360
+  local final_status=""
+  while [ $elapsed -lt $max_wait ]; do
+    sleep 10
+    elapsed=$((elapsed + 10))
+    local resp
+    resp=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/entries/$entry_key" 2>/dev/null)
+    local status
+    status=$(echo "$resp" | jq -r '.ingestStatus // .state // "unknown"')
+    echo "    $label: ${elapsed}s — $status"
+
+    if [ "$status" = "processed" ] || [ "$status" = "RESOLVED" ]; then
+      final_status="$status"
+      break
+    fi
+    if [ "$status" = "failed" ]; then
+      local err
+      err=$(echo "$resp" | jq -r '.lastError // "unknown"')
+      fail "$label entry failed: $err"
+      final_status="failed"
+      break
+    fi
+  done
+
+  if [ "$final_status" = "processed" ] || [ "$final_status" = "RESOLVED" ]; then
+    pass "$label reached $final_status in ${elapsed}s"
+  elif [ -z "$final_status" ]; then
+    fail "$label did not reach processed after ${max_wait}s (observe: LLM latency)"
+  fi
+}
+
+poll_entry "$ENTRY1_KEY" "startup voice"
+poll_entry "$ENTRY2_KEY" "nonprofit tone"
+poll_entry "$ENTRY3_KEY" "personal voice"
+
+########################################################################
+# 7. Report fragments
+########################################################################
+echo "— Report: fragments"
+FRAGS=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=100")
+FRAG_COUNT=$(echo "$FRAGS" | jq '.fragments | length' 2>/dev/null || echo "0")
+echo "    total fragments: $FRAG_COUNT"
+if [ "$FRAG_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "fragments exist ($FRAG_COUNT)"
+  echo "$FRAGS" | jq -r '.fragments[:10][] | "    - \(.title // .id)"' 2>/dev/null
+else
+  fail "no fragments after processing 3 voice entries"
+fi
+
+########################################################################
+# 8. Report people
+########################################################################
+echo "— Report: people"
+PEOPLE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people")
+PEOPLE_COUNT=$(echo "$PEOPLE" | jq '.people | length' 2>/dev/null || echo "0")
+echo "    total people: $PEOPLE_COUNT"
+if [ "$PEOPLE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "people extracted ($PEOPLE_COUNT)"
+  echo "$PEOPLE" | jq -r '.people[:10][] | "    - \(.name // .id)"' 2>/dev/null
+else
+  echo "    (observe: people extraction is probabilistic — zero is acceptable)"
+fi
+
+########################################################################
+# 9. Report edges (graph)
+########################################################################
+echo "— Report: graph edges"
+GRAPH=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/graph")
+NODE_COUNT=$(echo "$GRAPH" | jq '.nodes | length' 2>/dev/null || echo "0")
+EDGE_COUNT=$(echo "$GRAPH" | jq '.edges | length' 2>/dev/null || echo "0")
+echo "    nodes: $NODE_COUNT, edges: $EDGE_COUNT"
+if [ "$NODE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has nodes ($NODE_COUNT)"
+else
+  echo "    (observe: graph population depends on pipeline — zero may be valid)"
+fi
+if [ "$EDGE_COUNT" -gt 0 ] 2>/dev/null; then
+  pass "graph has edges ($EDGE_COUNT)"
+  echo "$GRAPH" | jq -r '.edges[:5][] | "    - \(.edgeType): \(.source) → \(.target)"' 2>/dev/null
+fi
+
+########################################################################
+# 10. Check wiki detail for each voice wiki (fragments + people)
+########################################################################
+echo "— Wiki detail snapshots"
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  eval "WSLUG=\${${WIKI_VAR}_SLUG}"
+  if [ -n "$WID" ]; then
+    DETAIL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$WID")
+    W_STATE=$(echo "$DETAIL" | jq -r '.state // "unknown"')
+    W_FRAGS=$(echo "$DETAIL" | jq '.fragments | length' 2>/dev/null || echo "0")
+    W_PEOPLE=$(echo "$DETAIL" | jq '.people | length' 2>/dev/null || echo "0")
+    W_CONTENT_LEN=$(echo "$DETAIL" | jq -r '.wikiContent // ""' | wc -c)
+    echo "    $WIKI_VAR ($WSLUG): state=$W_STATE, fragments=$W_FRAGS, people=$W_PEOPLE, contentLen=$W_CONTENT_LEN"
+  fi
+done
+
+########################################################################
+# 11. Trigger regeneration on each voice wiki
+########################################################################
+echo "— Trigger wiki regeneration"
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  if [ -n "$WID" ]; then
+    REGEN_RESP=$(curl -s -w "\n%{http_code}" -X POST \
+      -b "$COOKIE_JAR" \
+      -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$WID/regenerate")
+    REGEN_HTTP=$(echo "$REGEN_RESP" | tail -1)
+    REGEN_BODY=$(echo "$REGEN_RESP" | sed '$d')
+
+    if [ "$REGEN_HTTP" = "200" ]; then
+      RFRAG=$(echo "$REGEN_BODY" | jq -r '.fragmentCount // 0')
+      pass "$WIKI_VAR regen → 200 (fragments=$RFRAG)"
+    else
+      # Regen may fail if no fragments linked yet — observe, don't hard-fail
+      REGEN_ERR=$(echo "$REGEN_BODY" | jq -r '.error // "unknown"')
+      echo "    $WIKI_VAR regen → HTTP $REGEN_HTTP: $REGEN_ERR (observe: regen depends on linked fragments)"
+    fi
+  fi
+done
+
+########################################################################
+# 12. Report final wiki state
+########################################################################
+echo "— Final wiki state"
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  eval "WSLUG=\${${WIKI_VAR}_SLUG}"
+  if [ -n "$WID" ]; then
+    FINAL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$WID")
+    F_STATE=$(echo "$FINAL" | jq -r '.state // "unknown"')
+    F_FRAGS=$(echo "$FINAL" | jq '.fragments | length' 2>/dev/null || echo "0")
+    F_PEOPLE=$(echo "$FINAL" | jq '.people | length' 2>/dev/null || echo "0")
+    F_CONTENT=$(echo "$FINAL" | jq -r '.wikiContent // ""')
+    F_CONTENT_LEN=${#F_CONTENT}
+
+    echo "    $WIKI_VAR ($WSLUG):"
+    echo "      state: $F_STATE"
+    echo "      fragments: $F_FRAGS"
+    echo "      people: $F_PEOPLE"
+    echo "      content length: $F_CONTENT_LEN chars"
+    if [ "$F_CONTENT_LEN" -gt 0 ]; then
+      echo "      content preview: ${F_CONTENT:0:200}..."
+    fi
+
+    # Assert: wiki state should be RESOLVED or PENDING after regen
+    if [ "$F_STATE" = "RESOLVED" ]; then
+      pass "$WIKI_VAR final state=RESOLVED"
+    elif [ "$F_STATE" = "PENDING" ]; then
+      echo "    (observe: $WIKI_VAR still PENDING — regen may not have completed)"
+    else
+      echo "    (observe: $WIKI_VAR state=$F_STATE — unexpected but not fatal)"
+    fi
+  fi
+done
+
+########################################################################
+# 13. Verify voice wikis appear in type-filtered listing
+########################################################################
+echo "— Verify type-filtered listing"
+VOICE_LIST_HTTP=$(curl -s -o /tmp/uat-voice-list.json -w "%{http_code}" \
+  -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wikis?type=voice")
+if [ "$VOICE_LIST_HTTP" = "200" ]; then
+  VOICE_COUNT=$(jq '.wikis | length' /tmp/uat-voice-list.json 2>/dev/null || echo "0")
+  if [ "$VOICE_COUNT" -ge 3 ] 2>/dev/null; then
+    pass "GET /wikis?type=voice → $VOICE_COUNT wikis (>= 3 expected)"
+  else
+    fail "GET /wikis?type=voice → only $VOICE_COUNT wikis (expected >= 3)"
+  fi
+else
+  fail "GET /wikis?type=voice → HTTP $VOICE_LIST_HTTP"
+fi
+
+########################################################################
+# Cleanup: soft-delete test wikis
+########################################################################
+echo "— Cleanup"
+for WIKI_VAR in WIKI1 WIKI2 WIKI3; do
+  eval "WID=\${${WIKI_VAR}_ID}"
+  if [ -n "$WID" ]; then
+    curl -s -o /dev/null -X DELETE \
+      -b "$COOKIE_JAR" \
+      -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$WID"
+  fi
+done
+echo "    test wikis soft-deleted"
+
+echo ""
+echo "════════════════════════════════════════"
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```


### PR DESCRIPTION
## Summary
- Fixed entry key extraction regex in 9 wiki-type UAT plans that used wrong patterns (`entry_`, `ent_`, or loose character classes) to parse the MCP `log_entry` response
- All plans now use the canonical `entry[0-9A-Z]{26}` pattern matching `LOOKUP_KEY_RE.entry` from `@robin/shared`
- Files already using the correct pattern (wiki-log, wiki-agent) were left unchanged

## Files changed
- `.uat/plans/wiki-types/wiki-collection.md` — `entry_[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-decision.md` — `entry_[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-belief.md` — `entry_[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-voice.md` — `entry_\S+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-project.md` — `entry_\S+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-objective.md` — `ent_[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-research.md` — `entry[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-skill.md` — `entry[A-Za-z0-9]+` → `entry[0-9A-Z]{26}`
- `.uat/plans/wiki-types/wiki-principles.md` — already correct (`entry[A-Z0-9]{26}`)

Closes #98