### PR TITLE
m-wiki-vitest: set up vitest in wiki/ + unit tests for sidecar modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: link:../packages/shared
       better-auth:
         specifier: ^1.0.0
-        version: 1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4)
       diff:
         specifier: ^8.0.3
         version: 8.0.4
@@ -117,7 +117,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
       zod-to-json-schema:
         specifier: ^3.25.1
         version: 3.25.2(zod@3.25.76)
@@ -163,7 +163,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/caslock:
     devDependencies:
@@ -181,7 +181,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/queue:
     dependencies:
@@ -206,7 +206,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/shared:
     dependencies:
@@ -237,7 +237,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   wiki:
     dependencies:
@@ -285,7 +285,7 @@ importers:
         version: 4.25.9(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.2
-        version: 1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -332,33 +332,57 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/diff':
         specifier: ^7.0.2
         version: 7.0.2
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/ui':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: ^16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.0.1)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
   '@a2a-js/sdk@0.2.5':
     resolution: {integrity: sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g==}
     engines: {node: '>=18'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@ai-sdk/gateway@3.0.95':
     resolution: {integrity: sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==}
@@ -419,6 +443,21 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -727,6 +766,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bull-board/api@6.21.0':
     resolution: {integrity: sha512-5bX3U8baU4OulDLeXwqWI6/FZolpi1APfoJVXndR4fKdmuYr9cdbH8cg7juublfzX01T+3zoiZkveX7iD5y8gA==}
     peerDependencies:
@@ -766,6 +809,42 @@ packages:
 
   '@codemirror/view@6.41.1':
     resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -1149,6 +1228,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1640,6 +1728,9 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -2008,6 +2099,29 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tiptap/core@3.22.4':
     resolution: {integrity: sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==}
     peerDependencies:
@@ -2197,6 +2311,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -2544,6 +2661,11 @@ packages:
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
+  '@vitest/ui@3.2.4':
+    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+    peerDependencies:
+      vitest: 3.2.4
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
@@ -2611,6 +2733,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -2620,6 +2746,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2785,6 +2914,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
@@ -3028,6 +3160,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -3042,6 +3181,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -3085,6 +3228,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -3168,6 +3314,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3324,6 +3476,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3633,6 +3789,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -3872,6 +4031,10 @@ packages:
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3918,6 +4081,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4064,6 +4231,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -4173,6 +4343,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4375,6 +4554,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4429,6 +4612,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -4573,6 +4759,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -4586,6 +4776,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -4816,6 +5010,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -4916,6 +5113,10 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -5025,6 +5226,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
@@ -5046,6 +5250,10 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -5183,6 +5391,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -5283,6 +5495,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -5403,6 +5619,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -5443,6 +5663,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -5513,9 +5736,17 @@ packages:
   tokenx@1.3.0:
     resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -5656,6 +5887,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -5862,9 +6097,25 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5926,6 +6177,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -6001,6 +6259,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@ai-sdk/gateway@3.0.95(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -6064,6 +6324,26 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6389,6 +6669,10 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bull-board/api@6.21.0(@bull-board/ui@6.21.0)':
     dependencies:
       '@bull-board/ui': 6.21.0
@@ -6467,6 +6751,30 @@ snapshots:
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -6716,6 +7024,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7208,6 +7520,8 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -7429,6 +7743,36 @@ snapshots:
       '@tanstack/query-core': 5.99.0
       react: 19.2.5
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tiptap/core@3.22.4(@tiptap/pm@3.22.4)':
     dependencies:
       '@tiptap/pm': 3.22.4
@@ -7632,6 +7976,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -7970,6 +8316,15 @@ snapshots:
       msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.4(@types/node@25.6.0)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -7978,16 +8333,6 @@ snapshots:
     optionalDependencies:
       msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.4(@types/node@25.6.0)(typescript@6.0.2)
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8026,6 +8371,17 @@ snapshots:
       tinyspy: 4.0.4
 
   '@vitest/spy@4.1.4': {}
+
+  '@vitest/ui@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      fflate: 0.8.2
+      flatted: 3.4.2
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8095,6 +8451,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   argparse@1.0.10:
@@ -8102,6 +8460,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -8212,7 +8574,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
-  better-auth@1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))
@@ -8237,12 +8599,12 @@ snapshots:
       next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))
@@ -8267,7 +8629,7 @@ snapshots:
       next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8280,6 +8642,10 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   birpc@4.0.0: {}
 
@@ -8544,6 +8910,13 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -8551,6 +8924,13 @@ snapshots:
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@7.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -8585,6 +8965,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -8645,6 +9027,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dotenv@16.6.1: {}
 
   dotenv@17.4.1: {}
@@ -8703,6 +9089,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -8887,7 +9275,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -8920,7 +9308,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8935,7 +9323,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9268,6 +9656,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -9527,6 +9917,12 @@ snapshots:
 
   hookable@6.1.0: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
@@ -9568,6 +9964,8 @@ snapshots:
   import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -9705,6 +10103,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -9803,6 +10203,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2(@noble/hashes@2.0.1):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -9955,6 +10381,8 @@ snapshots:
       react: 19.2.5
 
   luxon@3.7.2: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -10116,6 +10544,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -10345,6 +10775,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -10358,6 +10790,8 @@ snapshots:
       brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.0.0: {}
 
@@ -10677,6 +11111,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -10775,6 +11213,12 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -10920,6 +11364,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       '@types/hast': 3.0.4
@@ -10951,6 +11397,11 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -11153,6 +11604,10 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -11364,6 +11819,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sonic-boom@4.2.1:
@@ -11495,6 +11956,10 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -11525,6 +11990,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
 
@@ -11573,9 +12040,15 @@ snapshots:
 
   tokenx@1.3.0: {}
 
+  totalist@3.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -11743,6 +12216,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -11924,7 +12399,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -11952,6 +12427,8 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 20.19.39
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@vitejs/devtools'
       - esbuild
@@ -11967,7 +12444,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -11995,6 +12472,8 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.6.0
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@vitejs/devtools'
       - esbuild
@@ -12010,7 +12489,52 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 25.6.0
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -12035,41 +12559,29 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
-
-  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - msw
-    optional: true
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -12143,6 +12655,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -6,11 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "manifest": "openapi-ts && find src/lib/generated -name '*.ts' -exec sed -i \"s/\\.js'/'/g\" {} +"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",
-    "@robin/shared": "workspace:*",
     "@codemirror/commands": "6.10.3",
     "@codemirror/lang-yaml": "6.1.3",
     "@codemirror/language": "6.12.3",
@@ -18,6 +19,7 @@
     "@codemirror/theme-one-dark": "6.1.3",
     "@codemirror/view": "6.41.1",
     "@hey-api/client-fetch": "^0.13.1",
+    "@robin/shared": "workspace:*",
     "@tanstack/react-query": "^5.99.0",
     "@tiptap/extension-placeholder": "^3.22.3",
     "@tiptap/react": "^3.22.3",
@@ -41,12 +43,19 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.96.0",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/diff": "^7.0.2",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitest/ui": "^3.2.4",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.4",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/wiki/src/components/wiki/WikiChip.test.tsx
+++ b/wiki/src/components/wiki/WikiChip.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WikiChip } from './WikiChip'
+
+afterEach(cleanup)
+
+describe('<WikiChip>', () => {
+  it('renders an anchor with the given href and label when href is provided', () => {
+    render(<WikiChip label="Sarah Chen" href="/wiki/people/p-sarah" />)
+    const anchor = screen.getByText('Sarah Chen')
+    expect(anchor.tagName).toBe('A')
+    expect(anchor).toHaveAttribute('href', '/wiki/people/p-sarah')
+    expect(anchor).toHaveAttribute('data-slot', 'wiki-chip')
+    expect(anchor).toHaveClass('wchip')
+  })
+
+  it('renders a span (not an anchor) when href is omitted', () => {
+    render(<WikiChip label="Unresolved" />)
+    const chip = screen.getByText('Unresolved')
+    expect(chip.tagName).toBe('SPAN')
+    expect(chip).toHaveAttribute('data-slot', 'wiki-chip')
+    expect(chip).toHaveClass('wchip')
+    expect(chip).not.toHaveAttribute('href')
+  })
+
+  it('merges a caller-provided className with the wchip base class', () => {
+    render(<WikiChip label="Chip" href="/x" className="custom-extra" />)
+    const anchor = screen.getByText('Chip')
+    expect(anchor).toHaveClass('wchip')
+    expect(anchor).toHaveClass('custom-extra')
+  })
+})

--- a/wiki/src/components/wiki/WikiCitations.test.tsx
+++ b/wiki/src/components/wiki/WikiCitations.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WikiCitations } from './WikiCitations'
+import type { WikiCitation } from '@/lib/sidecarTypes'
+
+afterEach(cleanup)
+
+const citations: WikiCitation[] = [
+  {
+    fragmentId: 'f-self-attention-replaces-recurrence',
+    fragmentSlug: 'self-attention-replaces-recurrence',
+    quote: 'Self-attention replaces recurrence.',
+    capturedAt: '2017-06-12',
+  },
+  {
+    fragmentId: 'f-multi-head-attention-parallelism',
+    fragmentSlug: 'multi-head-attention-parallelism',
+    quote: 'Running attention h times in parallel.',
+    capturedAt: '2017-06-12',
+  },
+]
+
+describe('<WikiCitations>', () => {
+  it('renders a superscript per citation with per-section 1-based numbering', () => {
+    const { container } = render(<WikiCitations citations={citations} />)
+    const sups = container.querySelectorAll('sup[data-slot="wiki-citation"]')
+    expect(sups).toHaveLength(2)
+    expect(screen.getByText('[1]')).toBeInTheDocument()
+    expect(screen.getByText('[2]')).toBeInTheDocument()
+  })
+
+  it('links each superscript to /wiki/fragments/:fragmentId', () => {
+    const { container } = render(<WikiCitations citations={citations} />)
+    const anchors = container.querySelectorAll('sup[data-slot="wiki-citation"] a')
+    expect(anchors).toHaveLength(2)
+    expect(anchors[0].getAttribute('href')).toBe(
+      '/wiki/fragments/f-self-attention-replaces-recurrence',
+    )
+    expect(anchors[1].getAttribute('href')).toBe(
+      '/wiki/fragments/f-multi-head-attention-parallelism',
+    )
+  })
+
+  it('honours startIndex for running document-wide numbering', () => {
+    const { container } = render(<WikiCitations citations={citations} startIndex={5} />)
+    expect(screen.getByText('[5]')).toBeInTheDocument()
+    expect(screen.getByText('[6]')).toBeInTheDocument()
+    const sups = container.querySelectorAll('sup[data-slot="wiki-citation"]')
+    expect(sups).toHaveLength(2)
+  })
+
+  it('renders nothing when citations array is empty', () => {
+    const { container } = render(<WikiCitations citations={[]} />)
+    // Component returns null on empty input; the render root holds no children.
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('applies caller-provided className to the wrapper span', () => {
+    const { container } = render(
+      <WikiCitations citations={citations} className="custom-citations" />,
+    )
+    const wrapper = container.querySelector('span[data-slot="wiki-citations"]')
+    expect(wrapper).not.toBeNull()
+    expect(wrapper).toHaveClass('custom-citations')
+  })
+})

--- a/wiki/src/components/wiki/WikiInfobox.test.tsx
+++ b/wiki/src/components/wiki/WikiInfobox.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WikiInfobox, type WikiInfoboxSection } from './WikiInfobox'
+import { WikiChip } from './WikiChip'
+
+afterEach(cleanup)
+
+// A test section that exercises every sidecar valueKind variant
+// (text / ref / date / status) mapped onto the component's
+// presentation-agnostic {key, value} row shape. This is the shape
+// downstream pages will use when wiring the real fixture in — the
+// component itself is intentionally kind-unaware.
+const fixtureSections: WikiInfoboxSection[] = [
+  {
+    rows: [
+      // status valueKind — plain text label
+      { key: 'Status', value: 'complete' },
+      // text valueKind — plain text
+      { key: 'Paper', value: 'Attention Is All You Need' },
+      // ref valueKind — rendered via <WikiChip>
+      {
+        key: 'Lead author',
+        value: <WikiChip label="Ashish Vaswani" href="/wiki/people/p-ashish-vaswani" />,
+      },
+      // date valueKind — ISO date string
+      { key: 'Published', value: '2017-06-12' },
+    ],
+  },
+]
+
+describe('<WikiInfobox>', () => {
+  it('renders the title as the table caption', () => {
+    render(<WikiInfobox title="Transformer Architecture" sections={fixtureSections} />)
+    const caption = document.querySelector('caption.winfo__head')
+    expect(caption).not.toBeNull()
+    expect(caption!.textContent).toBe('Transformer Architecture')
+  })
+
+  it('renders every row label and value (all four valueKind variants)', () => {
+    render(<WikiInfobox title="Transformer" sections={fixtureSections} />)
+    // Keys (labels)
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Paper')).toBeInTheDocument()
+    expect(screen.getByText('Lead author')).toBeInTheDocument()
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    // Values
+    expect(screen.getByText('complete')).toBeInTheDocument()
+    expect(screen.getByText('Attention Is All You Need')).toBeInTheDocument()
+    expect(screen.getByText('2017-06-12')).toBeInTheDocument()
+    // ref-valueKind row renders a WikiChip anchor
+    const chip = screen.getByText('Ashish Vaswani')
+    expect(chip.tagName).toBe('A')
+    expect(chip).toHaveAttribute('href', '/wiki/people/p-ashish-vaswani')
+  })
+
+  it('renders an image and caption when provided', () => {
+    render(
+      <WikiInfobox
+        title="Transformer"
+        image="/images/transformer.png"
+        caption="Figure 1 — the canonical diagram."
+        sections={fixtureSections}
+      />,
+    )
+    const img = document.querySelector('td.winfo__image img') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    expect(img!.src).toContain('/images/transformer.png')
+    expect(img!.alt).toBe('Figure 1 — the canonical diagram.')
+    const caption = document.querySelector('td.winfo__caption')
+    expect(caption).not.toBeNull()
+    expect(caption!.textContent).toBe('Figure 1 — the canonical diagram.')
+  })
+
+  it('omits image + caption elements when image is not provided', () => {
+    render(<WikiInfobox title="Transformer" sections={fixtureSections} />)
+    expect(document.querySelector('td.winfo__image')).toBeNull()
+    expect(document.querySelector('td.winfo__caption')).toBeNull()
+  })
+
+  it('renders a section label (th.winfo__section) when section.label is set', () => {
+    render(
+      <WikiInfobox
+        title="Transformer"
+        sections={[
+          { label: 'Metadata', rows: [{ key: 'Status', value: 'complete' }] },
+        ]}
+      />,
+    )
+    const sectionHeader = document.querySelector('th.winfo__section')
+    expect(sectionHeader).not.toBeNull()
+    expect(sectionHeader!.textContent).toBe('Metadata')
+  })
+
+  it('applies caller-provided className to the outer table', () => {
+    render(
+      <WikiInfobox title="Transformer" sections={fixtureSections} className="custom-info" />,
+    )
+    const table = document.querySelector('table[data-slot="wiki-infobox"]')
+    expect(table).not.toBeNull()
+    expect(table).toHaveClass('winfo')
+    expect(table).toHaveClass('custom-info')
+  })
+})

--- a/wiki/src/lib/htmlTokenSubstitute.test.ts
+++ b/wiki/src/lib/htmlTokenSubstitute.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import type { WikiRef } from '@/lib/sidecarTypes'
+import { substituteTokensInHtml, refToHref, type RefsMap } from './htmlTokenSubstitute'
+
+function makeContainer(html: string): HTMLElement {
+  const div = document.createElement('div')
+  div.innerHTML = html
+  document.body.appendChild(div)
+  return div
+}
+
+function cleanup(el: HTMLElement): void {
+  el.remove()
+}
+
+const personRef: WikiRef = {
+  kind: 'person',
+  id: 'p-sarah',
+  slug: 'sarah-chen',
+  label: 'Sarah Chen',
+  relationship: 'Friend',
+}
+
+const fragmentRef: WikiRef = {
+  kind: 'fragment',
+  id: 'f-alpha',
+  slug: 'alpha',
+  label: 'Alpha fragment',
+  snippet: 'A snippet.',
+}
+
+const wikiRef: WikiRef = {
+  kind: 'wiki',
+  id: 'w-beta',
+  slug: 'beta',
+  label: 'Beta Wiki',
+  wikiType: 'reference',
+}
+
+const entryRef: WikiRef = {
+  kind: 'entry',
+  id: 'e-gamma',
+  slug: 'gamma',
+  label: 'Gamma Entry',
+  createdAt: '2025-01-01',
+}
+
+describe('refToHref', () => {
+  it('returns /wiki/people/:id for person refs', () => {
+    expect(refToHref(personRef)).toBe('/wiki/people/p-sarah')
+  })
+
+  it('returns /wiki/fragments/:id for fragment refs', () => {
+    expect(refToHref(fragmentRef)).toBe('/wiki/fragments/f-alpha')
+  })
+
+  it('returns /wiki/entries/:id for entry refs', () => {
+    expect(refToHref(entryRef)).toBe('/wiki/entries/e-gamma')
+  })
+
+  it('returns /wiki/:id for wiki refs (default branch)', () => {
+    expect(refToHref(wikiRef)).toBe('/wiki/w-beta')
+  })
+})
+
+describe('substituteTokensInHtml', () => {
+  it('replaces a single resolved token with a chip anchor', () => {
+    const container = makeContainer('<p>See [[person:sarah-chen]] for context.</p>')
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      const anchor = container.querySelector('a.wchip')
+      expect(anchor).not.toBeNull()
+      expect(anchor!.getAttribute('href')).toBe('/wiki/people/p-sarah')
+      expect(anchor!.getAttribute('data-slot')).toBe('wiki-chip')
+      expect(anchor!.textContent).toBe('Sarah Chen')
+      // Surrounding text preserved.
+      expect(container.textContent).toContain('See ')
+      expect(container.textContent).toContain(' for context.')
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('replaces multiple tokens of different kinds in one pass', () => {
+    const container = makeContainer(
+      '<p>[[person:sarah-chen]] wrote [[fragment:alpha]] for [[wiki:beta]].</p>',
+    )
+    const refs: RefsMap = {
+      'person:sarah-chen': personRef,
+      'fragment:alpha': fragmentRef,
+      'wiki:beta': wikiRef,
+    }
+    try {
+      substituteTokensInHtml(container, refs)
+      const anchors = Array.from(container.querySelectorAll('a.wchip'))
+      expect(anchors).toHaveLength(3)
+      expect(anchors.map((a) => a.getAttribute('href'))).toEqual([
+        '/wiki/people/p-sarah',
+        '/wiki/fragments/f-alpha',
+        '/wiki/w-beta',
+      ])
+      expect(anchors.map((a) => a.textContent)).toEqual([
+        'Sarah Chen',
+        'Alpha fragment',
+        'Beta Wiki',
+      ])
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('leaves unresolved tokens as raw literal text (graceful drop per Q1)', () => {
+    const container = makeContainer('<p>Ghost [[person:ghost]] and [[person:sarah-chen]] here.</p>')
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      // The resolved token became an anchor.
+      const anchor = container.querySelector('a.wchip')
+      expect(anchor).not.toBeNull()
+      expect(anchor!.textContent).toBe('Sarah Chen')
+      // The unresolved token survives as literal text.
+      expect(container.textContent).toContain('[[person:ghost]]')
+      // Only one chip was rendered.
+      expect(container.querySelectorAll('a.wchip')).toHaveLength(1)
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  // NOTE: The current walker implementation only skips text inside existing
+  // <a> elements — it does NOT skip text inside <code> or <pre>. These tests
+  // capture the ACTUAL current behavior so regressions are visible. The
+  // remark/markdown path handles this correctly via mdast (code nodes have
+  // no text children), so in practice this edge case arises only when
+  // Tiptap-saved HTML contains raw tokens inside code blocks — rare enough
+  // that the team deferred the fix.
+  // TODO(#121): if/when the walker is taught to skip `code`/`pre`, flip
+  // these assertions. Until then, they document the gap.
+  it('(current behaviour) DOES substitute tokens inside <code> tags — walker has no code-skip rule', () => {
+    const container = makeContainer('<p>See <code>[[person:sarah-chen]]</code> token.</p>')
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      // One anchor IS created inside the code element (undesired from a
+      // product-correctness view; recorded here as the implementation truth).
+      expect(container.querySelectorAll('a.wchip')).toHaveLength(1)
+      expect(container.querySelector('code a.wchip')).not.toBeNull()
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('(current behaviour) DOES substitute tokens inside <pre> blocks — same reason as above', () => {
+    const container = makeContainer(
+      '<pre><code>fn example() { [[person:sarah-chen]] }</code></pre>',
+    )
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      expect(container.querySelectorAll('a.wchip')).toHaveLength(1)
+      expect(container.querySelector('pre a.wchip')).not.toBeNull()
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('does NOT rewrap tokens already inside an existing <a> element', () => {
+    const container = makeContainer(
+      '<p><a href="/existing">Existing with [[person:sarah-chen]] inside</a> outside.</p>',
+    )
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      // The existing anchor is preserved, and the token inside is NOT nested into a new anchor.
+      const anchors = Array.from(container.querySelectorAll('a'))
+      expect(anchors).toHaveLength(1)
+      expect(anchors[0].getAttribute('href')).toBe('/existing')
+      // The text inside includes the raw token still.
+      expect(anchors[0].textContent).toContain('[[person:sarah-chen]]')
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('is a no-op on containers with no tokens present', () => {
+    const container = makeContainer('<p>Nothing special here.</p>')
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    const before = container.innerHTML
+    try {
+      substituteTokensInHtml(container, refs)
+      expect(container.innerHTML).toBe(before)
+    } finally {
+      cleanup(container)
+    }
+  })
+
+  it('is idempotent: running twice produces the same DOM', () => {
+    const container = makeContainer('<p>[[person:sarah-chen]] again.</p>')
+    const refs: RefsMap = { 'person:sarah-chen': personRef }
+    try {
+      substituteTokensInHtml(container, refs)
+      const afterFirst = container.innerHTML
+      substituteTokensInHtml(container, refs)
+      expect(container.innerHTML).toBe(afterFirst)
+    } finally {
+      cleanup(container)
+    }
+  })
+})

--- a/wiki/src/lib/remarkWikiTokens.test.ts
+++ b/wiki/src/lib/remarkWikiTokens.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import remarkWikiTokens, { WIKI_CHIP_DATA_ATTR } from './remarkWikiTokens'
+
+/**
+ * Minimal mdast shape accepted by the transformer. The plugin doesn't depend on
+ * any specific mdast library — it walks `children` arrays and splits `text`
+ * nodes — so test trees can be hand-built without importing mdast types.
+ */
+type Node = {
+  type: string
+  value?: string
+  children?: Node[]
+  data?: {
+    hName?: string
+    hProperties?: Record<string, unknown>
+  }
+}
+
+function root(...children: Node[]): Node {
+  return { type: 'root', children }
+}
+
+function paragraph(...children: Node[]): Node {
+  return { type: 'paragraph', children }
+}
+
+function text(value: string): Node {
+  return { type: 'text', value }
+}
+
+function codeBlock(value: string): Node {
+  // mdast `code` nodes have a `value` string but NO `children` array.
+  return { type: 'code', value }
+}
+
+function inlineCode(value: string): Node {
+  // mdast `inlineCode` nodes also have `value`, no `children`.
+  return { type: 'inlineCode', value }
+}
+
+/** Apply the plugin and return the transformed tree. */
+function transform(tree: Node): Node {
+  const plugin = remarkWikiTokens()
+  plugin(tree as never)
+  return tree
+}
+
+describe('remarkWikiTokens', () => {
+  it('leaves plain text without tokens untouched', () => {
+    const tree = root(paragraph(text('Just prose without any wiki links.')))
+    transform(tree)
+    expect(tree.children).toEqual([
+      { type: 'paragraph', children: [{ type: 'text', value: 'Just prose without any wiki links.' }] },
+    ])
+  })
+
+  it('detects [[person:slug]] tokens and emits a chip node with data-wiki-chip-key', () => {
+    const tree = root(paragraph(text('Hello [[person:sarah-chen]] there.')))
+    transform(tree)
+    const kids = (tree.children[0].children ?? []) as Node[]
+    expect(kids.map((n) => n.type)).toEqual(['text', 'text', 'text'])
+    expect(kids[0].value).toBe('Hello ')
+    expect(kids[1].value).toBe('[[person:sarah-chen]]')
+    expect(kids[1].data?.hName).toBe('span')
+    expect(kids[1].data?.hProperties).toEqual({ [WIKI_CHIP_DATA_ATTR]: 'person:sarah-chen' })
+    expect(kids[2].value).toBe(' there.')
+  })
+
+  it('detects [[fragment:slug]], [[wiki:slug]], and [[entry:slug]] tokens with correct keys', () => {
+    const tree = root(
+      paragraph(
+        text('A [[fragment:alpha]] B [[wiki:beta]] C [[entry:gamma]] D'),
+      ),
+    )
+    transform(tree)
+    const kids = (tree.children[0].children ?? []) as Node[]
+    const chips = kids.filter((n) => n.data?.[`hProperties` as never])
+    expect(chips).toHaveLength(3)
+    expect(chips.map((c) => c.data!.hProperties![WIKI_CHIP_DATA_ATTR])).toEqual([
+      'fragment:alpha',
+      'wiki:beta',
+      'entry:gamma',
+    ])
+    // Raw token text preserved as the visible value so unresolved tokens render as text.
+    expect(chips.map((c) => c.value)).toEqual([
+      '[[fragment:alpha]]',
+      '[[wiki:beta]]',
+      '[[entry:gamma]]',
+    ])
+  })
+
+  it('detects unqualified [[slug]] tokens and emits a key without kind prefix', () => {
+    const tree = root(paragraph(text('Look: [[orphan-slug]] end.')))
+    transform(tree)
+    const kids = (tree.children[0].children ?? []) as Node[]
+    const chip = kids.find((n) => n.data?.hName === 'span')
+    expect(chip).toBeDefined()
+    expect(chip!.value).toBe('[[orphan-slug]]')
+    expect(chip!.data!.hProperties![WIKI_CHIP_DATA_ATTR]).toBe('orphan-slug')
+  })
+
+  it('handles multiple tokens in one text node', () => {
+    const tree = root(
+      paragraph(text('[[person:a]] then [[fragment:b]] and [[c]] done.')),
+    )
+    transform(tree)
+    const kids = (tree.children[0].children ?? []) as Node[]
+    const chips = kids.filter((n) => n.data?.hName === 'span')
+    expect(chips.map((c) => c.data!.hProperties![WIKI_CHIP_DATA_ATTR])).toEqual([
+      'person:a',
+      'fragment:b',
+      'c',
+    ])
+  })
+
+  it('does NOT substitute tokens inside fenced code blocks (code nodes have no children)', () => {
+    const tree = root(
+      paragraph(text('before [[person:real]] after')),
+      codeBlock('[[person:inside-code]] should not be touched'),
+    )
+    transform(tree)
+    // The code block's value is unchanged; no children appear and no chip nodes were synthesized in it.
+    expect(tree.children[1]).toEqual({
+      type: 'code',
+      value: '[[person:inside-code]] should not be touched',
+    })
+    // Sanity: the paragraph WAS transformed.
+    const paragraphKids = (tree.children[0].children ?? []) as Node[]
+    expect(paragraphKids.some((n) => n.data?.hName === 'span')).toBe(true)
+  })
+
+  it('does NOT substitute tokens inside inline code (inlineCode nodes have no children)', () => {
+    const tree = root(
+      paragraph(
+        text('See '),
+        inlineCode('[[person:inline]]'),
+        text(' vs [[person:real]] here.'),
+      ),
+    )
+    transform(tree)
+    const kids = (tree.children[0].children ?? []) as Node[]
+    // inlineCode node is still present and untouched.
+    const inlineCodeNode = kids.find((n) => n.type === 'inlineCode')
+    expect(inlineCodeNode).toBeDefined()
+    expect(inlineCodeNode!.value).toBe('[[person:inline]]')
+    // The real token outside inline code was still substituted.
+    const chips = kids.filter((n) => n.data?.hName === 'span')
+    expect(chips).toHaveLength(1)
+    expect(chips[0].data!.hProperties![WIKI_CHIP_DATA_ATTR]).toBe('person:real')
+  })
+
+  it('recurses into nested parents (e.g. tokens inside emphasis)', () => {
+    const tree = root(
+      paragraph({
+        type: 'emphasis',
+        children: [text('Quoting [[person:nested]] inline.')],
+      }),
+    )
+    transform(tree)
+    const emphasis = tree.children[0].children![0] as Node
+    const chip = (emphasis.children ?? []).find((n) => n.data?.hName === 'span') as Node | undefined
+    expect(chip).toBeDefined()
+    expect(chip!.data!.hProperties![WIKI_CHIP_DATA_ATTR]).toBe('person:nested')
+  })
+})

--- a/wiki/src/lib/remarkWikiTokens.test.ts
+++ b/wiki/src/lib/remarkWikiTokens.test.ts
@@ -16,11 +16,13 @@ type Node = {
   }
 }
 
-function root(...children: Node[]): Node {
+type ParentNode = Node & { children: Node[] }
+
+function root(...children: Node[]): ParentNode {
   return { type: 'root', children }
 }
 
-function paragraph(...children: Node[]): Node {
+function paragraph(...children: Node[]): ParentNode {
   return { type: 'paragraph', children }
 }
 
@@ -39,7 +41,7 @@ function inlineCode(value: string): Node {
 }
 
 /** Apply the plugin and return the transformed tree. */
-function transform(tree: Node): Node {
+function transform(tree: ParentNode): ParentNode {
   const plugin = remarkWikiTokens()
   plugin(tree as never)
   return tree

--- a/wiki/src/lib/sectionEdit.test.ts
+++ b/wiki/src/lib/sectionEdit.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { fixtureMarkdown } from '@robin/shared/fixtures'
+import {
+  parseSectionsFromMarkdown,
+  replaceSectionInMarkdown,
+  getSectionBody,
+  slugifyHeading,
+  scrollToSectionAnchor,
+} from './sectionEdit'
+
+describe('slugifyHeading', () => {
+  it('lowercases and collapses non-alphanumerics to single hyphens', () => {
+    expect(slugifyHeading('Attention Is All You Need')).toBe('attention-is-all-you-need')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugifyHeading('  Hello World!  ')).toBe('hello-world')
+    expect(slugifyHeading('---Foo---')).toBe('foo')
+  })
+
+  it('handles empty and all-non-alphanumeric strings', () => {
+    expect(slugifyHeading('')).toBe('')
+    expect(slugifyHeading('!!!')).toBe('')
+  })
+})
+
+describe('parseSectionsFromMarkdown', () => {
+  it('returns an empty array for empty content', () => {
+    expect(parseSectionsFromMarkdown('')).toEqual([])
+  })
+
+  it('returns an empty array for content with no headings', () => {
+    expect(parseSectionsFromMarkdown('Just a paragraph.\n\nAnother.')).toEqual([])
+  })
+
+  it('parses a single level-1 heading', () => {
+    const sections = parseSectionsFromMarkdown('# Title\n\nBody.')
+    expect(sections).toHaveLength(1)
+    expect(sections[0]).toMatchObject({
+      id: 'title',
+      anchor: 'title',
+      heading: 'Title',
+      level: 1,
+      startLine: 0,
+      endLine: 2,
+    })
+  })
+
+  it('parses headings at levels 1/2/3 and computes endLine correctly', () => {
+    const md = [
+      '# Root', // 0
+      '', // 1
+      '## Sub A', // 2
+      'alpha', // 3
+      '### Sub Sub', // 4
+      'beta', // 5
+      '## Sub B', // 6
+      'gamma', // 7
+    ].join('\n')
+    const sections = parseSectionsFromMarkdown(md)
+    expect(sections.map((s) => ({ heading: s.heading, level: s.level, startLine: s.startLine, endLine: s.endLine }))).toEqual([
+      { heading: 'Root', level: 1, startLine: 0, endLine: 7 },
+      { heading: 'Sub A', level: 2, startLine: 2, endLine: 5 },
+      { heading: 'Sub Sub', level: 3, startLine: 4, endLine: 5 },
+      { heading: 'Sub B', level: 2, startLine: 6, endLine: 7 },
+    ])
+  })
+
+  it('disambiguates duplicate headings with -1, -2 suffixes on subsequent occurrences', () => {
+    const md = '## Notes\n\n## Notes\n\n## Notes\n'
+    const sections = parseSectionsFromMarkdown(md)
+    expect(sections.map((s) => s.anchor)).toEqual(['notes', 'notes-1', 'notes-2'])
+  })
+
+  it('ignores `#` lines inside fenced code blocks (backtick fences)', () => {
+    const md = [
+      '# Real',
+      '',
+      '```',
+      '# Not a heading',
+      '## Also not',
+      '```',
+      '',
+      '## Real Two',
+    ].join('\n')
+    const sections = parseSectionsFromMarkdown(md)
+    expect(sections.map((s) => s.heading)).toEqual(['Real', 'Real Two'])
+  })
+
+  it('ignores `#` lines inside fenced code blocks (tilde fences)', () => {
+    const md = [
+      '# Real',
+      '',
+      '~~~',
+      '# Not a heading',
+      '~~~',
+      '',
+      '## Real Two',
+    ].join('\n')
+    const sections = parseSectionsFromMarkdown(md)
+    expect(sections.map((s) => s.heading)).toEqual(['Real', 'Real Two'])
+  })
+
+  it('handles the fixtureMarkdown integration case (duplicate Notes produces notes + notes-1)', () => {
+    const sections = parseSectionsFromMarkdown(fixtureMarkdown)
+    const anchors = sections.map((s) => s.anchor)
+    // Full expected list derived from the fixture's heading structure
+    expect(anchors).toEqual([
+      'transformer-architecture',
+      'overview',
+      'the-attention-mechanism',
+      'architecture',
+      'encoder-stack',
+      'decoder-stack',
+      'notes',
+      'notes-1',
+    ])
+  })
+})
+
+describe('getSectionBody', () => {
+  it('returns the section including its heading line', () => {
+    const md = '# Title\n\nBody line.\n\n## Other\n\nOther body.'
+    const body = getSectionBody(md, 'other')
+    expect(body).toBe('## Other\n\nOther body.')
+  })
+
+  it('returns the heading line plus body for a leaf section', () => {
+    const md = '# A\n\naa\n\n## B\n\nbb'
+    expect(getSectionBody(md, 'b')).toBe('## B\n\nbb')
+  })
+
+  it('returns an empty string when sectionId does not match any section', () => {
+    const md = '# Real\n\nbody'
+    expect(getSectionBody(md, 'nonexistent')).toBe('')
+  })
+
+  it('does not crash on empty content with a stale sectionId', () => {
+    expect(getSectionBody('', 'anything')).toBe('')
+  })
+})
+
+describe('replaceSectionInMarkdown', () => {
+  it('replaces section body and preserves surrounding lines byte-for-byte on no-op', () => {
+    const md = '# A\n\naa\n\n## B\n\nbb'
+    const body = getSectionBody(md, 'b')
+    const out = replaceSectionInMarkdown(md, 'b', body)
+    expect(out).toBe(md)
+  })
+
+  it('round-trips identical body on every section of the fixture', () => {
+    const sections = parseSectionsFromMarkdown(fixtureMarkdown)
+    for (const section of sections) {
+      const body = getSectionBody(fixtureMarkdown, section.id)
+      const out = replaceSectionInMarkdown(fixtureMarkdown, section.id, body)
+      expect(out).toBe(fixtureMarkdown)
+    }
+  })
+
+  it('replaces only the targeted section when headings are nested', () => {
+    const md = [
+      '## Parent', // 0
+      '', // 1
+      'parent body', // 2
+      '### Child', // 3
+      'child body', // 4
+      '## Sibling', // 5
+      'sibling body', // 6
+    ].join('\n')
+    // Replacing H2 "Parent" must subsume H3 "Child" — the new body replaces lines 0..4.
+    const replaced = replaceSectionInMarkdown(md, 'parent', '## Parent\n\nnew parent body')
+    expect(replaced).toBe('## Parent\n\nnew parent body\n## Sibling\nsibling body')
+
+    // Replacing H3 "Child" alone only touches lines 3..4.
+    const childReplaced = replaceSectionInMarkdown(md, 'child', '### Child\nnew child body')
+    expect(childReplaced).toBe(
+      '## Parent\n\nparent body\n### Child\nnew child body\n## Sibling\nsibling body',
+    )
+  })
+
+  it('returns original content unchanged when sectionId is stale', () => {
+    const md = '# Real\n\nbody'
+    expect(replaceSectionInMarkdown(md, 'ghost', '# Something Else')).toBe(md)
+  })
+
+  it('replaces the correct disambiguated duplicate section', () => {
+    const md = '## Notes\n\nfirst\n\n## Notes\n\nsecond'
+    const out = replaceSectionInMarkdown(md, 'notes-1', '## Notes\n\nsecond-edited')
+    expect(out).toBe('## Notes\n\nfirst\n\n## Notes\n\nsecond-edited')
+  })
+})
+
+describe('scrollToSectionAnchor', () => {
+  it('does not throw when the target element does not exist', () => {
+    expect(() => scrollToSectionAnchor('definitely-not-here')).not.toThrow()
+  })
+
+  it('calls scrollIntoView on a matching element', () => {
+    const el = document.createElement('div')
+    el.id = 'target-section'
+    let called = false
+    el.scrollIntoView = () => {
+      called = true
+    }
+    document.body.appendChild(el)
+    try {
+      scrollToSectionAnchor('target-section')
+      expect(called).toBe(true)
+    } finally {
+      el.remove()
+    }
+  })
+})

--- a/wiki/vitest.config.ts
+++ b/wiki/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      // Monorepo subpath exports — map to source for direct ts resolution
+      // (mirrors core/vitest.config.ts). The shared package ships via
+      // compiled dist at runtime, but tests resolve source so an unbuilt
+      // workspace still runs.
+      '@robin/shared/schemas/sidecar': resolve(
+        __dirname,
+        '../packages/shared/src/schemas/sidecar.ts',
+      ),
+      '@robin/shared/fixtures': resolve(
+        __dirname,
+        '../packages/shared/src/fixtures/index.ts',
+      ),
+      '@robin/shared': resolve(__dirname, '../packages/shared/src/index.ts'),
+      // Next.js-style path alias for wiki-local imports
+      '@': resolve(__dirname, './src'),
+    },
+  },
+})

--- a/wiki/vitest.setup.ts
+++ b/wiki/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## Summary

Closes the frontend test-harness gap left by m-wiki-sidecar (surfaced as issue #121). Stands up vitest in the \`wiki/\` workspace and ports the pure-logic modules that landed with the sidecar feature into real unit tests. 56 tests, all green.

Single-agent milestone — issue #121.

## What's in

**Harness**
- \`wiki/vitest.config.ts\` + \`wiki/vitest.setup.ts\` — jsdom env, React Testing Library, \`@robin/shared\` subpath aliases mirrored from \`core/vitest.config.ts\`
- \`wiki/package.json\` — new \`test\` + \`test:watch\` scripts, vitest + RTL + jsdom devDeps
- \`turbo.json\` — registered \`@robin/wiki#test\` task

**Pure-logic tests (42 tests)**
- \`wiki/src/lib/sectionEdit.test.ts\` — 22 tests: parse/replace round-trips, slugify parity, duplicate-heading anchors, fenced-code skip, nested sub-sections, stale-sectionId handling, fixture integration
- \`wiki/src/lib/remarkWikiTokens.test.ts\` — 8 tests: every token kind, chip-key emission, raw fallback, code-fence isolation
- \`wiki/src/lib/htmlTokenSubstitute.test.ts\` — 12 tests: DOM walker behavior, \`refToHref\` per kind, unresolved-token text fallback

**Component smoke tests (14 tests)**
- \`wiki/src/components/wiki/WikiChip.test.tsx\` — 3 tests
- \`wiki/src/components/wiki/WikiCitations.test.tsx\` — 5 tests
- \`wiki/src/components/wiki/WikiInfobox.test.tsx\` — 6 tests

## Verification

- \`pnpm -C wiki test\` — **56/56 green** (1.66s)
- \`pnpm typecheck\` — 9/9 tasks green, FULL TURBO
- \`pnpm turbo run test --filter=@robin/wiki\` — green (builds \`@robin/shared\` first per dep graph)

## Out of scope (per #121)

- Playwright / E2E browser tests — separate future milestone
- Coverage thresholds — add after suite stabilizes
- Component tests for \`WikiEntityArticle\`, \`EntryArticle\`, detail pages — those need heavier mocking; smoke-level only in this PR

## Noted gap for future follow-up

The \`htmlTokenSubstitute\` DOM walker currently substitutes tokens inside \`<code>\` and \`<pre>\` tags (code fences). The tests capture this as current behavior with a \`TODO(#121)\` marker rather than papering over it with a production-code change (hard-boundary: no prod code changes in this milestone). Filing a follow-up to tighten the walker would be a small, scoped fix.

## Test plan

- [ ] Pull the branch, \`pnpm install\`, \`pnpm -C wiki test\` — expect 56/56 green
- [ ] \`pnpm test\` at root — wiki workspace test task picked up by turbo alongside existing core + shared tests
- [ ] Review the test files for coverage gaps on the three pure-logic modules