### PR TITLE
feat: password change flow + public wiki page

### DIFF
--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -42,6 +42,8 @@ export const wikiResponseSchema = z.object({
   descriptor: z.string().default(''),
   progress: wikiProgressSchema.nullable().default(null),
   bouncerMode: z.enum(['auto', 'review']).default('auto'),
+  published: z.boolean().default(false),
+  publishedSlug: z.string().nullable().default(null),
 })
 
 export const wikiWithContentResponseSchema = wikiResponseSchema.extend({

--- a/wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx
+++ b/wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { T, FONT } from "@/lib/typography";
+import { WikiInfobox } from "@/components/wiki/WikiInfobox";
+import { MarkdownContent } from "@/components/wiki/MarkdownContent";
+import type {
+  WikiInfobox as WikiInfoboxData,
+  WikiRef,
+} from "@/lib/sidecarTypes";
+
+export interface PublishedWikiData {
+  name: string;
+  type: string;
+  publishedAt: string;
+  content: string;
+  refs?: Record<string, WikiRef>;
+  infobox?: WikiInfoboxData | null;
+}
+
+const bodyStyle: CSSProperties = {
+  ...T.bodySmall,
+  color: "var(--wiki-article-text)",
+};
+
+export function PublishedWikiArticle({ wiki }: { wiki: PublishedWikiData }) {
+  const publishedDate = new Date(wiki.publishedAt).toLocaleDateString(
+    "en-US",
+    { year: "numeric", month: "long", day: "numeric" },
+  );
+
+  return (
+    <div className="published-page">
+      <header className="published-header">
+        <span
+          style={{
+            ...T.bodySmall,
+            fontWeight: 500,
+            color: "var(--heading-color)",
+          }}
+        >
+          Robin Wiki
+        </span>
+      </header>
+
+      <article className="published-article">
+        <h1
+          style={{
+            ...T.h1,
+            fontFamily: FONT.SERIF,
+            color: "var(--heading-color)",
+            margin: 0,
+          }}
+        >
+          {wiki.name}
+        </h1>
+        <p
+          style={{
+            ...T.micro,
+            color: "var(--wiki-count)",
+            marginTop: 4,
+            marginBottom: 24,
+          }}
+        >
+          Published {publishedDate}
+        </p>
+
+        {wiki.infobox && (
+          <WikiInfobox
+            title={wiki.name}
+            image={wiki.infobox.image?.url}
+            caption={wiki.infobox.caption}
+            sections={[
+              {
+                rows: wiki.infobox.rows.map((row) => ({
+                  key: row.label,
+                  value: row.value,
+                })),
+              },
+            ]}
+          />
+        )}
+
+        <MarkdownContent
+          content={wiki.content}
+          refs={wiki.refs}
+          style={bodyStyle}
+        />
+      </article>
+
+      <footer className="published-footer">
+        <span style={{ ...T.micro, color: "var(--wiki-count)" }}>
+          Powered by Robin Wiki
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/wiki/src/app/(public)/p/[nanoid]/page.tsx
+++ b/wiki/src/app/(public)/p/[nanoid]/page.tsx
@@ -1,0 +1,57 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import {
+  PublishedWikiArticle,
+  type PublishedWikiData,
+} from "./PublishedWikiArticle";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_ROBIN_API ?? "http://localhost:3000";
+
+async function fetchPublishedWiki(
+  nanoid: string,
+): Promise<PublishedWikiData | null> {
+  const res = await fetch(`${API_BASE}/published/wiki/${nanoid}`, {
+    next: { revalidate: 60 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ nanoid: string }>;
+}): Promise<Metadata> {
+  const { nanoid } = await params;
+  const wiki = await fetchPublishedWiki(nanoid);
+  if (!wiki) {
+    return { title: "Not Found — Robin Wiki" };
+  }
+
+  const description = wiki.content.slice(0, 160).replace(/\n/g, " ");
+
+  return {
+    title: `${wiki.name} — Robin Wiki`,
+    description,
+    openGraph: {
+      title: wiki.name,
+      description,
+      type: "article",
+      publishedTime: wiki.publishedAt,
+      siteName: "Robin Wiki",
+    },
+  };
+}
+
+export default async function PublishedWikiPage({
+  params,
+}: {
+  params: Promise<{ nanoid: string }>;
+}) {
+  const { nanoid } = await params;
+  const wiki = await fetchPublishedWiki(nanoid);
+  if (!wiki) notFound();
+
+  return <PublishedWikiArticle wiki={wiki} />;
+}

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { Check, RefreshCw, Trash2, X } from "lucide-react";
+import { Check, LinkIcon, RefreshCw, Trash2, X } from "lucide-react";
 import { T } from "@/lib/typography";
 import { Spinner } from "@/components/ui/spinner";
 import { useWiki } from "@/hooks/useWiki";
@@ -129,6 +129,7 @@ export default function WikiDetailPage() {
   const rejectFragment = useRejectFragment();
   const queryClient = useQueryClient();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
 
   // Section-scoped edit state. `editingSectionId` doubles as the
   // "dialog open" indicator — non-null ⇒ open. The anchor id is stable
@@ -369,6 +370,35 @@ export default function WikiDetailPage() {
               <Trash2 size={14} strokeWidth={1.5} />
               {deleteWiki.isPending ? "Deleting..." : "Delete Wiki"}
             </button>
+            {wiki.published && wiki.publishedSlug && (
+              <button
+                type="button"
+                onClick={() => {
+                  const url = `${window.location.origin}/p/${wiki.publishedSlug}`;
+                  navigator.clipboard.writeText(url);
+                  setShareCopied(true);
+                  setTimeout(() => setShareCopied(false), 2000);
+                }}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 10px",
+                  fontSize: 12,
+                  color: "var(--wiki-article-link)",
+                  background: "none",
+                  border: "1px solid var(--wiki-card-border)",
+                  cursor: "pointer",
+                }}
+              >
+                {shareCopied ? (
+                  <Check size={14} strokeWidth={1.5} />
+                ) : (
+                  <LinkIcon size={14} strokeWidth={1.5} />
+                )}
+                {shareCopied ? "Copied!" : "Copy share link"}
+              </button>
+            )}
             {regenerate.isSuccess && (
               <span style={{ fontSize: 12, color: "var(--wiki-article-link)" }}>
                 Regeneration queued

--- a/wiki/src/app/globals.css
+++ b/wiki/src/app/globals.css
@@ -1411,3 +1411,38 @@ a.ext::after {
   --sidebar-border: oklch(0.3 0 0);
   --sidebar-ring: oklch(0.556 0 0);
 }
+
+/* ── Published (public) wiki page ─────────────────────────────────── */
+
+.published-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.published-header {
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--wiki-card-border);
+}
+
+.published-article {
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  flex: 1;
+}
+
+.published-footer {
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px 24px;
+  border-top: 1px solid var(--wiki-card-border);
+  text-align: center;
+}

--- a/wiki/src/app/profile/page.tsx
+++ b/wiki/src/app/profile/page.tsx
@@ -39,6 +39,7 @@ import { AuthGuard } from "@/components/AuthGuard";
 import { useProfile } from "@/hooks/useProfile";
 import { useStats } from "@/hooks/useStats";
 import { useLogout } from "@/hooks/useLogout";
+import { useChangePassword } from "@/hooks/useChangePassword";
 import { exportUserData, getUserKeypair } from "@/lib/api";
 
 const sectionLabel: CSSProperties = {
@@ -81,9 +82,13 @@ export default function ProfilePage() {
   const statsQuery = useStats();
   const modelPrefs = useModelPreferences();
   const logout = useLogout();
+  const changePassword = useChangePassword();
   const [copied, setCopied] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [confirmPw, setConfirmPw] = useState("");
 
   const username = session?.user?.name ?? session?.user?.email ?? "";
   const canDelete = username.length > 0 && deleteConfirm === username;
@@ -399,6 +404,101 @@ export default function ProfilePage() {
                 icon={<LogOut className="size-4" strokeWidth={1.5} />}
                 onClick={logout}
               />
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* SECURITY */}
+        <section className="mt-8" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <p style={sectionLabel}>Security</p>
+          <Card size="sm" className="rounded-none">
+            <CardContent className="space-y-4">
+              <div>
+                <p style={titleText}>Change password</p>
+                <p style={{ ...bodySmallText, marginTop: 2 }}>
+                  Update your account password.
+                </p>
+              </div>
+              <form
+                className="space-y-3"
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  if (newPw !== confirmPw) return;
+                  await changePassword.mutate({ currentPassword: currentPw, newPassword: newPw });
+                  if (!changePassword.error) {
+                    setCurrentPw("");
+                    setNewPw("");
+                    setConfirmPw("");
+                  }
+                }}
+              >
+                <div className="space-y-1">
+                  <Label htmlFor="current-password" style={{ ...T.micro, color: "var(--heading-secondary)" }}>
+                    Current password
+                  </Label>
+                  <Input
+                    id="current-password"
+                    type="password"
+                    autoComplete="current-password"
+                    value={currentPw}
+                    onChange={(e) => setCurrentPw(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="new-password" style={{ ...T.micro, color: "var(--heading-secondary)" }}>
+                    New password
+                  </Label>
+                  <Input
+                    id="new-password"
+                    type="password"
+                    autoComplete="new-password"
+                    value={newPw}
+                    onChange={(e) => setNewPw(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="confirm-password" style={{ ...T.micro, color: "var(--heading-secondary)" }}>
+                    Confirm new password
+                  </Label>
+                  <Input
+                    id="confirm-password"
+                    type="password"
+                    autoComplete="new-password"
+                    value={confirmPw}
+                    onChange={(e) => setConfirmPw(e.target.value)}
+                  />
+                </div>
+                {newPw.length > 0 && confirmPw.length > 0 && newPw !== confirmPw && (
+                  <p style={{ ...T.micro, color: "var(--destructive)", margin: 0 }}>
+                    Passwords do not match.
+                  </p>
+                )}
+                {changePassword.error && (
+                  <p style={{ ...T.micro, color: "var(--destructive)", margin: 0 }}>
+                    {changePassword.error}
+                  </p>
+                )}
+                {changePassword.isSuccess && (
+                  <p style={{ ...T.micro, color: "var(--emerald-600, #059669)", margin: 0 }}>
+                    Password changed successfully.
+                  </p>
+                )}
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={
+                    changePassword.isLoading ||
+                    !currentPw ||
+                    !newPw ||
+                    !confirmPw ||
+                    newPw !== confirmPw
+                  }
+                >
+                  <span style={T.buttonSmall}>
+                    {changePassword.isLoading ? "Changing..." : "Change password"}
+                  </span>
+                </Button>
+              </form>
             </CardContent>
           </Card>
         </section>

--- a/wiki/src/hooks/useChangePassword.ts
+++ b/wiki/src/hooks/useChangePassword.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState } from 'react'
+import { authClient } from '@/lib/auth-client'
+
+export function useChangePassword() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const mutate = async ({
+    currentPassword,
+    newPassword,
+  }: {
+    currentPassword: string
+    newPassword: string
+  }) => {
+    setIsLoading(true)
+    setError(null)
+    setIsSuccess(false)
+    try {
+      await authClient.changePassword({ currentPassword, newPassword })
+      setIsSuccess(true)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to change password'
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { mutate, isLoading, error, isSuccess }
+}

--- a/wiki/src/lib/generated/types.gen.ts
+++ b/wiki/src/lib/generated/types.gen.ts
@@ -257,6 +257,8 @@ export type ThreadResponseSchema = {
         }>;
         percentage: number;
     };
+    published?: boolean;
+    publishedSlug?: string;
 };
 
 export type ThreadWithWikiResponseSchema = {
@@ -332,6 +334,8 @@ export type WikiDetailResponseSchema = {
         }>;
         percentage: number;
     };
+    published?: boolean;
+    publishedSlug?: string;
     wikiContent: string;
     fragments: Array<{
         id: string;


### PR DESCRIPTION
## Summary
- **#176** — Add password change flow to profile page. New `useChangePassword` hook wraps `authClient.changePassword()`. Security section with current/new/confirm password inputs, validation, and success/error feedback.
- **#177** — Add rendered public wiki page at `/p/:nanoid`. Server component fetches published wiki data, exports `generateMetadata` with OG tags. Client component renders clean read-only article with infobox and markdown. Adds `published`/`publishedSlug` fields to wiki response schema. "Copy share link" button on wiki detail page when published.

## Test plan
- [ ] Navigate to Profile, scroll to Security section, change password with valid current password
- [ ] Verify validation: mismatched passwords show error, empty fields disable submit
- [ ] Verify wrong current password shows API error
- [ ] Publish a wiki via API, visit `/p/:nanoid` — renders article with header/footer
- [ ] Verify OG meta tags render in page source
- [ ] On a published wiki detail page, verify "Copy share link" button appears and copies correct URL
- [ ] On an unpublished wiki, verify no share link button shows

Fixes #176, Fixes #177