### PR TITLE
fix(pipeline): set state RESOLVED after regen + add LINKING guard

### DIFF
--- a/core/src/lib/regen.test.ts
+++ b/core/src/lib/regen.test.ts
@@ -104,8 +104,13 @@ vi.mock('../db/client.js', () => {
     select: (..._args: unknown[]) => selectChain(),
     update: () => ({
       set: (data: Record<string, unknown>) => ({
-        where: async () => {
+        where: (..._args: unknown[]) => {
           dbUpdates.push(data)
+          return {
+            then: (onFulfilled: (v: unknown) => unknown, onRejected?: (r: unknown) => unknown) =>
+              Promise.resolve(undefined).then(onFulfilled, onRejected),
+            returning: async () => [{ lookupKey: 'wiki-key-1', state: 'LINKING' }],
+          }
         },
       }),
     }),
@@ -124,9 +129,11 @@ vi.mock('../db/schema.js', () => ({
     type: 'wikis.type',
     prompt: 'wikis.prompt',
     slug: 'wikis.slug',
+    state: 'wikis.state',
     content: 'wikis.content',
     metadata: 'wikis.metadata',
     citationDeclarations: 'wikis.citationDeclarations',
+    updatedAt: 'wikis.updatedAt',
     deletedAt: 'wikis.deletedAt',
   },
   wikiTypes: {
@@ -414,11 +421,12 @@ describe('regenerateWiki — sidecar persistence', () => {
 
     expect(result.content).toBe(llmResponse.markdown)
 
-    // First update writes content + metadata + citationDeclarations in one shot
-    const contentUpdate = dbUpdates[0]
+    // First update is the LINKING guard; second writes content + sidecar
+    const contentUpdate = dbUpdates[1]
     expect(contentUpdate).toBeDefined()
     expect(contentUpdate.content).toBe(llmResponse.markdown)
     expect(contentUpdate.citationDeclarations).toEqual(llmResponse.citations)
+    expect(contentUpdate.state).toBe('RESOLVED')
     const merged = contentUpdate.metadata as { infobox: unknown }
     expect(merged).toBeDefined()
     expect(merged.infobox).toEqual(llmResponse.infobox)
@@ -440,10 +448,12 @@ describe('regenerateWiki — sidecar persistence', () => {
 
     await regenerateWiki(undefined, 'wiki-key-1', { skipEmbedding: true })
 
-    const contentUpdate = dbUpdates[0]
+    // dbUpdates[0] is the LINKING guard; [1] is the content update
+    const contentUpdate = dbUpdates[1]
     expect(contentUpdate).toBeDefined()
     expect(contentUpdate.content).toBe('# Minimal output')
     expect(contentUpdate.citationDeclarations).toEqual([])
+    expect(contentUpdate.state).toBe('RESOLVED')
     const merged = contentUpdate.metadata as { infobox: unknown }
     expect(merged.infobox).toBeNull()
   })
@@ -469,7 +479,8 @@ describe('regenerateWiki — sidecar persistence', () => {
 
     await regenerateWiki(undefined, 'wiki-key-1', { skipEmbedding: true })
 
-    const contentUpdate = dbUpdates[0]
+    // dbUpdates[0] is the LINKING guard; [1] is the content update
+    const contentUpdate = dbUpdates[1]
     const merged = contentUpdate.metadata as { infobox: unknown; futureField?: unknown }
     expect(merged.infobox).toEqual(llmResponse.infobox)
     expect(merged.futureField).toEqual({ answer: 42 })

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -308,6 +308,18 @@ export async function regenerateWiki(
   const [wiki] = await database.select().from(wikis).where(eq(wikis.lookupKey, wikiKey))
   if (!wiki) throw new Error(`Wiki not found: ${wikiKey}`)
 
+  // Optimistic lock: transition to LINKING to prevent concurrent regen runs.
+  // If the wiki is already LINKING, another worker owns it — bail out.
+  const [lockedWiki] = await database
+    .update(wikis)
+    .set({ state: 'LINKING' })
+    .where(and(eq(wikis.lookupKey, wikiKey), ne(wikis.state, 'LINKING')))
+    .returning()
+  if (!lockedWiki) {
+    log.warn({ wikiKey }, 'wiki is already being regenerated, skipping')
+    return { content: '', fragmentCount: 0, hasEmbedding: false, timing: { classify: 0, gatherFragments: 0, llmCall: 0, embed: 0, total: 0 } }
+  }
+
   // Classify unfiled fragments into this wiki before gathering (mechanism 1)
   const tClassify0 = performance.now()
   try {
@@ -551,6 +563,7 @@ export async function regenerateWiki(
       content: markdown,
       metadata: mergedMetadata,
       citationDeclarations: llmCitations,
+      state: 'RESOLVED',
       lastRebuiltAt: now,
       updatedAt: now,
     })

--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -100,6 +100,8 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
     }
 
     // ── Reason 3: Wikis stuck in non-RESOLVED state ──
+    // Respect the LINKING lock: only pick up LINKING wikis if they've been
+    // stuck for over 15 minutes (stale lock from a crashed worker).
     const stuckWikis = await db
       .select({ lookupKey: wikis.lookupKey })
       .from(wikis)
@@ -107,6 +109,7 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
         and(
           isNull(wikis.deletedAt),
           sql`${wikis.state} != 'RESOLVED'`,
+          sql`(${wikis.state} != 'LINKING' OR ${wikis.updatedAt} < NOW() - INTERVAL '15 minutes')`,
         )
       )
     for (const r of stuckWikis) candidateKeys.add(r.lookupKey)


### PR DESCRIPTION
## Summary
- `regenerateWiki()` never set `state: 'RESOLVED'` after completing, so every wiki stayed PENDING forever and got re-processed every midnight batch, causing fragments to shift between wikis
- Adds `state: 'RESOLVED'` to the final `.set()` call after LLM generation
- Adds an optimistic LINKING lock at function entry -- concurrent regen calls on the same wiki bail out immediately
- Tightens the batch worker's Reason 3 (stuck-wiki) query to respect the LINKING state, only picking up LINKING wikis that have been stuck for >15 minutes (stale lock from a crashed worker)
- Updates test mock to support `.returning()` chain and adds assertions that `state: 'RESOLVED'` is present in the content update

## Test plan
- [x] `npx tsc --noEmit` passes (zero errors)
- [x] `npx vitest run src/lib/regen.test.ts` -- all 10 tests pass
- [ ] Deploy to staging and verify wikis transition to RESOLVED after regen
- [ ] Verify midnight batch skips RESOLVED wikis and doesn't re-process them
- [ ] Verify concurrent regen calls on the same wiki are deduplicated (second call bails out)

Fixes #170