### PR TITLE
fix(core): include sidecar fields in wikiDetailResponseSchema

### DIFF
--- a/core/src/__tests__/wiki-detail-response.test.ts
+++ b/core/src/__tests__/wiki-detail-response.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { wikiDetailResponseSchema } from '../schemas/wikis.schema.js'
+
+const baseThreadFields = {
+  id: 'wiki01ABC',
+  lookupKey: 'wiki01ABC',
+  slug: 'example',
+  name: 'Example',
+  type: 'project',
+  prompt: '',
+  state: 'RESOLVED',
+  lastRebuiltAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  noteCount: 0,
+  lastUpdated: new Date().toISOString(),
+  shortDescriptor: '',
+  descriptor: '',
+  progress: null,
+  wikiContent: '## Overview\n',
+  fragments: [],
+  people: [],
+}
+
+describe('wikiDetailResponseSchema', () => {
+  it('preserves refs, infobox, and sections on a populated payload', () => {
+    const personRef = {
+      kind: 'person' as const,
+      id: 'person01',
+      slug: 'ashish-vaswani',
+      label: 'Ashish Vaswani',
+    }
+    const infoboxRow = { label: 'Owner', value: 'Test', valueKind: 'text' as const }
+    const section = {
+      id: 'overview',
+      anchor: 'overview',
+      heading: 'Overview',
+      level: 2,
+      citations: [],
+    }
+    const result = wikiDetailResponseSchema.safeParse({
+      ...baseThreadFields,
+      refs: { 'person:ashish-vaswani': personRef },
+      infobox: { rows: [infoboxRow] },
+      sections: [section],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.refs).toEqual({ 'person:ashish-vaswani': personRef })
+    expect(result.data.infobox).toEqual({ rows: [infoboxRow] })
+    expect(result.data.sections).toHaveLength(1)
+    expect(result.data.sections[0].anchor).toBe('overview')
+  })
+
+  it('defaults refs/infobox/sections when the server omits them', () => {
+    const result = wikiDetailResponseSchema.safeParse(baseThreadFields)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.refs).toEqual({})
+    expect(result.data.infobox).toBeNull()
+    expect(result.data.sections).toEqual([])
+  })
+})

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -62,6 +62,9 @@ export const wikiDetailResponseSchema = threadResponseSchema.extend({
       name: z.string(),
     })
   ),
+  refs: wikiRefsMapSchema.default({}),
+  infobox: wikiInfoboxSchema.nullable().default(null),
+  sections: z.array(wikiSectionSchema).default([]),
 })
 
 export const threadListResponseSchema = z.object({


### PR DESCRIPTION
Fixes #136.

## Problem

`GET /wikis/:id` handler (`core/src/routes/wikis.ts:271-287`) builds a sidecar via `buildSidecar(...)` and passes `refs`, `infobox`, `sections` into `wikiDetailResponseSchema.parse({...})`. But the schema at `core/src/schemas/wikis.schema.ts:49-65` did **not** declare those fields, so zod's default object parsing stripped them silently. The entire m-wiki-sidecar structured surface (token chips, structured infobox, per-section citations, per-section edit affordance) never reached the authenticated wiki UI.

The bug was hidden because:
1. `publicWikiResponseSchema` (lines 116-125, preview route) correctly declares the fields, so the public path worked.
2. The wiki client reads each field with a defensive `??` fallback (see RESEARCH NQ13 comment at `wiki/src/app/wiki/[id]/page.tsx:428`), so a stripped payload rendered as empty data, not as an error.

## Fix

Extend `wikiDetailResponseSchema` with three fields, mirroring `publicWikiResponseSchema`:

```diff
  people: z.array(...)
+ refs: wikiRefsMapSchema.default({}),
+ infobox: wikiInfoboxSchema.nullable().default(null),
+ sections: z.array(wikiSectionSchema).default([]),
 })
```

The imports from `@robin/shared/schemas/sidecar` already existed at the top of the file.

## Test

New unit test `core/src/__tests__/wiki-detail-response.test.ts`:
- Asserts `refs`, `infobox`, `sections` round-trip through `parse` when present.
- Asserts defaults (`{}`, `null`, `[]`) apply when the server omits them.

Both pass.

## Not done in this PR (deliberate)

- Removing the defensive `??` fallbacks in the wiki client. They now point at a server contract that's guaranteed to provide defaults, so they're technically dead weight. But the generated SDK types still mark these as optional (per the NQ13 comment), so removing them would require an SDK regeneration. Separate cleanup.

## Verification

- ✅ `pnpm --filter @robin/core typecheck` clean.
- ✅ New test passes: 2/2.
- ✅ `pnpm --filter @robin/core lint` — 0 new errors introduced. 23 pre-existing baseline errors unchanged.