### PR TITLE
fix(onboarding): YAML path, sync keypair, MCP polling + entry capture modal

### DIFF
--- a/core/src/bootstrap/jit-provision.ts
+++ b/core/src/bootstrap/jit-provision.ts
@@ -2,6 +2,7 @@ import { eq, sql } from 'drizzle-orm'
 import { auth } from '../auth.js'
 import { db } from '../db/client.js'
 import { users } from '../db/schema.js'
+import { generateKeypair } from '../keypair.js'
 import { generateDek, loadMasterKey, wrapDek } from '../lib/crypto.js'
 import { logger } from '../lib/logger.js'
 import { producer } from '../queue/producer.js'
@@ -72,7 +73,21 @@ export async function ensureFirstUser(): Promise<void> {
     })
     .where(eq(users.id, userId))
 
-  // Fire-and-forget provision job for keypair generation
+  // Generate keypair inline so the MCP endpoint is available immediately
+  // after onboarding — no dependency on BullMQ worker being up.
+  const kek = process.env.KEY_ENCRYPTION_SECRET ?? ''
+  if (kek) {
+    try {
+      const { publicKey, encryptedPrivateKey } = generateKeypair(kek)
+      await db.update(users).set({ publicKey, encryptedPrivateKey }).where(eq(users.id, userId))
+      log.info({ userId }, 'keypair generated inline during provisioning')
+    } catch (err) {
+      log.error({ userId, err }, 'inline keypair generation failed — falling back to async')
+    }
+  }
+
+  // Fallback: enqueue async provision job. The worker skips if keypair
+  // already exists (guard at processProvisionJob).
   producer
     .enqueueProvision({
       type: 'provision',

--- a/core/src/routes/wiki-types.ts
+++ b/core/src/routes/wiki-types.ts
@@ -27,12 +27,10 @@ const log = logger.child({ component: 'wiki-types' })
 const wikiTypesRouter = new Hono()
 wikiTypesRouter.use('*', sessionMiddleware)
 
-// Resolve the wiki-types YAML directory on disk (colocated with @robin/shared).
+// Resolve the wiki-types YAML directory via @robin/shared's dist output.
+// tsdown copies YAML specs to packages/shared/dist/prompts/specs/wiki-types/
+// so this path works in both dev and production (no src/ dependency).
 const __dirname = dirname(fileURLToPath(import.meta.url))
-// TODO: see .planning/phases/prompt-backend-reconcile/04-PLAN.md#known-limitation-runtime-yaml-path-resolution
-// This __dirname-relative walk breaks under bundled/production deployments.
-// Deferred to a future 'prompt-path-resolution-hardening' phase — Phase 1
-// inherits the pre-existing fragility already present in @robin/shared's loadSpec.
 const SPECS_WIKI_TYPES_DIR = resolve(
   __dirname,
   '..',
@@ -40,7 +38,7 @@ const SPECS_WIKI_TYPES_DIR = resolve(
   '..',
   'packages',
   'shared',
-  'src',
+  'dist',
   'prompts',
   'specs',
   'wiki-types'

--- a/wiki/src/components/layout/AddEntryModal.tsx
+++ b/wiki/src/components/layout/AddEntryModal.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { T } from "@/lib/typography";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createEntry } from "@/lib/generated";
+
+export interface AddEntryModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Label
+      className="text-[12px] font-normal leading-4 tracking-[0.32px]"
+      style={{ color: "#545353" }}
+    >
+      {children}
+    </Label>
+  );
+}
+
+export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
+  const wasOpen = useRef(false);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("Entry created");
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (open) {
+      if (!wasOpen.current) {
+        setTitle("");
+        setContent("");
+        setSubmitError(null);
+        setSubmitting(false);
+        setShowToast(false);
+      }
+      wasOpen.current = true;
+    } else {
+      wasOpen.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+        toastTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleSubmit = async () => {
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      setSubmitError("Content is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const { data, error } = await createEntry({
+        body: {
+          content: trimmedContent,
+          title: title.trim() || undefined,
+          source: "web",
+          type: "thought",
+        },
+        credentials: "include",
+      });
+
+      if (error) {
+        const message =
+          (error as { error?: string })?.error ?? "Failed to create entry.";
+        setSubmitError(message);
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ["entries"] });
+      onClose();
+      setToastMessage("Entry created");
+      setShowToast(true);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => {
+        setShowToast(false);
+        toastTimerRef.current = null;
+      }, 2000);
+    } catch {
+      setSubmitError("Network error. Check your connection and retry.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose();
+        }}
+      >
+        <DialogContent
+          className="flex flex-col gap-0 rounded-2xl border-black/10 p-0 sm:max-w-[571px]"
+          style={{ maxHeight: "min(500px, 90vh)", overflow: "hidden" }}
+        >
+          <DialogHeader className="shrink-0 px-5 pb-2 pt-5">
+            <DialogTitle
+              style={{
+                ...T.h1,
+                color: "#111111",
+                fontWeight: 400,
+                margin: 0,
+              }}
+            >
+              Add Entry
+            </DialogTitle>
+            <DialogDescription
+              style={{
+                ...T.micro,
+                lineHeight: "19px",
+                color: "#676d76",
+                margin: 0,
+              }}
+            >
+              Capture a thought, note, or idea. Robin will process it
+              automatically.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Title (optional)</FieldLabel>
+              <Input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Give your thought a title"
+                className="h-10"
+              />
+            </div>
+
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Content</FieldLabel>
+              <Textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="What's on your mind?"
+                rows={6}
+                className="min-h-[144px] resize-none"
+              />
+            </div>
+
+            <div className="pb-5" />
+
+            {submitError ? (
+              <div
+                role="alert"
+                className="px-5 pt-3 text-[13px]"
+                style={{ color: "#c0392b" }}
+              >
+                {submitError}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="flex shrink-0 items-center justify-end gap-3 px-5 py-4">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
+            >
+              {submitting ? "Adding..." : "Add Entry"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Toast
+        message={toastMessage}
+        visible={!open && showToast}
+        onDismiss={() => setShowToast(false)}
+      />
+    </>
+  );
+}

--- a/wiki/src/components/layout/Header.tsx
+++ b/wiki/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { useSession } from "@/hooks/useSession";
 import { useLogout } from "@/hooks/useLogout";
 
 import AddWikiModal from "@/components/layout/AddWikiModal";
+import AddEntryModal from "@/components/layout/AddEntryModal";
 import WikiHeaderSearch from "@/components/layout/WikiHeaderSearch";
 
 interface HeaderProps {
@@ -16,6 +17,7 @@ interface HeaderProps {
 export default function Header({ onMenuToggle }: HeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [addWikiOpen, setAddWikiOpen] = useState(false);
+  const [addEntryOpen, setAddEntryOpen] = useState(false);
   const { session } = useSession();
   const router = useRouter();
   const pathname = usePathname();
@@ -67,6 +69,49 @@ export default function Header({ onMenuToggle }: HeaderProps) {
         className="flex shrink-0 items-center"
         style={{ gap: 16, position: "relative" }}
       >
+        <button
+          type="button"
+          onClick={() => setAddEntryOpen(true)}
+          className="flex cursor-pointer items-center justify-center"
+          style={{
+            gap: 4,
+            padding: "8px 12px",
+            height: 35,
+            boxSizing: "border-box",
+            background: "transparent",
+            border: "none",
+            borderRadius: 2,
+          }}
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden
+          >
+            <path
+              d="M12 5v14M5 12h14"
+              stroke={addWikiFg}
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span
+            style={{
+              ...T.bodySmall,
+              fontWeight: 600,
+              lineHeight: "normal",
+              letterSpacing: "-0.0336px",
+              color: addWikiFg,
+              whiteSpace: "nowrap",
+            }}
+          >
+            Add Entry
+          </span>
+        </button>
+
         <button
           type="button"
           onClick={() => setAddWikiOpen(true)}
@@ -254,6 +299,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
       </div>
 
       <AddWikiModal open={addWikiOpen} onClose={() => setAddWikiOpen(false)} />
+      <AddEntryModal open={addEntryOpen} onClose={() => setAddEntryOpen(false)} />
     </header>
   );
 }

--- a/wiki/src/components/onboarding/CompleteStep.tsx
+++ b/wiki/src/components/onboarding/CompleteStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Check, Copy } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -8,6 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { T } from "@/lib/typography";
 import { useProfile } from "@/hooks/useProfile";
 import { ActionButton } from "@/components/ui/action-button";
+import { Spinner } from "@/components/ui/spinner";
 import { Card, CardContent } from "@/components/ui/card";
 
 function Logo() {
@@ -34,6 +35,15 @@ export default function CompleteStep() {
   const [copied, setCopied] = useState(false);
   const [completing, setCompleting] = useState(false);
   const mcpEndpoint = profile?.mcpEndpointUrl ?? "";
+
+  // Poll for MCP endpoint until it becomes available (keypair may still be generating)
+  useEffect(() => {
+    if (mcpEndpoint || profileLoading) return
+    const interval = setInterval(() => {
+      queryClient.invalidateQueries({ queryKey: ['profile'] })
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [mcpEndpoint, profileLoading, queryClient])
 
   const handleCopy = async () => {
     try {
@@ -100,7 +110,14 @@ export default function CompleteStep() {
                   color: "var(--card-desc)",
                 }}
               >
-                {profileLoading ? "Loading..." : mcpEndpoint || "Unavailable"}
+                {profileLoading
+                  ? "Loading..."
+                  : mcpEndpoint || (
+                    <span className="inline-flex items-center gap-1.5">
+                      <Spinner className="size-3" />
+                      Generating your MCP endpoint...
+                    </span>
+                  )}
               </span>
             </div>
             <button

--- a/wiki/src/components/onboarding/PromptsStep.tsx
+++ b/wiki/src/components/onboarding/PromptsStep.tsx
@@ -171,7 +171,7 @@ export default function PromptsStep({ onNext, onSkip }: PromptsStepProps) {
           <ActionButton
             type="button"
             onClick={handleContinue}
-            disabled={!hasEdited}
+            disabled={false}
           >
             Continue
           </ActionButton>


### PR DESCRIPTION
## Summary
- **YAML path resolution** (`wiki-types.ts`): Resolve wiki-type specs from `packages/shared/dist/` instead of `src/` so the path works in production deployments where `src/` doesn't exist
- **Sync keypair generation** (`jit-provision.ts`): Generate Ed25519 keypair inline during JIT provisioning so the MCP endpoint URL is available immediately after onboarding, without depending on the BullMQ worker being up. Async job kept as fallback; worker already guards against duplicate generation.
- **Enable Continue without edits** (`PromptsStep.tsx`): Remove `disabled={!hasEdited}` gate so users who review prompts without editing can proceed through onboarding
- **MCP endpoint polling** (`CompleteStep.tsx`): Poll profile every 2s when MCP endpoint URL is empty, showing a spinner + "Generating your MCP endpoint..." instead of "Unavailable"
- **Entry capture modal** (`AddEntryModal.tsx` + `Header.tsx`): New modal mirroring AddWikiModal pattern — title (optional) + content (required), submits via generated SDK `createEntry` with `source: 'web'`, `type: 'thought'`. "Add Entry" button added to header alongside "Add Wiki".

Fixes #172, Fixes #183

## Test plan
- [ ] Deploy and run through full onboarding flow — verify Continue button works without editing prompts
- [ ] Verify MCP endpoint appears on Complete step (with spinner while generating)
- [ ] Verify wiki-types load correctly (YAML resolved from dist/)
- [ ] Click "Add Entry" in header, submit a thought, verify it appears in entries list
- [ ] Verify "Add Wiki" still works as before