### PR TITLE
build: rebuild workspace packages before dev to prevent stale dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run build --filter='./packages/*' && turbo run dev --filter=@robin/core --filter=@robin/wiki --parallel",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "lint": "turbo run lint",
@@ -12,7 +12,7 @@
     "clean": "find core wiki packages -type d \\( -name dist -o -name node_modules -o -name .turbo -o -name .next \\) -prune -exec rm -rf {} + && rm -rf node_modules .turbo",
     "seed-openrouter-key": "tsx core/scripts/seed-openrouter-key.ts",
     "port": "sh -c 'ss -tlnp \"sport = :$0\"'",
-    "serve": "npx concurrently -n core,wiki -c blue,magenta \"pnpm --filter @robin/core dev\" \"pnpm --filter @robin/wiki dev\"",
+    "serve": "pnpm dev",
     "manifest": "pnpm --filter @robin/core openapi:manifest && pnpm --filter @robin/wiki manifest"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #135.

## Problem

`packages/*/dist/` is correctly `.gitignore`d and `turbo.json` declares `dev.dependsOn: ["^build"]`, so a clean `turbo run dev` would rebuild workspace packages before consumers read them. But the root `pnpm serve` and `pnpm dev` scripts both bypassed turbo — `serve` used `concurrently` to invoke each consumer's dev script directly, and `dev` used `turbo run dev --parallel` which explicitly ignores the task graph.

Result: when `packages/shared/src/fixtures/wikiSidecarFixture.ts` was rewritten in `c2feef4`, nothing triggered a rebuild of the cached `packages/shared/dist/fixtures/wikiSidecarFixture.mjs`. Core silently imported old `sample-wiki` / `sarah-chen` data, and the first-run demo wiki seeded the wrong fixture. UAT plan 22 caught this as 15 failures downstream of fixture identity drift.

## Fix

```diff
- "dev": "turbo run dev --parallel",
+ "dev": "turbo run build --filter='./packages/*' && turbo run dev --filter=@robin/core --filter=@robin/wiki --parallel",
- "serve": "npx concurrently -n core,wiki -c blue,magenta \"pnpm --filter @robin/core dev\" \"pnpm --filter @robin/wiki dev\"",
+ "serve": "pnpm dev",
```

1. One-shot `turbo run build --filter='./packages/*'` builds shared, agent, caslock, queue before consumers boot. ~4s cold, cached after.
2. Dev then runs only core and wiki — **not** the packages' own `dev` scripts (tsdown --watch). Including them caused a race: the watcher would nuke dist mid-write, and core's `tsx watch` would fail `ERR_MODULE_NOT_FOUND` on `@robin/shared/dist/index.mjs` during the window.

## Trade-off this introduces

Editing a workspace package's source during a live `pnpm dev` session no longer auto-rebuilds its dist. Workflow for package-internal iteration:

```
# terminal 1
pnpm dev
# terminal 2
pnpm --filter @robin/shared dev   # tsdown --watch
```

This matches the pre-existing `concurrently` behavior, which also didn't rebuild packages during a session.

## Verification

- ✅ `rm -rf packages/*/dist .turbo && pnpm dev` — turbo builds all 4 packages first, then core+wiki start.
- ✅ `pnpm -C core seed-fixture --dry-run` against fresh build reports `transformer-architecture`, 3 people (Vaswani/Shazeer/Parmar), 5 fragments, 1 entry (attention-paper-abstract). Previously reported sample-wiki / Sarah Chen.
- ✅ `pnpm typecheck` — 9/9 tasks pass.
- ✅ Core boots past all module imports (confirmed by migration + wiki-type seed logs).

## Out of scope

- Core and wiki both default to port 3000, causing a boot race (whoever binds first wins, the other crashes). Pre-existing bug; unrelated to the stale-dist issue. Will file separately.