### PR TITLE
feat(mcp): rename get_thread to get_wiki and add ?raw wiki body

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Robin exposes an MCP server for Claude, ChatGPT, and other AI clients.
 | `create_wiki` | Create a new wiki with auto-inferred type |
 | `edit_wiki` | Update wiki content with edit history preservation |
 | `list_wikis` | List all wikis with fragment counts and type info |
-| `get_thread` | Get wiki details with full body and fragment snippets |
+| `get_wiki` | Get wiki details with full body and fragment snippets |
 | `get_fragment` | Get full fragment content by slug |
 | `find_person` | Find a person by ID or fuzzy name search |
 | `brief_person` | Get a formatted person briefing (no LLM call) |

--- a/core/src/__tests__/mcp-resolvers.test.ts
+++ b/core/src/__tests__/mcp-resolvers.test.ts
@@ -84,7 +84,7 @@ describe('resolveSlug', () => {
 
 import type postgres from 'postgres'
 import type { McpResolverDeps } from '../mcp/resolvers.js'
-import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery } from '../mcp/resolvers.js'
+import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery } from '../mcp/resolvers.js'
 import { makeLookupKey, ObjectType } from '@robin/shared'
 import { entries, fragments, wikis, people, edges } from '../db/schema.js'
 import {
@@ -320,11 +320,11 @@ describe('MCP resolvers (real DB)', () => {
     })
   })
 
-  // ─── getThread ───
+  // ─── getWiki ───
 
-  describe('getThread', () => {
+  describe('getWiki', () => {
     it('resolves exact slug and returns wiki body + linked fragments', async () => {
-      const result = await getThread({ db }, 'ai-infrastructure')
+      const result = await getWiki({ db }, 'ai-infrastructure')
 
       expect('thread' in result).toBe(true)
       if ('thread' in result) {
@@ -339,7 +339,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('resolves fuzzy slug match', async () => {
-      const result = await getThread({ db }, 'ai-infra')
+      const result = await getWiki({ db }, 'ai-infra')
       expect('thread' in result).toBe(true)
       if ('thread' in result) {
         expect(result.thread.slug).toBe('ai-infrastructure')
@@ -347,7 +347,7 @@ describe('MCP resolvers (real DB)', () => {
     })
 
     it('returns error for no match', async () => {
-      const result = await getThread({ db }, 'zzz-nonexistent')
+      const result = await getWiki({ db }, 'zzz-nonexistent')
       expect('error' in result).toBe(true)
       if ('error' in result) {
         expect(result.suggestions).toContain('ai-infrastructure')
@@ -357,7 +357,7 @@ describe('MCP resolvers (real DB)', () => {
     it('excludes soft-deleted fragment edges', async () => {
       await db.update(edges).set({ deletedAt: new Date() }).where(eq(edges.srcId, fragKey2))
 
-      const result = await getThread({ db }, 'ai-infrastructure')
+      const result = await getWiki({ db }, 'ai-infrastructure')
       expect('thread' in result).toBe(true)
       if ('thread' in result) {
         expect(result.fragments).toHaveLength(1)
@@ -368,7 +368,7 @@ describe('MCP resolvers (real DB)', () => {
     // ─── sidecar shape (full detail) ───
 
     it('emits sidecar refs/sections/infobox on thread detail', async () => {
-      const result = await getThread({ db }, 'ai-infrastructure')
+      const result = await getWiki({ db }, 'ai-infrastructure')
       expect('thread' in result).toBe(true)
       if (!('thread' in result)) return
 
@@ -400,7 +400,7 @@ describe('MCP resolvers (real DB)', () => {
 
     it('emits infobox=null when wikis.metadata is unset', async () => {
       await db.update(wikis).set({ metadata: null }).where(eq(wikis.lookupKey, wikiKey))
-      const result = await getThread({ db }, 'ai-infrastructure')
+      const result = await getWiki({ db }, 'ai-infrastructure')
       expect('thread' in result).toBe(true)
       if ('thread' in result) {
         expect(result.infobox).toBeNull()

--- a/core/src/lib/strip-wiki-content.test.ts
+++ b/core/src/lib/strip-wiki-content.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { stripWikiContent } from './strip-wiki-content.js'
+import type { WikiRef } from '@robin/shared/schemas/sidecar'
+
+const refs: Record<string, WikiRef> = {
+  'person:jane-doe': {
+    kind: 'person',
+    id: 'person01ABC',
+    slug: 'jane-doe',
+    label: 'Jane Doe',
+  },
+  'wiki:ai-infrastructure': {
+    kind: 'wiki',
+    id: 'wiki01XYZ',
+    slug: 'ai-infrastructure',
+    label: 'AI Infrastructure',
+    wikiType: 'log',
+  },
+  'fragment:vector-db-note': {
+    kind: 'fragment',
+    id: 'frag01DEF',
+    slug: 'vector-db-note',
+    label: 'Vector DB Note',
+  },
+}
+
+describe('stripWikiContent', () => {
+  it('replaces [[kind:slug]] tokens with resolved labels', () => {
+    const input = 'See [[person:jane-doe]] for details on [[wiki:ai-infrastructure]].'
+    const result = stripWikiContent(input, refs)
+    expect(result).toBe('See Jane Doe for details on AI Infrastructure.')
+  })
+
+  it('falls back to title-casing the slug when no ref exists', () => {
+    const input = 'Check [[wiki:unknown-topic]] for more.'
+    const result = stripWikiContent(input, refs)
+    expect(result).toBe('Check Unknown Topic for more.')
+  })
+
+  it('strips inline citation markers', () => {
+    const input = 'This is a fact[1] with multiple citations[2][12].'
+    const result = stripWikiContent(input, refs)
+    expect(result).toBe('This is a fact with multiple citations.')
+  })
+
+  it('handles both tokens and citations together', () => {
+    const input = '[[person:jane-doe]] noted this[1]. See [[wiki:ai-infrastructure]][2].'
+    const result = stripWikiContent(input, refs)
+    expect(result).toBe('Jane Doe noted this. See AI Infrastructure.')
+  })
+
+  it('returns content unchanged when no tokens or citations', () => {
+    const input = '# Plain Heading\n\nJust regular markdown.'
+    const result = stripWikiContent(input, refs)
+    expect(result).toBe(input)
+  })
+
+  it('handles empty content', () => {
+    expect(stripWikiContent('', refs)).toBe('')
+  })
+
+  it('handles empty refs map', () => {
+    const input = 'See [[person:jane-doe]] here.'
+    const result = stripWikiContent(input, {})
+    expect(result).toBe('See Jane Doe here.')
+  })
+})

--- a/core/src/lib/strip-wiki-content.ts
+++ b/core/src/lib/strip-wiki-content.ts
@@ -1,0 +1,41 @@
+import type { WikiRef } from '@robin/shared/schemas/sidecar'
+
+/**
+ * Title-case a slug: "jane-doe" → "Jane Doe".
+ * Used as fallback when a token has no matching ref entry.
+ */
+function titleCase(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => (w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ')
+}
+
+/**
+ * Strip wiki-link tokens and citation markers from markdown content,
+ * producing a clean, token-efficient body for LLM consumption.
+ *
+ * 1. Replaces `[[kind:slug]]` tokens with the resolved label from the
+ *    refs map, falling back to title-casing the slug when no ref exists.
+ * 2. Removes inline citation markers like `[1]`, `[2]`, etc.
+ *
+ * @param content - Raw markdown with wiki-link tokens
+ * @param refs    - Sidecar refs map keyed by `${kind}:${slug}`
+ * @returns Clean markdown string
+ */
+export function stripWikiContent(
+  content: string,
+  refs: Record<string, WikiRef>
+): string {
+  // Replace [[kind:slug]] tokens with resolved labels
+  let result = content.replace(/\[\[([a-z]+):([a-z0-9-]+)\]\]/g, (_match, _kind, slug) => {
+    const key = `${_kind}:${slug}`
+    const ref = refs[key]
+    return ref?.label ?? titleCase(slug)
+  })
+
+  // Strip inline citation markers [N] (e.g. [1], [12])
+  result = result.replace(/\[(\d+)\]/g, '')
+
+  return result
+}

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -13,8 +13,8 @@
  * - {@link handleLogEntry} feeds the full 6-stage AI pipeline via BullMQ.
  *   The entry row must exist before enqueue because the worker reads it.
  * - {@link handleLogFragment} is the fast path — bypasses the pipeline and
- *   writes a fragment directly to a known thread. Useful when the caller
- *   already knows the destination (e.g. after `list_threads`).
+ *   writes a fragment directly to a known wiki. Useful when the caller
+ *   already knows the destination (e.g. after `list_wikis`).
  *
  * **Fail-open semantics:**
  * - Entity extraction errors → fragment persisted without people edges.

--- a/core/src/mcp/resolvers.ts
+++ b/core/src/mcp/resolvers.ts
@@ -22,7 +22,7 @@
  * @see {@link resolveSlug} — generic fuzzy slug matching (auto-resolve at 70+)
  * @see {@link resolveThreadBySlug} — strict exact-match for write paths
  * @see {@link listWikis} — wiki listing with fragment counts
- * @see {@link getThread} — full thread detail with wiki body
+ * @see {@link getWiki} — full wiki detail with wiki body
  * @see {@link getFragment} — full fragment with content + frontmatter
  * @see {@link findPersonById} — exact PK lookup
  * @see {@link findPersonByQuery} — fuzzy name/slug/alias search
@@ -84,7 +84,7 @@ interface WikiSummary {
  * Sidecar: detail tool emits `refs`, `infobox`, and `sections[].citations`
  * per CONTRACT §9. `infobox` is sourced from `wikis.metadata.infobox`.
  */
-interface ThreadDetail {
+interface WikiDetail {
   thread: {
     lookupKey: string
     slug: string
@@ -513,20 +513,20 @@ export async function listWikis(
 }
 
 /**
- * Get full thread detail by slug with fuzzy matching.
+ * Get full wiki detail by slug with fuzzy matching.
  *
  * @remarks
- * Reads the thread's wiki body from the `content` column and fetches
+ * Reads the wiki body from the `content` column and fetches
  * all member fragments via `FRAGMENT_IN_WIKI` edges with 300-char snippets.
  *
  * @param deps      - Database client
- * @param slugInput - Thread slug (exact or fuzzy)
- * @returns {@link ThreadDetail} with wiki body and fragments, or {@link ErrorResult}
+ * @param slugInput - Wiki slug (exact or fuzzy)
+ * @returns {@link WikiDetail} with wiki body and fragments, or {@link ErrorResult}
  */
-export async function getThread(
+export async function getWiki(
   deps: McpResolverDeps,
   slugInput: string
-): Promise<ThreadDetail | ErrorResult> {
+): Promise<WikiDetail | ErrorResult> {
   const allThreads = await deps.db
     .select({
       lookupKey: wikis.lookupKey,

--- a/core/src/mcp/resolvers.ts
+++ b/core/src/mcp/resolvers.ts
@@ -32,6 +32,7 @@ import { eq, and, isNull, sql, inArray, ne } from 'drizzle-orm'
 import type { DB } from '../db/client.js'
 import { wikis, fragments, people, edges, wikiTypes } from '../db/schema.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
+import { stripWikiContent } from '../lib/strip-wiki-content.js'
 import { makeSidecarDeps } from '../lib/wikiSidecarDeps.js'
 import type {
   WikiInfobox,
@@ -593,6 +594,9 @@ export async function getWiki(
     deps: makeSidecarDeps(deps.db),
   })
 
+  // MCP consumers are always LLMs — strip tokens for efficiency
+  const strippedBody = stripWikiContent(wikiBody, sidecar.refs)
+
   return {
     thread: {
       lookupKey: thread.lookupKey,
@@ -602,7 +606,7 @@ export async function getWiki(
       state: thread.state,
       lastRebuiltAt: thread.lastRebuiltAt?.toISOString() ?? null,
     },
-    wikiBody,
+    wikiBody: strippedBody,
     fragments: fragmentSnippets,
     refs: sidecar.refs,
     infobox: sidecar.infobox,

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -20,7 +20,7 @@
 import { z } from 'zod/v4'
 import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { listWikis, getThread, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveThreadBySlug } from './resolvers.js'
+import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveThreadBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
 import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleDeleteWiki, handleDeletePerson } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
@@ -74,14 +74,14 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     'log_fragment',
     {
       description:
-        'Persist a fragment directly to a known thread, bypassing the AI ingestion pipeline. ' +
-        'Use when you already know which thread the content belongs to. ' +
-        'Get thread slugs from list_threads or get_thread first.',
+        'Persist a fragment directly to a known wiki, bypassing the AI ingestion pipeline. ' +
+        'Use when you already know which wiki the content belongs to. ' +
+        'Get wiki slugs from list_wikis or get_wiki first.',
       inputSchema: {
         content: z.string().describe('Fragment body content'),
         threadSlug: z
           .string()
-          .describe('Exact thread slug to attach to (from list_threads or get_thread)'),
+          .describe('Exact wiki slug to attach to (from list_wikis or get_wiki)'),
         title: z.string().optional().describe('Fragment title (derived from content if omitted)'),
         tags: z.array(z.string()).optional().describe('Optional tags'),
       },
@@ -174,7 +174,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         'resolves any [[kind:slug]] tokens present in the wiki content — use it ' +
         'to render or follow references without re-fetching each target. ' +
         'Per-section citations and infoboxes are omitted from list results; ' +
-        'call get_thread for full detail.',
+        'call get_wiki for full detail.',
       inputSchema: {
         includeDescriptors: z.boolean().optional().describe(
           'Include type descriptors in the response (default: true). Set false for compact output.'
@@ -202,10 +202,10 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
    ***********************************************************************/
 
   server.registerTool(
-    'get_thread',
+    'get_wiki',
     {
       description:
-        'Get full detail for a wiki (thread) by slug. Response includes:\n' +
+        'Get full detail for a wiki by slug. Response includes:\n' +
         '- `wikiBody`: markdown content with [[kind:slug]] tokens for internal references\n' +
         '- `refs`: resolver map from `${kind}:${slug}` → entity metadata. Use to render or ' +
         'follow tokens without re-fetching each target\n' +
@@ -216,12 +216,12 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
         'wiki type supports one — null otherwise\n' +
         '- `fragments`: member fragment snippets (unchanged)',
       inputSchema: {
-        slug: z.string().describe('Thread slug or partial slug for fuzzy matching'),
+        slug: z.string().describe('Wiki slug or partial slug for fuzzy matching'),
       },
     },
     async ({ slug }) => {
       try {
-        const result = await getThread(resolverDeps, slug)
+        const result = await getWiki(resolverDeps, slug)
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         }

--- a/core/src/routes/published.ts
+++ b/core/src/routes/published.ts
@@ -5,6 +5,7 @@ import { wikis } from '../db/schema.js'
 import { publicWikiResponseSchema } from '../schemas/wikis.schema.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
 import { makeSidecarDeps } from '../lib/wikiSidecarDeps.js'
+import { stripWikiContent } from '../lib/strip-wiki-content.js'
 
 const publishedRoutes = new Hono()
 
@@ -31,16 +32,16 @@ publishedRoutes.get('/wiki/:nanoid', async (c) => {
 
   c.header('Cache-Control', 'no-store')
 
-  if (c.req.query('raw') !== undefined) {
-    return c.text(wiki.content)
-  }
-
   const sidecar = await buildSidecar({
     content: wiki.content,
     metadata: wiki.metadata ?? null,
     citationDeclarations: wiki.citationDeclarations ?? [],
     deps: makeSidecarDeps(db),
   })
+
+  if (c.req.query('raw') !== undefined) {
+    return c.text(stripWikiContent(wiki.content, sidecar.refs))
+  }
 
   return c.json(
     publicWikiResponseSchema.parse({

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -15,6 +15,7 @@ import { nanoid24 } from '../lib/id.js'
 import { regenerateWiki } from '../lib/regen.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
 import { makeSidecarDeps } from '../lib/wikiSidecarDeps.js'
+import { stripWikiContent } from '../lib/strip-wiki-content.js'
 import { producer } from '../queue/producer.js'
 import {
   threadResponseSchema,
@@ -266,6 +267,25 @@ wikisRouter.get('/:id', async (c) => {
     citationDeclarations: thread.citationDeclarations ?? [],
     deps: makeSidecarDeps(db),
   })
+
+  // ?raw — token-efficient response for LLM consumption
+  if (c.req.query('raw') !== undefined) {
+    const stripped = stripWikiContent(thread.content ?? '', sidecar.refs)
+    return c.json({
+      ...prepareThread(thread),
+      wikiContent: stripped,
+      fragments: frags.map((f) => ({
+        id: f.lookupKey,
+        slug: f.slug,
+        title: f.title,
+        snippet: (f.content ?? '').slice(0, 200),
+      })),
+      people: peopleRows.map((p) => ({
+        id: p.lookupKey,
+        name: p.name,
+      })),
+    })
+  }
 
   return c.json(
     wikiDetailResponseSchema.parse({


### PR DESCRIPTION
## Summary
- Rename MCP tool `get_thread` → `get_wiki` (hard rename, no alias)
- Add `?raw=true` query param to `GET /wikis/:id` for token-efficient LLM consumption
- MCP `get_wiki` now returns stripped markdown by default
- New `stripWikiContent()` utility with unit tests

Fixes #124, Fixes #125

## Test plan
- [ ] `grep -r 'get_thread' core/` returns 0 results
- [ ] MCP resolver tests pass with renamed functions
- [ ] `GET /wikis/:id?raw=true` returns content with no `[[tokens]]`
- [ ] Strip utility tests pass
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)