### PR TITLE
fix(mcp): persist wiki description + fragment dedup

### DIFF
--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -219,6 +219,7 @@ export const fragments = pgTable(
   },
   (t) => [
     uniqueIndex('fragments_slug_uidx').on(t.slug),
+    index('fragments_dedup_hash_idx').on(t.dedupHash),
     // Partial index — keeps the retry scan O(unembedded) regardless of
     // table size.
     index('fragments_embedding_null_idx')

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -539,6 +539,7 @@ export async function handleCreateWiki(
       lookupKey,
       slug: finalSlug,
       name: input.title.trim(),
+      description: input.description?.trim() ?? '',
       type: resolvedType,
       state: 'PENDING',
       prompt: '',

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -34,7 +34,7 @@ import {
 import type { PeopleExtractionOutput } from '@robin/shared'
 import type { BullMQProducer, ExtractionJob } from '@robin/queue'
 import { resolveEntrySlug, resolveWikiSlug } from '../db/slug.js'
-import { computeContentHash, findDuplicateEntry } from '../db/dedup.js'
+import { computeContentHash, findDuplicateEntry, findDuplicateFragment } from '../db/dedup.js'
 import type { DB } from '../db/client.js'
 import {
   entries as entriesTable,
@@ -220,6 +220,14 @@ export async function handleLogFragment(
   }
 
   try {
+    const hash = computeContentHash(trimmed)
+    const dup = await findDuplicateFragment(deps.db, hash)
+    if (dup) {
+      return {
+        content: [{ type: 'text' as const, text: `Duplicate: fragment ${dup.lookupKey} already contains this content` }],
+      }
+    }
+
     const resolverDeps: McpResolverDeps = {
       db: deps.db,
     }
@@ -292,6 +300,7 @@ export async function handleLogFragment(
       entryId: null,
       state: 'RESOLVED',
       content: trimmed,
+      dedupHash: hash,
     })
 
     // Insert FRAGMENT_IN_WIKI edge

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -108,7 +108,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
           .string()
           .optional()
           .describe(
-            'What this wiki is for — used to infer the type when `type` is omitted'
+            'What this wiki is for — persisted on the wiki row and used to infer the type when `type` is omitted'
           ),
         type: z
           .string()


### PR DESCRIPTION
## Summary
- **#168**: `create_wiki` now persists the `description` field to the wikis table row and updates the MCP tool description text to reflect this.
- **#184**: `log_fragment` now computes a content hash before insert and short-circuits with a duplicate notice if an identical fragment already exists. The hash is stored as `dedupHash` on the fragment row, backed by a new `fragments_dedup_hash_idx` index.

Fixes #168, Fixes #184

## Test plan
- [ ] Call `create_wiki` with a description via MCP and verify it appears in the DB row
- [ ] Call `log_fragment` twice with identical content and verify the second call returns a duplicate message
- [ ] Verify `fragments_dedup_hash_idx` is created on next migration run