### PR TITLE
fix(db): catch-up migration for wikis.description column

### DIFF
--- a/core/drizzle/migrations/0007_wikis_add_description.sql
+++ b/core/drizzle/migrations/0007_wikis_add_description.sql
@@ -1,0 +1,10 @@
+-- Catch-up migration for wikis.description (issue #159). The column was
+-- added to the drizzle schema in commit 73084fc (PR for #126) but no
+-- migration was generated. Every INSERT into wikis has been failing
+-- silently since that commit landed on main because drizzle's insert
+-- statement lists the column (passing `default`) but the DB doesn't
+-- know it.
+--
+-- Default '' matches the schema declaration (.notNull().default('')).
+-- Existing live wikis are unaffected — there are none on any fresh DB.
+ALTER TABLE "wikis" ADD COLUMN "description" text NOT NULL DEFAULT '';

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777766400000,
       "tag": "0006_fragments_embedding_retry",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777852800000,
+      "tag": "0007_wikis_add_description",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Fixes #159.

Commit 73084fc added \`description: text('description').notNull().default('')\` to the wikis table in \`core/src/db/schema.ts:235\` but shipped no migration file. Every INSERT into wikis has been failing silently on fresh DBs since that commit landed — visible via seedDemoWiki's error-swallow log line on first-user provisioning, but also breaks MCP \`create_wiki\`, HTTP \`POST /wikis\`, and the regen persist path.

Fix: \`ALTER TABLE "wikis" ADD COLUMN "description" text NOT NULL DEFAULT ''\`. Default matches the schema declaration. Existing live wikis are unaffected (none on any broken-fresh-DB).

Numbered 0007 — #156's \`0006_fragments_embedding_retry\` landed first.

## Verification

After merge + boot against a fresh DB:
- \`runMigrations\` applies 0007 cleanly.
- \`pnpm -C core seed-fixture\` (or first-user provisioning) succeeds — no "seed-demo-wiki failed" in the core log.
- \`psql \\d wikis\` shows \`description\` column with \`NOT NULL\` + default \`''\`.