### PR TITLE
fix(security): CORS, auth gates, soft-delete, SQL injection, MCP revocation

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import { cors } from 'hono/cors'
+import { sessionMiddleware } from './middleware/session.js'
 import { httpLogger } from './middleware/http-logger.js'
 import { logger } from './lib/logger.js'
 import { auth } from './auth.js'
@@ -75,10 +76,17 @@ process.once('SIGTERM', () => process.exit(0))
 const app = new Hono()
 
 app.use('*', httpLogger())
+const allowedOrigins = new Set(
+  (process.env.WIKI_ORIGIN ?? 'http://localhost:8080,http://localhost:3001')
+    .split(',')
+    .map((s) => s.trim())
+)
+allowedOrigins.add(process.env.SERVER_PUBLIC_URL ?? 'http://localhost:3000')
+
 app.use(
   '*',
   cors({
-    origin: (origin) => origin,
+    origin: (origin) => (allowedOrigins.has(origin) ? origin : ''),
     credentials: true,
   })
 )
@@ -100,8 +108,9 @@ const openapiSpec = JSON.parse(readFileSync(new URL('../openapi.json', import.me
 const faviconBuf = readFileSync(new URL('../assets/favicon.ico', import.meta.url))
 
 /***********************************************************************
- * ## Pre-auth routes
- * Health, OpenAPI, internal HMAC, admin — no session middleware.
+ * ## Pre-auth routes (+ session-gated admin)
+ * Health, OpenAPI, auth recovery, published, system — no session middleware.
+ * Admin and BullBoard routes apply their own session middleware.
  ***********************************************************************/
 
 app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
@@ -124,11 +133,9 @@ app.route('/system', systemRoutes)
 app.use('/api/auth/*', (c) => auth.handler(c.req.raw))
 
 // BullBoard exposes queue payloads (raw user fragments), retry controls, and
-// drain actions. It has no auth in front. Only mount outside production until
-// issue #73 ships a proper session gate.
-if (process.env.NODE_ENV !== 'production') {
-  app.route('/admin/queues', bullBoardApp)
-}
+// drain actions. Gated behind session auth (issue #73).
+app.use('/admin/queues/*', sessionMiddleware)
+app.route('/admin/queues', bullBoardApp)
 
 /***********************************************************************
  * ## Authenticated API

--- a/core/src/lib/search.ts
+++ b/core/src/lib/search.ts
@@ -136,13 +136,13 @@ async function vectorSearchTable(
       id: meta.idCol,
       title: meta.titleCol,
       content: meta.contentCol,
-      distance: sql<number>`${meta.embeddingCol} <=> ${sql.raw(`'${vecLiteral}'::vector`)}`,
+      distance: sql<number>`${meta.embeddingCol} <=> ${vecLiteral}::vector`,
     })
     .from(meta.table)
     .where(
       sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL`
     )
-    .orderBy(sql`${meta.embeddingCol} <=> ${sql.raw(`'${vecLiteral}'::vector`)}`)
+    .orderBy(sql`${meta.embeddingCol} <=> ${vecLiteral}::vector`)
     .limit(limit)
 
   return rows.map((r) => ({

--- a/core/src/mcp/jwt.ts
+++ b/core/src/mcp/jwt.ts
@@ -95,6 +95,8 @@ export async function signMcpToken(userId: string): Promise<string | null> {
 
   return new SignJWT({ ver: user.mcpTokenVersion })
     .setProtectedHeader({ alg: 'EdDSA', kid })
+    .setIssuer('robin')
+    .setAudience('robin-mcp')
     .setIssuedAt()
     .setExpirationTime('100y')
     .sign(privateKey)
@@ -130,10 +132,19 @@ export async function verifyMcpToken(token: string): Promise<string> {
     format: 'der',
     type: 'spki',
   })
-  const { payload } = await jwtVerify(token, publicKey)
+  const { payload } = await jwtVerify(token, publicKey, {
+    issuer: 'robin',
+    audience: 'robin-mcp',
+  })
 
-  /** @gate — token version mismatch → revoked */
-  if (payload.ver !== user.mcpTokenVersion) throw new Error('Token revoked')
+  /** @gate — re-fetch mcpTokenVersion from DB to defeat stale kidCache */
+  const [freshUser] = await db
+    .select({ mcpTokenVersion: users.mcpTokenVersion })
+    .from(users)
+    .where(eq(users.id, user.id))
+  if (!freshUser || payload.ver !== freshUser.mcpTokenVersion) {
+    throw new Error('Token revoked')
+  }
 
   return user.id
 }

--- a/core/src/routes/admin.ts
+++ b/core/src/routes/admin.ts
@@ -5,6 +5,7 @@ import { db } from '../db/client.js'
 import { fragments, entries } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
 import { logger } from '../lib/logger.js'
+import { sessionMiddleware } from '../middleware/session.js'
 import {
   retryStuckDryRunResponseSchema,
   retryStuckResponseSchema,
@@ -13,19 +14,20 @@ import {
 const log = logger.child({ component: 'admin' })
 
 export const adminRoutes = new Hono()
+adminRoutes.use('*', sessionMiddleware)
 
 /**
  * POST /admin/retry-stuck
  *
  * Finds PENDING fragments older than ?minutes (default 5) and re-enqueues
- * their link jobs. No auth — intended for curl from the dev machine.
+ * their link jobs. Session-authenticated.
  *
  * Query params:
- *   minutes  — age threshold (default 5)
+ *   minutes  — age threshold (default 5, clamped 1-1440)
  *   dryRun   — if "true", returns what would be re-enqueued without doing it
  */
 adminRoutes.post('/retry-stuck', async (c) => {
-  const minutes = Number(c.req.query('minutes') ?? '5')
+  const minutes = Math.max(1, Math.min(1440, Number(c.req.query('minutes') ?? '5') || 5))
   const dryRun = c.req.query('dryRun') === 'true'
 
   const stuckFragments = (await db.execute(
@@ -34,7 +36,7 @@ adminRoutes.post('/retry-stuck', async (c) => {
         JOIN ${entries} e ON e.lookup_key = f.entry_id
         WHERE f.state = 'PENDING'
           AND f.locked_by IS NULL
-          AND f.updated_at < NOW() - INTERVAL '${sql.raw(String(minutes))} minutes'
+          AND f.updated_at < NOW() - make_interval(mins => ${minutes})
         ORDER BY f.updated_at ASC`
   )) as Array<{
     lookup_key: string

--- a/core/src/routes/entries.ts
+++ b/core/src/routes/entries.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { eq, desc } from 'drizzle-orm'
+import { eq, and, desc, isNull } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
 import { sessionMiddleware } from '../middleware/session.js'
 import { producer } from '../queue/producer.js'
@@ -102,6 +102,7 @@ entries.get('/', async (c) => {
   const rows = await db
     .select()
     .from(entriesTable)
+    .where(isNull(entriesTable.deletedAt))
     .orderBy(desc(entriesTable.createdAt))
     .limit(limit)
   return c.json(
@@ -113,7 +114,10 @@ entries.get('/', async (c) => {
 entries.get('/:id', async (c) => {
   const id = c.req.param('id')
 
-  const [entry] = await db.select().from(entriesTable).where(eq(entriesTable.lookupKey, id))
+  const [entry] = await db
+    .select()
+    .from(entriesTable)
+    .where(and(eq(entriesTable.lookupKey, id), isNull(entriesTable.deletedAt)))
   if (!entry) return c.json({ error: 'Not found' }, 404)
 
   // Entries have no metadata column and no LLM citations yet; sidecar only
@@ -140,13 +144,16 @@ entries.get('/:id', async (c) => {
 entries.get('/:id/fragments', async (c) => {
   const id = c.req.param('id')
 
-  const [entry] = await db.select().from(entriesTable).where(eq(entriesTable.lookupKey, id))
+  const [entry] = await db
+    .select()
+    .from(entriesTable)
+    .where(and(eq(entriesTable.lookupKey, id), isNull(entriesTable.deletedAt)))
   if (!entry) return c.json({ error: 'Not found' }, 404)
 
   const rows = await db
     .select()
     .from(fragments)
-    .where(eq(fragments.entryId, id))
+    .where(and(eq(fragments.entryId, id), isNull(fragments.deletedAt)))
     .orderBy(desc(fragments.createdAt))
 
   return c.json(

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -39,6 +39,7 @@ fragmentsRouter.get('/', async (c) => {
   const rows = await db
     .select()
     .from(fragments)
+    .where(isNull(fragments.deletedAt))
     .orderBy(desc(fragments.updatedAt))
     .limit(limit)
     .offset(offset)
@@ -52,7 +53,10 @@ fragmentsRouter.get('/', async (c) => {
 fragmentsRouter.get('/:id', async (c) => {
   const id = c.req.param('id')
 
-  const [fragment] = await db.select().from(fragments).where(eq(fragments.lookupKey, id))
+  const [fragment] = await db
+    .select()
+    .from(fragments)
+    .where(and(eq(fragments.lookupKey, id), isNull(fragments.deletedAt)))
   if (!fragment) return c.json({ error: 'Not found' }, 404)
 
   // Resolve backlinks: edges where this fragment is srcId


### PR DESCRIPTION
## Summary

- **CORS allowlist**: Replace reflecting-origin callback with allowlist from `WIKI_ORIGIN` + `SERVER_PUBLIC_URL` env vars
- **Admin auth**: Apply `sessionMiddleware` to all admin routes (was unauthenticated)
- **BullBoard session gate**: Remove `NODE_ENV !== 'production'` check; gate behind session auth in all environments
- **SQL injection**: Replace `sql.raw(String(minutes))` with parameterized `make_interval(mins => $1)` in admin retry-stuck; replace `sql.raw('${vecLiteral}')` with parameterized vector binding in search
- **Soft-delete filters**: Add `isNull(deletedAt)` to fragments and entries list/detail queries (matches wikis/people pattern)
- **MCP token revocation**: Fix kidCache bug where stale cached `mcpTokenVersion` allowed revoked tokens; now re-fetches from DB after cache hit. Add `iss`/`aud` claims to JWT signing and verification.

Fixes #173, Fixes #73

## Test plan

- [ ] Verify CORS rejects requests from unlisted origins
- [ ] Verify admin routes return 401 without session cookie
- [ ] Verify BullBoard returns 401 without session cookie (in production mode)
- [ ] Verify soft-deleted fragments and entries are excluded from list and detail endpoints
- [ ] Verify vector search still returns results (parameterized binding)
- [ ] Verify MCP token verification rejects tokens after `mcpTokenVersion` bump
- [ ] Verify MCP token signing includes `iss` and `aud` claims