### PR TITLE
docs(uat): refine plans to cover gaps exposed by #156 review

### DIFF
--- a/.uat/plans/21-wiki-sidecar-rendering.md
+++ b/.uat/plans/21-wiki-sidecar-rendering.md
@@ -581,6 +581,89 @@ else
   skip "13. Person 'ashish-vaswani' not seeded — re-run seed-fixture"
 fi
 
+# ── 14. H1 + intro + H2 shape — regression guard for #152 ───
+# The Transformer fixture starts `# Title\n\nIntro paragraph\n\n## Section`.
+# Before #152's fix, the render loop treated H1 as a full-span block that
+# ran to EOF, so every post-H1 section rendered twice. The first fix (#156
+# commit 3803473) skipped H1 in the loop but dropped the intro paragraph
+# entirely — a regression caught in ultrathink review and fixed in commit
+# 061c3a6. This step guards against BOTH failure modes by asserting the
+# intro renders exactly once AND each section body renders exactly once.
+#
+# Drive the shape directly via PUT so this assertion survives future
+# fixture body edits.
+
+INTRO_BODY='# Transformer Architecture
+
+The Transformer discards recurrence in favour of attention. Canonical refs live at [[person:ashish-vaswani]] and [[wiki:attention-is-all-you-need]].
+
+## Overview
+
+Body of overview with [[fragment:self-attention-replaces-recurrence]].
+
+## Architecture
+
+Body of architecture.'
+
+curl -s -o /dev/null -b "$COOKIE_JAR" -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg body "$INTRO_BODY" --arg name "Transformer Architecture" '{frontmatter:{name:$name,type:"project",prompt:""},body:$body}')" \
+  "$SERVER_URL/api/content/wiki/$TRANSFORMER_KEY"
+
+npx agent-browser open "$WIKI_URL/wiki/$TRANSFORMER_KEY" 2>/dev/null
+npx agent-browser wait --load networkidle
+sleep 1
+INTRO_SNAP=$(npx agent-browser snapshot 2>/dev/null)
+npx agent-browser eval "document.documentElement.outerHTML" > /tmp/uat-21-h1intro-dom.html 2>/dev/null
+npx agent-browser screenshot /tmp/uat-21-14-h1intro.png 2>/dev/null
+
+# 14a. Intro paragraph renders at least once — the regression dropped
+# it entirely because preamble was `lines.slice(0, H1.startLine) = ''`.
+if echo "$INTRO_SNAP" | grep -q "Transformer discards recurrence in favour of attention"; then
+  pass "14a. H1-intro paragraph renders (not dropped)"
+else
+  fail "14a. H1-intro paragraph is missing — regression of 061c3a6"
+fi
+
+# 14b. Intro paragraph renders EXACTLY once — original bug rendered it
+# twice because H1's full span was rendered then each H2 again.
+INTRO_COUNT=$(echo "$INTRO_SNAP" | grep -oc "Transformer discards recurrence in favour of attention" || echo 0)
+if [ "$INTRO_COUNT" = "1" ]; then
+  pass "14b. H1-intro paragraph rendered exactly once"
+else
+  fail "14b. H1-intro rendered $INTRO_COUNT times (expected 1) — double-render regression"
+fi
+
+# 14c. Each H2 body renders exactly once.
+OVERVIEW_COUNT=$(echo "$INTRO_SNAP" | grep -oc "Body of overview with" || echo 0)
+ARCH_COUNT=$(echo "$INTRO_SNAP" | grep -oc "Body of architecture" || echo 0)
+if [ "$OVERVIEW_COUNT" = "1" ] && [ "$ARCH_COUNT" = "1" ]; then
+  pass "14c. H2 bodies render exactly once each"
+else
+  fail "14c. H2 body render counts: overview=$OVERVIEW_COUNT architecture=$ARCH_COUNT (expected 1 each)"
+fi
+
+# 14d. The markdown `# Transformer Architecture` does NOT render as an <h1>
+# in the body — page chrome owns the document-level heading.
+if grep -qE '<h1[^>]*>[^<]*Transformer Architecture' /tmp/uat-21-h1intro-dom.html; then
+  # Chrome H1 lives inside .wiki-article-h1 — the SectionedMarkdownBody
+  # MUST NOT produce its own H1 with the title text. Distinguish chrome
+  # from body by checking whether any <h1> outside the chrome class contains
+  # the title.
+  if grep -oE '<h1[^>]*(wiki-article-h1)[^>]*>[^<]*Transformer' /tmp/uat-21-h1intro-dom.html >/dev/null \
+     && ! grep -oE '<h1(?![^>]*wiki-article-h1)[^>]*>[^<]*Transformer' /tmp/uat-21-h1intro-dom.html >/dev/null; then
+    pass "14d. H1 only rendered by page chrome, not markdown body"
+  else
+    fail "14d. H1 'Transformer Architecture' appears in markdown body (should only be page chrome)"
+  fi
+else
+  fail "14d. No <h1> contains the wiki title — page chrome regression"
+fi
+
+# Restore the canonical fixture body for downstream steps and plan 22.
+pnpm -C core seed-fixture >/dev/null 2>&1 || true
+
 # ── Cleanup ──────────────────────────────────────────────────
 npx agent-browser close 2>/dev/null || true
 
@@ -608,6 +691,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 11 | Code-fence isolation: tokens inside `<code>`/`<pre>` render as literal source, prose tokens still resolve | HTML-body walker |
 | 12 | Entry detail page resolves tokens and has no infobox | useEntry + EntryArticle |
 | 13 | Person detail page renders server-derived .winfo infobox with Relationship row | usePerson + derivePersonInfobox |
+| 14 | H1 + intro + H2 shape: intro renders exactly once, H2 bodies render exactly once, no body-level H1 — regression guard for #152 + 061c3a6 | SectionedMarkdownBody preamble + H1 skip |
 
 ---
 

--- a/.uat/plans/22-onboarding-demo-seed.md
+++ b/.uat/plans/22-onboarding-demo-seed.md
@@ -362,6 +362,76 @@ else
   skip "6. No Transformer lookupKey — delete/re-seed path untested"
 fi
 
+# ── 7. Invariants — data-plane + retry scheduler ─────────────
+# Post-seed, the data plane must be in a known-good shape. These are
+# the checks that #150 (silent embeddings) and #151 (no retry) would
+# have failed pre-fix — they pair with the fixes to keep the data
+# plane from drifting silently going forward.
+
+# 7a. The seeded demo wiki must be RESOLVED (not PENDING / LINKING).
+# A seeded wiki that never reached RESOLVED means the seed path broke
+# before finalization — the wiki listing would show it but detail pages
+# would refuse to render.
+WIKI_STATE=$(psql -t -A -c "SELECT state FROM wikis WHERE slug='transformer-architecture' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+if [ "$WIKI_STATE" = "RESOLVED" ]; then
+  pass "7a. seeded demo wiki is RESOLVED"
+else
+  fail "7a. seeded demo wiki state='$WIKI_STATE' (expected RESOLVED)"
+fi
+
+# 7b. The embedding retry scheduler must be registered in Redis (issue
+# #151). Without it, any fragment whose embedding failed at ingest time
+# stays NULL forever. Detect registration via BullMQ's scheduler key.
+if command -v redis-cli >/dev/null; then
+  if redis-cli KEYS 'bull:regen-scheduler-queue:repeat:*' 2>/dev/null | grep -q 'embedding-retry'; then
+    pass "7b. embedding retry scheduler registered"
+  elif redis-cli KEYS 'bull:regen-scheduler-queue:meta*' 2>/dev/null >/dev/null; then
+    # BullMQ's key shape varies across versions. Fall back to a broader
+    # search so this doesn't fail on a mere key-naming change.
+    if redis-cli --scan --pattern 'bull:regen-scheduler-queue:*' 2>/dev/null | grep -qi embedding; then
+      pass "7b. embedding retry scheduler registered (fallback match)"
+    else
+      fail "7b. no 'embedding-retry' scheduler found on regen-scheduler-queue"
+    fi
+  else
+    skip "7b. scheduler queue not initialized yet — retry check inconclusive"
+  fi
+else
+  skip "7b. redis-cli unavailable — scheduler registration not verified"
+fi
+
+# 7c. Count of unembedded live fragments must be *observable* (i.e.,
+# queryable with the index #151 added). This is not a zero-tolerance
+# check — the retry scheduler runs every 15 min and UAT can't wait
+# that long — but a SELECT that returns a definite integer proves the
+# index exists and the columns were migrated. Logs the count so a
+# soak test downstream can assert convergence to zero.
+UNEMBEDDED=$(psql -t -A -c "SELECT COUNT(*) FROM fragments WHERE embedding IS NULL AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+if [[ "$UNEMBEDDED" =~ ^[0-9]+$ ]]; then
+  pass "7c. unembedded-fragments count is observable (=$UNEMBEDDED)"
+  echo "    ↳ soak target: this value should trend to 0 as the retry scheduler runs"
+else
+  fail "7c. unembedded-fragments count query failed — migration 0006 not applied?"
+fi
+
+# 7d. Columns added by migration 0006 exist on fragments.
+HAS_ATTEMPT_COL=$(psql -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_attempt_count'" 2>/dev/null | tr -d '[:space:]')
+HAS_LAST_COL=$(psql -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_last_attempt_at'" 2>/dev/null | tr -d '[:space:]')
+if [ "$HAS_ATTEMPT_COL" = "1" ] && [ "$HAS_LAST_COL" = "1" ]; then
+  pass "7d. embedding retry bookkeeping columns present"
+else
+  fail "7d. migration 0006 did not apply (attempt_count=$HAS_ATTEMPT_COL, last=$HAS_LAST_COL)"
+fi
+
+# 7e. The partial index #151 added exists. Without it the retry scan
+# degrades to a table scan at scale.
+HAS_PARTIAL_IDX=$(psql -t -A -c "SELECT 1 FROM pg_indexes WHERE indexname='fragments_embedding_null_idx' AND indexdef LIKE '%WHERE%embedding IS NULL%deleted_at IS NULL%'" 2>/dev/null | tr -d '[:space:]')
+if [ "$HAS_PARTIAL_IDX" = "1" ]; then
+  pass "7e. fragments_embedding_null_idx is partial on embedding/deleted_at"
+else
+  fail "7e. partial index missing or non-partial — retry scan will degrade"
+fi
+
 # ── Cleanup ──────────────────────────────────────────────────
 npx agent-browser close 2>/dev/null || true
 
@@ -381,6 +451,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 4 | Seeded wiki returns populated sidecar: refs for all 4 kinds, infobox with 4 valueKinds, 2 citations each on 'overview' + 'architecture', empty on 'notes' + 'notes-1', tokens in body, `anonymous-reviewer` deliberately absent from refs | `buildSidecar` + fixture identity |
 | 5 | Explorer lists the seeded wiki; click → detail page with rendered body | onboarding landing path |
 | 6 | Deleting the demo wiki + subsequent sign-in does NOT re-seed (intentional — `ensureFirstUser` only fires when users table is empty); CLI `seed-fixture` remains the documented recovery path | bootstrap gate policy |
+| 7 | Invariants: wiki RESOLVED; embedding retry scheduler registered; unembedded count observable; migration 0006 applied with partial index | #150 + #151 |
 
 ---
 

--- a/.uat/plans/99-endpoint-sweep.md
+++ b/.uat/plans/99-endpoint-sweep.md
@@ -1,0 +1,226 @@
+# 99 — Endpoint Sweep
+
+## What it proves
+Every top-level authenticated HTTP endpoint responds (200 or documented auth-gated status) and returns schema-valid JSON against the seeded fixture. Catches whole-surface regressions — response-shape drift, enum mismatches between DB values and schema, a route handler that throws on realistic seeded data — that feature-specific plans miss because they only exercise the endpoints they care about.
+
+This plan is the cheapest regression net in the suite: ~30 seconds, no browser automation, just `curl | jq` per endpoint. It would have caught issue #153 (`/graph` 500 on `raw_source` edges) in the run that seeded the Transformer fixture.
+
+## Prerequisites
+- Plan 22 has already run (or `pnpm -C core seed-fixture` is complete) so the Transformer demo wiki + its edges exist.
+- Core server reachable at `SERVER_URL` (default `http://localhost:3000`).
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` set in `core/.env`.
+- `jq` installed.
+
+## Coverage philosophy
+- **200 or documented code** — every endpoint either returns 2xx against seeded data, or returns a documented non-2xx (401 without cookies, 404 for a known-missing id). Anything else is a fail.
+- **JSON-valid** — every 2xx body must parse as JSON. A 200 with `<html>` is a reverse-proxy misconfiguration, and a 200 with a raw stack trace is a server bug.
+- **Shape smoke** — each endpoint gets one `jq -e` assertion on a key that must exist (`.nodes | length > 0` for `/graph`, `.wikis | length > 0` for `/wikis`). Not exhaustive — just enough to catch "entire payload was silently stripped by a response schema" (the failure mode in #139).
+
+## Out of scope
+- Unauthenticated surface (handled by `/health` + published routes in other plans).
+- MCP surface (handled by `98-mcp-tools.md` when it lands).
+- Write endpoints — we only sweep reads here. Write-path UAT lives per-feature.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-99-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "99 — Endpoint Sweep"
+echo ""
+
+# ── 0. Sign in ───────────────────────────────────────────────
+curl -s -o /dev/null -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+
+if [ -s "$COOKIE_JAR" ]; then
+  pass "0. sign-in established a session cookie"
+else
+  fail "0. sign-in failed — all sweep steps will be skipped"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Resolve a known wiki key + fragment key + person key + entry key from
+# the seeded fixture so we can hit detail endpoints with real ids.
+WIKI_KEY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wikis?limit=50" \
+  | jq -r '.wikis[] | select(.slug=="transformer-architecture") | .lookupKey // .id' \
+  | head -1)
+
+PERSON_KEY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/people?limit=50" \
+  | jq -r '.people[] | select(.slug=="ashish-vaswani") | .lookupKey // .id' \
+  | head -1)
+
+FRAGMENT_KEY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments?limit=50" \
+  | jq -r '.fragments[] | select(.slug=="self-attention-replaces-recurrence") | .lookupKey // .id' \
+  | head -1)
+
+if [ -z "$WIKI_KEY" ] || [ "$WIKI_KEY" = "null" ]; then
+  fail "0a. Transformer fixture not seeded — run plan 22 first"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# ── Helper: sweep one endpoint ───────────────────────────────
+# Args: $1 = step id, $2 = URL path, $3 = jq expression (must eval truthy)
+sweep() {
+  local step="$1"
+  local path="$2"
+  local shape="$3"
+  local code body
+  body=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -w "\n__HTTP__%{http_code}" "$SERVER_URL$path")
+  code="${body##*__HTTP__}"
+  body="${body%__HTTP__*}"
+
+  if [ "$code" != "200" ]; then
+    fail "$step $path returned $code"
+    echo "    body: ${body:0:200}"
+    return
+  fi
+
+  if ! echo "$body" | jq -e . >/dev/null 2>&1; then
+    fail "$step $path returned 200 but body is not valid JSON"
+    echo "    body: ${body:0:200}"
+    return
+  fi
+
+  if ! echo "$body" | jq -e "$shape" >/dev/null 2>&1; then
+    fail "$step $path shape check failed (\`$shape\`)"
+    echo "    body: ${body:0:200}"
+    return
+  fi
+
+  pass "$step $path — 200, valid JSON, shape OK"
+}
+
+# ── 1. Listing endpoints ─────────────────────────────────────
+sweep "1a." "/wikis?limit=10"                    '.wikis | type == "array"'
+sweep "1b." "/fragments?limit=10"                '.fragments | type == "array"'
+sweep "1c." "/people?limit=10"                   '.people | type == "array"'
+sweep "1d." "/entries?limit=10"                  '(.entries // .raw_sources) | type == "array"'
+sweep "1e." "/wiki-types"                        '.wikiTypes // .types | type == "array"'
+
+# ── 2. Detail endpoints ──────────────────────────────────────
+# Known-good IDs from the fixture. #139-era regression: a response schema
+# that silently stripped fields would pass a pure-200 check but fail the
+# shape assertion below.
+sweep "2a." "/wikis/$WIKI_KEY"                   '.wikiContent | type == "string"'
+sweep "2b." "/wikis/$WIKI_KEY"                   '.sections | type == "array"'
+sweep "2c." "/wikis/$WIKI_KEY"                   '.refs | type == "object"'
+sweep "2d." "/wikis/$WIKI_KEY/timeline"          '.events | type == "array"'
+sweep "2e." "/wikis/$WIKI_KEY/history"           '.edits | type == "array"'
+[ -n "$FRAGMENT_KEY" ] && [ "$FRAGMENT_KEY" != "null" ] \
+  && sweep "2f." "/fragments/$FRAGMENT_KEY"      '.lookupKey // .id | type == "string"' \
+  || skip "2f. fragment key not resolved"
+[ -n "$PERSON_KEY" ] && [ "$PERSON_KEY" != "null" ] \
+  && sweep "2g." "/people/$PERSON_KEY"           '.name | type == "string"' \
+  || skip "2g. person key not resolved"
+
+# ── 3. Graph endpoint — regression guard for #153 ────────────
+# The Transformer fixture creates edges with src_type='raw_source' in the
+# edges table. Before #153, the graph route's response schema enum
+# ('wiki'|'fragment'|'person'|'entry') rejected 'raw_source' and the whole
+# endpoint 500'd. The sweep below would have caught this.
+sweep "3a." "/graph"                             '.nodes | type == "array" and length > 0'
+sweep "3b." "/graph"                             '.edges | type == "array" and length > 0'
+sweep "3c." "/graph?wikiId=$WIKI_KEY"            '.nodes | type == "array"'
+
+# Every node must have a type in the schema enum. If any node survives
+# with an unknown type, the schema.parse at the end of the route is the
+# next place to add it — but the sweep catches the drift here first.
+GRAPH_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/graph")
+UNKNOWN_TYPES=$(echo "$GRAPH_BODY" | jq -r \
+  '.nodes[]? | select((.type | IN("wiki","fragment","person","entry")) | not) | .type' \
+  | sort -u)
+if [ -z "$UNKNOWN_TYPES" ]; then
+  pass "3d. every graph node has a known type"
+else
+  fail "3d. graph nodes have unknown types: $UNKNOWN_TYPES"
+fi
+
+# ── 4. Search ────────────────────────────────────────────────
+sweep "4a." "/search?q=attention&limit=5"        '.results // .hits | type == "array"'
+
+# ── 5. System / misc ─────────────────────────────────────────
+sweep "5a." "/system/status"                     '.status | type == "string"'
+
+# ── 6. Cross-kind: every response referenced by the sidecar parses ───
+# Walks the wiki detail's `refs` map — every person/fragment/wiki/entry
+# reference must resolve to a live detail endpoint. Catches "seed created
+# an edge but the target row is missing" and "detail schema rejects the
+# seeded shape" in one pass.
+REFS_JSON=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/wikis/$WIKI_KEY" | jq '.refs // {}')
+BROKEN_REFS=0
+while IFS=$'\t' read -r kind slug id; do
+  [ -z "$kind" ] && continue
+  case "$kind" in
+    person)   detail_path="/people/$id" ;;
+    fragment) detail_path="/fragments/$id" ;;
+    wiki)     detail_path="/wikis/$id" ;;
+    entry)    detail_path="/entries/$id" ;;
+    *)        continue ;;
+  esac
+  detail_code=$(curl -s -o /dev/null -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -w "%{http_code}" "$SERVER_URL$detail_path")
+  if [ "$detail_code" != "200" ]; then
+    BROKEN_REFS=$((BROKEN_REFS+1))
+    echo "    broken ref: $kind:$slug → $detail_path returned $detail_code"
+  fi
+done < <(echo "$REFS_JSON" | jq -r 'to_entries[] | "\(.value.kind)\t\(.value.slug)\t\(.value.id)"')
+
+if [ "$BROKEN_REFS" = "0" ]; then
+  pass "6. every sidecar ref resolves to a live detail endpoint"
+else
+  fail "6. $BROKEN_REFS sidecar refs point at missing or erroring detail rows"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```
+
+---
+
+## Pass/Fail Summary
+
+| # | Assertion | Source |
+|---|-----------|--------|
+| 0 | Authenticated session established; Transformer fixture keys resolved | prerequisite |
+| 1 | Listing endpoints (`/wikis`, `/fragments`, `/people`, `/entries`, `/wiki-types`) all 200 + shape | top-level surface |
+| 2 | Detail endpoints (`/wikis/:id` incl. sidecar keys, `/wikis/:id/timeline`, `/wikis/:id/history`, `/fragments/:id`, `/people/:id`) all 200 + shape | detail surface; #139 regression guard |
+| 3 | `/graph` returns valid nodes + edges; every node has a schema-known type | #153 regression guard |
+| 4 | `/search` returns results shape | search endpoint |
+| 5 | `/system/status` returns 200 + `.status` | system endpoint |
+| 6 | Every ref in the wiki sidecar resolves to a live detail endpoint | cross-kind integrity |
+
+---
+
+## Notes
+
+- The sweep is deliberately authenticated-only. Unauthenticated surface (published routes, `/health`) has narrower contracts and is covered by plan 01 and published-route plans.
+- Shape checks are minimal (`type == "array"`, key existence). They're designed to catch "entire payload was stripped" and "endpoint returns a string instead of an object" — not exhaustive validation. Per-feature plans still own deep assertions.
+- When a new top-level endpoint ships, add a `sweep` line here. The sweep should grow with the API surface.
+- If `agent-browser` or the wiki frontend changes port convention, this plan is unaffected — it only hits `SERVER_URL`.


### PR DESCRIPTION
Fixes #157.

Three additions to `.uat/plans/` that address the three highest-ROI UAT gaps exposed by the #156 review (bundle fixing #150-#154 plus the H1-intro regression caught in ultrathink). Each commit is its own file and references its own failure mode.

## What this PR adds

- **`aebc1a9`** — new `.uat/plans/99-endpoint-sweep.md`: authenticated API-surface smoke that runs after any fixture seed. Curl every top-level read endpoint, assert 200 + JSON-valid + minimal shape check. Plus a cross-kind integrity walk of the wiki sidecar's `refs` map that confirms every referenced entity resolves to a live detail endpoint. Would have caught #153 (graph 500 on `raw_source`).
- **`62ce182`** — plan 21 step 14: drives the Transformer fixture's `# Title\n\nIntro\n\n## Section` shape directly via PUT and asserts the intro paragraph renders **exactly once** and each H2 body renders **exactly once**. Would have caught both the original #152 double-render AND the H1-intro drop regression I introduced in `3803473` and fixed in `061c3a6`.
- **`88df6a3`** — plan 22 step 7: five data-plane invariants (seeded wiki state, retry scheduler registered, unembedded-count observable, migration 0006 applied, partial index shape). Would have surfaced #150/#151 as missing-coverage gaps pre-merge instead of as tester reports.

## Pattern established

The three additions collectively codify three assertion shapes that most existing plans are missing:

1. **Count-based assertions** (not just `grep -q`) — caught double-render + drop regressions.
2. **Endpoint-surface sweep post-seed** — catches schema / response-shape drift across features.
3. **Data-plane invariants block** — catches "the action succeeded but the data it produced is malformed" failure modes.

A follow-up issue should codify these in `.uat/TEMPLATE.md` and backfill them across the rest of the plan library (01-20).

## Not done in this PR (deliberately)

Explicitly out of scope per #157:
- `.uat/plans/98-mcp-tools.md` — end-to-end MCP surface plan. Would have caught #154. Needs its own PR with MCP-client harness decisions.
- `.uat/TEMPLATE.md` — codify count/negative/invariant patterns as mandatory for new plans.
- Failure-injection section across feature plans (boot with invalid OpenRouter key, DB unreachable).
- `/debug/force-scheduler` admin endpoint so plan 22 step 7c can assert the unembedded count trends to zero instead of just being observable.

Each is a net new capability; folding them into this PR would dilute the review surface for the three additions that ARE tightly scoped to #156's lessons.

## Verification

These plans are shell scripts; they're verified by running. Against a freshly-seeded stack:

```
bash .uat/plans/22-onboarding-demo-seed.md   # run step 7 invariants
bash .uat/plans/99-endpoint-sweep.md         # full surface sweep
bash .uat/plans/21-wiki-sidecar-rendering.md # step 14 regression guard
```

Expected: all pass green against `main` post-#156 merge. If any fail, either a real regression has landed or the plan needs adjusting — both are useful signal.