### PR TITLE
feat(wiki): settings persistence, edit behaviors, latency monitoring, accept/reject

### DIFF
--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -220,6 +220,7 @@ export const wikis = pgTable(
   {
     ...baseColumns(),
     name: text('name').notNull(),
+    description: text('description').notNull().default(''),
     type: text('type').notNull().default('log'),
     prompt: text('prompt').notNull().default(''),
     lastRebuiltAt: timestamp('last_rebuilt_at'),

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -60,10 +60,19 @@ export const STRONG_SIGNAL_THRESHOLD = 0.7
 /** Max unfiled fragments to evaluate per regen call */
 const MAX_UNFILED_PER_REGEN = 50
 
+export interface RegenTiming {
+  classify: number
+  gatherFragments: number
+  llmCall: number
+  embed: number
+  total: number
+}
+
 export interface RegenResult {
   content: string
   fragmentCount: number
   hasEmbedding: boolean
+  timing?: RegenTiming
 }
 
 /**
@@ -293,16 +302,19 @@ export async function regenerateWiki(
   wikiKey: string,
   opts?: { skipEmbedding?: boolean }
 ): Promise<RegenResult> {
+  const t0 = performance.now()
   const [wiki] = await database.select().from(wikis).where(eq(wikis.lookupKey, wikiKey))
   if (!wiki) throw new Error(`Wiki not found: ${wikiKey}`)
 
   // Classify unfiled fragments into this wiki before gathering (mechanism 1)
+  const tClassify0 = performance.now()
   try {
     const classifyResult = await classifyUnfiledFragments(database, wikiKey)
     log.info({ wikiKey, linked: classifyResult.linked }, 'unfiled fragment classification completed')
   } catch (err) {
     log.warn({ wikiKey, err }, 'unfiled fragment classification failed — continuing with existing fragments')
   }
+  const classifyMs = performance.now() - tClassify0
 
   const previousContent = wiki.content
 
@@ -317,6 +329,7 @@ export async function regenerateWiki(
   )
 
   // Gather linked fragments via FRAGMENT_IN_WIKI edges, with signal strength
+  const tGather0 = performance.now()
   const fragmentEdgeRows = await database
     .select({ srcId: edges.srcId, attrs: edges.attrs })
     .from(edges)
@@ -485,6 +498,8 @@ export async function regenerateWiki(
     }
   }
 
+  const gatherMs = performance.now() - tGather0
+
   const vars = {
     fragments: fragmentsText,
     title: wiki.name,
@@ -511,7 +526,9 @@ export async function regenerateWiki(
     spec = loadWikiGenerationSpec(wiki.type as WikiType, vars)
   }
 
+  const tLlm0 = performance.now()
   const llmOutput = await callLlm(spec.system, spec.user)
+  const llmMs = performance.now() - tLlm0
   const markdown = llmOutput.markdown
   const llmInfobox: WikiInfobox | null = llmOutput.infobox ?? null
   const llmCitations: WikiCitationDeclaration[] = llmOutput.citations ?? []
@@ -538,6 +555,7 @@ export async function regenerateWiki(
     .where(eq(wikis.lookupKey, wikiKey))
 
   // Compute and store embedding for the new content
+  const tEmbed0 = performance.now()
   let hasEmbedding = false
   if (!opts?.skipEmbedding) {
     const vec = await embedText(markdown, {
@@ -548,6 +566,16 @@ export async function regenerateWiki(
       await database.update(wikis).set({ embedding: vec }).where(eq(wikis.lookupKey, wikiKey))
       hasEmbedding = true
     }
+  }
+  const embedMs = performance.now() - tEmbed0
+  const totalMs = performance.now() - t0
+
+  const timing: RegenTiming = {
+    classify: Math.round(classifyMs),
+    gatherFragments: Math.round(gatherMs),
+    llmCall: Math.round(llmMs),
+    embed: Math.round(embedMs),
+    total: Math.round(totalMs),
   }
 
   // Log edit with source: 'regen'
@@ -567,10 +595,10 @@ export async function regenerateWiki(
     eventType: 'composed',
     source: 'system',
     summary: `Wiki regenerated from ${fragmentCount} fragments`,
-    detail: { wikiKey, fragmentCount, hasEmbedding },
+    detail: { wikiKey, fragmentCount, hasEmbedding, timing },
   })
 
-  log.info({ wikiKey, fragmentCount, hasEmbedding }, 'wiki regenerated')
+  log.info({ wikiKey, fragmentCount, hasEmbedding, timing }, 'wiki regenerated')
 
-  return { content: markdown, fragmentCount, hasEmbedding }
+  return { content: markdown, fragmentCount, hasEmbedding, timing }
 }

--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -15,11 +15,13 @@ const BATCH_LIMIT = 5
 
 export async function processRegenJob(job: RegenJob): Promise<JobResult> {
   log.info({ jobId: job.jobId, wikiKey: job.objectKey }, 'processing regen job')
+  const t0 = performance.now()
 
   try {
     const result = await regenerateWiki(db, job.objectKey)
+    const elapsed = Math.round(performance.now() - t0)
     log.info(
-      { jobId: job.jobId, wikiKey: job.objectKey, fragmentCount: result.fragmentCount },
+      { jobId: job.jobId, wikiKey: job.objectKey, fragmentCount: result.fragmentCount, ms: elapsed, timing: result.timing },
       'regen job completed'
     )
     return {
@@ -28,8 +30,9 @@ export async function processRegenJob(job: RegenJob): Promise<JobResult> {
       processedAt: new Date().toISOString(),
     }
   } catch (err) {
+    const elapsed = Math.round(performance.now() - t0)
     const message = err instanceof Error ? err.message : String(err)
-    log.error({ jobId: job.jobId, wikiKey: job.objectKey, error: message }, 'regen job failed')
+    log.error({ jobId: job.jobId, wikiKey: job.objectKey, error: message, ms: elapsed }, 'regen job failed')
     return {
       jobId: job.jobId,
       success: false,

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -7,6 +7,8 @@ import { computeContentHash, findDuplicateFragment } from '../db/dedup.js'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
 import { fragments, entries, edges, wikis, people } from '../db/schema.js'
+import { producer } from '../queue/producer.js'
+import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
 import {
   fragmentResponseSchema,
@@ -19,6 +21,8 @@ import {
   fragmentReviewBodySchema,
 } from '../schemas/fragments.schema.js'
 import { emitAuditEvent } from '../db/audit.js'
+
+const log = logger.child({ component: 'fragments' })
 
 const fragmentsRouter = new Hono()
 fragmentsRouter.use('*', sessionMiddleware)
@@ -281,6 +285,20 @@ fragmentsRouter.post('/:id/reject', zValidator('json', fragmentReviewBodySchema,
     summary: `Fragment rejected from ${wiki.name ?? wikiId}`,
     detail: { fragmentKey: id, wikiKey: wikiId },
   })
+
+  // Queue wiki regen so the rejected fragment's content is removed from the wiki body
+  try {
+    await producer.enqueueRegen({
+      type: 'regen',
+      jobId: crypto.randomUUID(),
+      objectKey: wikiId,
+      objectType: 'wiki',
+      triggeredBy: 'manual',
+      enqueuedAt: new Date().toISOString(),
+    })
+  } catch (err) {
+    log.warn({ wikiKey: wikiId, err }, 'failed to enqueue regen after fragment rejection')
+  }
 
   return c.json({ ok: true, fragmentId: id, wikiId })
 })

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -207,8 +207,17 @@ wikisRouter.post('/', zValidator('json', createThreadBodySchema, validationHook)
 // GET /wikis/:id — wiki detail with member fragments and aggregated people
 wikisRouter.get('/:id', async (c) => {
   const id = c.req.param('id')
-  const [thread] = await db.select().from(wikis).where(and(eq(wikis.lookupKey, id), isNull(wikis.deletedAt)))
-  if (!thread) return c.json({ error: 'Not found' }, 404)
+  const [row] = await db
+    .select({
+      wiki: wikis,
+      shortDescriptor: wikiTypes.shortDescriptor,
+      descriptor: wikiTypes.descriptor,
+    })
+    .from(wikis)
+    .leftJoin(wikiTypes, eq(wikis.type, wikiTypes.slug))
+    .where(and(eq(wikis.lookupKey, id), isNull(wikis.deletedAt)))
+  if (!row) return c.json({ error: 'Not found' }, 404)
+  const thread = row.wiki
 
   // Member fragments via FRAGMENT_IN_WIKI edges
   const fragEdges = await db
@@ -269,7 +278,11 @@ wikisRouter.get('/:id', async (c) => {
 
   return c.json(
     wikiDetailResponseSchema.parse({
-      ...prepareThread(thread),
+      ...prepareThread({
+        ...thread,
+        shortDescriptor: row.shortDescriptor ?? '',
+        descriptor: row.descriptor ?? '',
+      }),
       wikiContent: thread.content ?? '',
       fragments: frags.map((f) => ({
         id: f.lookupKey,

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -123,6 +123,7 @@ wikisRouter.post('/', zValidator('json', createThreadBodySchema, validationHook)
       lookupKey,
       slug: finalSlug,
       name: body.name.trim(),
+      description: body.description ?? '',
       type: wikiType,
       state: 'PENDING',
       prompt: body.prompt ?? '',
@@ -401,7 +402,12 @@ wikisRouter.put('/:id', zValidator('json', updateThreadBodySchema, validationHoo
       ? candidateSlug
       : await resolveWikiSlug(db, candidateSlug)
   }
-  if (body.type != null) updates.type = body.type
+  if (body.description != null) updates.description = body.description
+  if (body.type != null) {
+    updates.type = body.type
+    // Type change affects wiki generation — mark PENDING so regen rebuilds with new type's prompt
+    if (body.type !== existing.type) updates.state = 'PENDING'
+  }
   if (body.prompt != null) {
     updates.prompt = body.prompt
     // Prompt change affects wiki generation — mark PENDING so regen rebuilds with new prompt
@@ -414,13 +420,17 @@ wikisRouter.put('/:id', zValidator('json', updateThreadBodySchema, validationHoo
     .where(eq(wikis.lookupKey, id))
     .returning()
 
+  const typeTransition = body.type != null && body.type !== existing.type
+    ? { from: existing.type, to: body.type }
+    : undefined
+
   await emitAuditEvent(db, {
     entityType: 'wiki',
     entityId: id,
     eventType: 'edited',
     source: 'api',
     summary: `Wiki edited: ${thread.name}`,
-    detail: { wikiKey: id, changedFields: Object.keys(updates).filter(k => k !== 'updatedAt') },
+    detail: { wikiKey: id, changedFields: Object.keys(updates).filter(k => k !== 'updatedAt'), typeTransition },
   })
 
   return c.json(threadResponseSchema.parse(prepareThread(thread)))

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -221,16 +221,25 @@ wikisRouter.get('/:id', async (c) => {
   const thread = row.wiki
 
   // Member fragments via FRAGMENT_IN_WIKI edges
+  // For review-mode wikis, also include pending edges (deletedAt set) so the UI
+  // can show them for accept/reject. Pending = edge exists with deletedAt set.
+  const isReviewMode = thread.bouncerMode === 'review'
+  const edgeConditions = [
+    eq(edges.dstId, id),
+    eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+  ]
+  if (!isReviewMode) edgeConditions.push(isNull(edges.deletedAt))
+
   const fragEdges = await db
-    .select({ srcId: edges.srcId })
+    .select({ srcId: edges.srcId, deletedAt: edges.deletedAt })
     .from(edges)
-    .where(
-      and(
-        eq(edges.dstId, id),
-        eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
-        isNull(edges.deletedAt)
-      )
-    )
+    .where(and(...edgeConditions))
+
+  // Build a map of fragmentKey → edgeStatus for the response
+  const edgeStatusMap = new Map<string, 'active' | 'pending'>()
+  for (const e of fragEdges) {
+    edgeStatusMap.set(e.srcId, e.deletedAt ? 'pending' : 'active')
+  }
   const fragKeys = fragEdges.map((e) => e.srcId)
 
   const frags =
@@ -290,6 +299,7 @@ wikisRouter.get('/:id', async (c) => {
         slug: f.slug,
         title: f.title,
         snippet: (f.content ?? '').slice(0, 200),
+        edgeStatus: edgeStatusMap.get(f.lookupKey) ?? 'active',
       })),
       people: peopleRows.map((p) => ({
         id: p.lookupKey,

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -507,6 +507,10 @@ wikisRouter.post('/:id/regenerate', async (c) => {
   try {
     const result = await regenerateWiki(db, id)
     log.info({ wikiKey: id, ...result }, 'wiki regenerated via on-demand endpoint')
+    if (result.timing) {
+      const t = result.timing
+      c.header('Server-Timing', `classify;dur=${t.classify}, gather;dur=${t.gatherFragments}, llm;dur=${t.llmCall}, embed;dur=${t.embed}, total;dur=${t.total}`)
+    }
     return c.json({ ok: true, lookupKey: id, fragmentCount: result.fragmentCount })
   } catch (err) {
     if (err instanceof NoOpenRouterKeyError) {

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -29,6 +29,7 @@ export const threadResponseSchema = z.object({
   lookupKey: lookupKeySchema,
   slug: z.string(),
   name: z.string(),
+  description: z.string().default(''),
   type: z.string(),
   prompt: z.string(),
   state: objectStateSchema,
@@ -87,6 +88,7 @@ export const createThreadBodySchema = z.object({
 
 export const updateThreadBodySchema = z.object({
   name: z.string().optional(),
+  description: z.string().optional(),
   type: z.string().optional(),
   prompt: z.string().optional(),
 })

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -41,6 +41,7 @@ export const threadResponseSchema = z.object({
   shortDescriptor: z.string().default(''),
   descriptor: z.string().default(''),
   progress: wikiProgressSchema.nullable().default(null),
+  bouncerMode: z.enum(['auto', 'review']).default('auto'),
 })
 
 export const threadWithWikiResponseSchema = threadResponseSchema.extend({
@@ -55,6 +56,7 @@ export const wikiDetailResponseSchema = threadResponseSchema.extend({
       slug: z.string(),
       title: z.string(),
       snippet: z.string(),
+      edgeStatus: z.enum(['active', 'pending']).default('active'),
     })
   ),
   people: z.array(

--- a/wiki/src/app/wiki/[id]/page.tsx
+++ b/wiki/src/app/wiki/[id]/page.tsx
@@ -3,12 +3,14 @@
 import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { RefreshCw, Trash2 } from "lucide-react";
+import { Check, RefreshCw, Trash2, X } from "lucide-react";
 import { T } from "@/lib/typography";
 import { Spinner } from "@/components/ui/spinner";
 import { useWiki } from "@/hooks/useWiki";
 import { useRegenerateWiki } from "@/hooks/useRegenerateWiki";
 import { useDeleteWiki } from "@/hooks/useDeleteWiki";
+import { useAcceptFragment } from "@/hooks/useAcceptFragment";
+import { useRejectFragment } from "@/hooks/useRejectFragment";
 import { useQueryClient } from "@tanstack/react-query";
 import ConfirmDialog from "@/components/prompts/ConfirmDialog";
 import SectionEditor from "@/components/editor/SectionEditor";
@@ -303,6 +305,8 @@ export default function WikiDetailPage() {
   const { data: wiki, isLoading, error } = useWiki(id);
   const regenerate = useRegenerateWiki();
   const deleteWiki = useDeleteWiki();
+  const acceptFragment = useAcceptFragment();
+  const rejectFragment = useRejectFragment();
   const queryClient = useQueryClient();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -678,7 +682,7 @@ export default function WikiDetailPage() {
             }}
           >
             {wiki.fragments.map((frag) => (
-              <li key={frag.id}>
+              <li key={frag.id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
                 <Link
                   href={`/wiki/fragments/${frag.id}`}
                   style={{
@@ -689,6 +693,45 @@ export default function WikiDetailPage() {
                 >
                   {frag.title}
                 </Link>
+                {wiki.bouncerMode === "review" && frag.edgeStatus === "pending" && (
+                  <span style={{ display: "inline-flex", gap: 4, alignItems: "center" }}>
+                    <button
+                      type="button"
+                      title="Accept fragment"
+                      onClick={() => acceptFragment.mutate({ id: frag.id, wikiId: wiki.id })}
+                      disabled={acceptFragment.isPending}
+                      style={{
+                        background: "none",
+                        border: "1px solid var(--wiki-card-border)",
+                        cursor: "pointer",
+                        padding: "2px 4px",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        color: "green",
+                      }}
+                    >
+                      <Check size={12} strokeWidth={2} />
+                    </button>
+                    <button
+                      type="button"
+                      title="Reject fragment"
+                      onClick={() => rejectFragment.mutate({ id: frag.id, wikiId: wiki.id })}
+                      disabled={rejectFragment.isPending}
+                      style={{
+                        background: "none",
+                        border: "1px solid var(--wiki-card-border)",
+                        cursor: "pointer",
+                        padding: "2px 4px",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        color: "red",
+                      }}
+                    >
+                      <X size={12} strokeWidth={2} />
+                    </button>
+                    <span style={{ fontSize: 10, color: "var(--wiki-count)", fontStyle: "italic" }}>pending</span>
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/wiki/src/app/wiki/[id]/page.tsx
+++ b/wiki/src/app/wiki/[id]/page.tsx
@@ -471,6 +471,8 @@ export default function WikiDetailPage() {
       chipIcon={getWikiTypeIcon(typeLabel)}
       chipLabel={typeLabel}
       title={wiki.name}
+      promptOverride={wiki.prompt}
+      description={wiki.shortDescriptor}
       infobox={{ kind: "simple", typeLabel, lastUpdated: wiki.updatedAt, showSettings: true }}
       renderCustomInfobox={
         sidecarInfobox

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -322,6 +322,10 @@ export type WikiEntityArticleProps = {
    * Optional sections rendered after divider and before modal.
    */
   customBottomSections?: ReactNode;
+  /** Per-wiki prompt override to prefill in settings modal */
+  promptOverride?: string;
+  /** Wiki description / shortDescriptor to prefill in settings modal */
+  description?: string;
   /** Real wiki id for settings-mode PUT. Prototype pages omit → 'preview' sentinel. */
   wikiId?: string;
   /** Called after local save completes — persist to backend here. */
@@ -366,6 +370,8 @@ export function WikiEntityArticle({
   infobox,
   renderCustomInfobox,
   customBottomSections,
+  promptOverride,
+  description,
   wikiId,
   onSave,
   children,
@@ -403,8 +409,8 @@ export function WikiEntityArticle({
   const wikiTypeLocked = isPeopleWikiType(displayChipLabel);
 
   const wikiSettingsPrefill = useMemo(
-    () => wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel }),
-    [displayTitle, displayChipLabel],
+    () => wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel, description, promptOverride }),
+    [displayTitle, displayChipLabel, description, promptOverride],
   );
 
   const tabs = ["Read", "Edit", "View history"] as const;

--- a/wiki/src/hooks/useAcceptFragment.ts
+++ b/wiki/src/hooks/useAcceptFragment.ts
@@ -10,9 +10,10 @@ export function useAcceptFragment() {
       const { data } = await acceptFragment({ path: { id }, body: { wikiId } })
       return data
     },
-    onSuccess: (_data, { id }) => {
+    onSuccess: (_data, { id, wikiId }) => {
       queryClient.invalidateQueries({ queryKey: ['fragment', id] })
       queryClient.invalidateQueries({ queryKey: ['fragments'] })
+      queryClient.invalidateQueries({ queryKey: ['wiki', wikiId] })
     },
   })
 }

--- a/wiki/src/hooks/useRejectFragment.ts
+++ b/wiki/src/hooks/useRejectFragment.ts
@@ -10,9 +10,10 @@ export function useRejectFragment() {
       const { data } = await rejectFragment({ path: { id }, body: { wikiId } })
       return data
     },
-    onSuccess: (_data, { id }) => {
+    onSuccess: (_data, { id, wikiId }) => {
       queryClient.invalidateQueries({ queryKey: ['fragment', id] })
       queryClient.invalidateQueries({ queryKey: ['fragments'] })
+      queryClient.invalidateQueries({ queryKey: ['wiki', wikiId] })
     },
   })
 }

--- a/wiki/src/lib/wikiSettingsPrefill.ts
+++ b/wiki/src/lib/wikiSettingsPrefill.ts
@@ -41,13 +41,14 @@ function wikiTypeSelectValueForChip(chipLabel: string): string {
 export function wikiEntitySettingsPrefill(input: {
   title: string;
   chipLabel: string;
+  description?: string;
   promptOverride?: string;
 }): WikiSettingsPrefill {
   return {
     name: input.title,
     wikiType: wikiTypeSelectValueForChip(input.chipLabel),
     folder: "default",
-    description: WIKI_INTRO_LEAD_PLAINTEXT,
+    description: input.description ?? WIKI_INTRO_LEAD_PLAINTEXT,
     subtitle: `${input.chipLabel} wiki — update name, type, and visibility`,
     promptOverride: input.promptOverride,
   };


### PR DESCRIPTION
## Summary
- Fix wiki settings modal to show current type, description, and prompt (#120)
- Type change now triggers regen, description column added (#126)
- Phase-level timing instrumentation on regen + wiki-create paths (#77)
- Wire fragment accept/reject with regen trigger and bouncer-mode-aware UI (#128)

Fixes #120, Fixes #126, Fixes #77, Fixes #128

## Test plan
- [ ] Wiki settings modal shows correct type, description, prompt
- [ ] Changing wiki type sets state to PENDING
- [ ] `POST /wikis/:id/regenerate` response includes `Server-Timing` header
- [ ] `POST /fragments/:id/reject` triggers wiki regen
- [ ] Review-mode wiki shows pending fragments with Accept/Reject buttons
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)