### PR TITLE
fix(wiki): login form does not redirect after successful authentication

### DIFF
--- a/wiki/src/app/login/page.tsx
+++ b/wiki/src/app/login/page.tsx
@@ -33,12 +33,17 @@ export default function LoginPage() {
       })
       if (signInError) {
         setError(signInError.message ?? 'Sign in failed')
+        setLoading(false)
         return
       }
-      router.push('/')
+      // Don't navigate here — better-auth's session atom refreshes
+      // asynchronously (10ms after sign-in). If we router.push('/')
+      // immediately, the home page sees stale isAuthenticated=false
+      // and bounces back to /login. Instead, keep the spinner visible
+      // and let the useEffect above redirect once useSession() reflects
+      // the new session.
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed')
-    } finally {
       setLoading(false)
     }
   }


### PR DESCRIPTION
## Summary

- Fix race condition where `router.push('/')` fires before better-auth's session atom refreshes (10ms async delay), causing the home page to see stale `isAuthenticated=false` and bounce back to `/login`
- Remove immediate navigation after sign-in; let the existing `useEffect` redirect once `useSession()` reflects the new session
- Keep spinner visible during the brief window between sign-in success and session state update

## Root cause

better-auth's client proxy toggles the session signal atom via `setTimeout(..., 10)` in its `onSuccess` handler (`proxy.mjs:64`). The old code called `router.push('/')` synchronously after `signIn.email()` resolved, before that timeout fired. The home page (`/`) then read `isAuthenticated: false` from the stale session atom and immediately redirected back to `/login`.

## Test plan

- [ ] Enter valid credentials on `/login` and verify redirect to `/` (then `/wiki` if onboarded)
- [ ] Enter invalid credentials and verify error message displays, no redirect
- [ ] Verify button shows "Signing in..." until redirect completes (no flicker back to "Sign in")
- [ ] Verify already-authenticated users visiting `/login` are redirected to `/`

Closes #109