### PR TITLE
fix(wiki): add onboarding guard to shell layout

### DIFF
--- a/wiki/src/components/AuthGuard.tsx
+++ b/wiki/src/components/AuthGuard.tsx
@@ -3,22 +3,36 @@
 import { useRouter, usePathname } from 'next/navigation'
 import { useEffect } from 'react'
 import { useSession } from '@/hooks/useSession'
+import { useProfile } from '@/hooks/useProfile'
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const pathname = usePathname()
   const { isAuthenticated, isLoading } = useSession()
+  const { data: profile, isLoading: profileLoading } = useProfile({
+    enabled: isAuthenticated,
+  })
 
   const isPublicPath = pathname === '/login' || pathname === '/recover'
 
+  // Redirect unauthenticated users to login
   useEffect(() => {
     if (!isLoading && !isAuthenticated && !isPublicPath) {
       router.push('/login')
     }
   }, [isLoading, isAuthenticated, isPublicPath, router])
 
+  // Redirect authenticated but un-onboarded users to onboarding wizard
+  useEffect(() => {
+    if (isAuthenticated && !profileLoading && !profile?.onboardedAt && !isPublicPath) {
+      router.replace('/')
+    }
+  }, [isAuthenticated, profileLoading, profile, isPublicPath, router])
+
   if (isLoading) return null
   if (!isAuthenticated && !isPublicPath) return null
+  if (isAuthenticated && profileLoading) return null
+  if (isAuthenticated && !profile?.onboardedAt && !isPublicPath) return null
 
   return <>{children}</>
 }


### PR DESCRIPTION
## Summary
- AuthGuard component now checks onboarding status via `useProfile` after authentication passes
- Un-onboarded users are redirected to `/` (onboarding wizard) before shell content renders
- Prevents deep-linking to `/wiki` or any shell route before completing setup

Fixes #144

## Test plan
- [ ] Onboarded user can access /wiki normally
- [ ] Un-onboarded user navigating to /wiki gets redirected to /
- [ ] Loading state doesn't flash wiki content before redirect
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)