### PR TITLE
fix(db): make wikis_slug_uidx partial on deleted_at IS NULL

### DIFF
--- a/core/drizzle/migrations/0005_wikis_slug_partial_uidx.sql
+++ b/core/drizzle/migrations/0005_wikis_slug_partial_uidx.sql
@@ -1,0 +1,9 @@
+-- Make `wikis_slug_uidx` partial on `deleted_at IS NULL` so a soft-deleted
+-- wiki no longer blocks re-insertion at the same slug. Previously, seeding
+-- the demo fixture after a user soft-deleted it hit a unique-constraint
+-- violation because the tombstoned row still held the slug.
+--
+-- Read-path queries already filter `isNull(deletedAt)`, so restricting the
+-- uniqueness predicate to live rows matches the effective invariant.
+DROP INDEX "wikis_slug_uidx";--> statement-breakpoint
+CREATE UNIQUE INDEX "wikis_slug_uidx" ON "wikis" USING btree ("slug") WHERE "wikis"."deleted_at" IS NULL;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777248000000,
       "tag": "0004_wikis_citation_declarations",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0005_wikis_slug_partial_uidx",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -246,7 +246,7 @@ export const wikis = pgTable(
       .default(sql`'[]'::jsonb`),
   },
   (t) => [
-    uniqueIndex('wikis_slug_uidx').on(t.slug),
+    uniqueIndex('wikis_slug_uidx').on(t.slug).where(sql`${t.deletedAt} IS NULL`),
     uniqueIndex('wikis_published_slug_uidx').on(t.publishedSlug),
   ]
 )


### PR DESCRIPTION
Fixes #137.

## Problem

`core/src/db/schema.ts:249` — `wikis_slug_uidx` had no partial predicate:

```ts
uniqueIndex('wikis_slug_uidx').on(t.slug)
```

So a soft-deleted wiki row still held its slug under the unique constraint. `seedFixture()` at `core/src/lib/seedFixture.ts:73-77` looks up live rows with `isNull(wikis.deletedAt)` and falls through to INSERT when no live row is found. If a user has previously soft-deleted the demo wiki, that INSERT hits:

```
ERROR:  duplicate key value violates unique constraint "wikis_slug_uidx"
DETAIL:  Key (slug)=(demo) already exists.
```

## Fix

1. Schema — restrict the uniqueness predicate to live rows:

```ts
uniqueIndex('wikis_slug_uidx').on(t.slug).where(sql`${t.deletedAt} IS NULL`)
```

2. Migration `0005_wikis_slug_partial_uidx.sql` — drop + recreate the index as partial. Written by hand to match the existing migration style (0001-0004 are all small focused ALTER/INSERT files; the team doesn't check in generated drizzle-kit dumps).

Read-path queries throughout the codebase already filter `isNull(deletedAt)`, so this change matches the effective invariant — live-row uniqueness is still enforced; tombstones no longer collide.

## Verification

Applied all migrations against a fresh `robinwiki` DB:

```sql
-- Seed
INSERT INTO wikis (lookup_key, slug, name, type) VALUES ('wiki001', 'demo', 'Demo wiki', 'log');
-- Soft-delete
UPDATE wikis SET deleted_at = NOW() WHERE lookup_key = 'wiki001';
-- Re-insert at same slug (would have failed before this migration)
INSERT INTO wikis (lookup_key, slug, name, type) VALUES ('wiki002', 'demo', 'Demo wiki v2', 'log');
-- Both coexist
SELECT lookup_key, slug, deleted_at IS NOT NULL AS tombstoned FROM wikis;
--  wiki001 | demo | t
--  wiki002 | demo | f
-- Try a THIRD insertion at same slug while wiki002 is live
INSERT INTO wikis (lookup_key, slug, name, type) VALUES ('wiki003', 'demo', 'Should fail', 'log');
-- ERROR: duplicate key value violates unique constraint "wikis_slug_uidx"
```

Tombstone + live row coexist. Two live rows still collide.

Index definition after migration:
```
wikis_slug_uidx | CREATE UNIQUE INDEX wikis_slug_uidx ON public.wikis USING btree (slug) WHERE (deleted_at IS NULL)
```

## Out of scope

- Audit `people.slug`, `fragments.slug`, `raw_sources.slug`, `groups.slug` for the same soft-delete pattern. Likely systemic; should file separately.
- Full integration test for `seedFixture()` — the manual reproducer above exercises the exact failure mode. Adding a DB-backed vitest run requires `robin_dev` / `robin_test` test DBs that aren't provisioned in this env.

## Verification checklist

- ✅ `pnpm --filter @robin/core typecheck` clean.
- ✅ Migration applies cleanly against a DB that has already run 0000–0004.
- ✅ Index is confirmed partial via `pg_indexes` inspection.
- ✅ Reproducer case (re-insert after soft-delete) succeeds.
- ✅ Live-row uniqueness still enforced.