### PR TITLE
feat: collections UI + fragment similarity edges

### DIFF
--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -57,6 +57,9 @@ export const STRONG_SIGNAL_THRESHOLD = 0.7
 /** Below LLM_REVIEW_THRESHOLD → skip entirely, not relevant */
 // (implicit: similarity < 0.5 is ignored)
 
+/** Fragment-to-fragment similarity threshold for RELATED_TO edges */
+export const RELATED_FRAGMENT_THRESHOLD = 0.75
+
 /** Max unfiled fragments to evaluate per regen call */
 const MAX_UNFILED_PER_REGEN = 50
 
@@ -73,6 +76,101 @@ export interface RegenResult {
   fragmentCount: number
   hasEmbedding: boolean
   timing?: RegenTiming
+}
+
+/**
+ * Create bidirectional FRAGMENT_RELATED_TO_FRAGMENT edges between a newly-filed
+ * fragment and other fragments in the same wiki that are semantically similar.
+ *
+ * Uses cosine distance on stored embeddings. Only creates edges when similarity
+ * >= RELATED_FRAGMENT_THRESHOLD (0.75). Idempotent via onConflictDoNothing.
+ */
+export async function createRelatedToEdges(
+  database: DB,
+  fragmentKey: string,
+  wikiKey: string
+): Promise<number> {
+  const [frag] = await database
+    .select({ embedding: fragments.embedding })
+    .from(fragments)
+    .where(and(eq(fragments.lookupKey, fragmentKey), isNull(fragments.deletedAt)))
+    .limit(1)
+
+  if (!frag?.embedding) return 0
+
+  const vecLiteral = JSON.stringify(frag.embedding)
+  const maxDistance = 1 - RELATED_FRAGMENT_THRESHOLD
+
+  const neighbors = await database
+    .select({
+      lookupKey: fragments.lookupKey,
+      distance: sql<number>`${fragments.embedding} <=> ${vecLiteral}::vector`,
+    })
+    .from(fragments)
+    .innerJoin(
+      edges,
+      and(
+        eq(edges.srcId, fragments.lookupKey),
+        eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+        eq(edges.dstId, wikiKey),
+        isNull(edges.deletedAt)
+      )
+    )
+    .where(
+      and(
+        isNull(fragments.deletedAt),
+        sql`${fragments.embedding} IS NOT NULL`,
+        sql`${fragments.lookupKey} != ${fragmentKey}`,
+        sql`${fragments.embedding} <=> ${vecLiteral}::vector < ${maxDistance}`
+      )
+    )
+    .orderBy(sql`${fragments.embedding} <=> ${vecLiteral}::vector`)
+    .limit(20)
+
+  let created = 0
+  for (const neighbor of neighbors) {
+    const similarity = 1 - neighbor.distance
+    await database
+      .insert(edges)
+      .values({
+        id: crypto.randomUUID(),
+        srcType: 'fragment',
+        srcId: fragmentKey,
+        dstType: 'fragment',
+        dstId: neighbor.lookupKey,
+        edgeType: 'FRAGMENT_RELATED_TO_FRAGMENT',
+        attrs: { score: similarity, method: 'cosine-regen' },
+      })
+      .onConflictDoNothing()
+    await database
+      .insert(edges)
+      .values({
+        id: crypto.randomUUID(),
+        srcType: 'fragment',
+        srcId: neighbor.lookupKey,
+        dstType: 'fragment',
+        dstId: fragmentKey,
+        edgeType: 'FRAGMENT_RELATED_TO_FRAGMENT',
+        attrs: { score: similarity, method: 'cosine-regen' },
+      })
+      .onConflictDoNothing()
+    created++
+
+    await emitAuditEvent(database, {
+      entityType: 'fragment',
+      entityId: fragmentKey,
+      eventType: 'related_detected',
+      source: 'system',
+      summary: `Related fragment detected: ${neighbor.lookupKey} (${Math.round(similarity * 100)}%)`,
+      detail: { fragmentKey, relatedKey: neighbor.lookupKey, similarity, wikiKey, method: 'cosine-regen' },
+    })
+  }
+
+  if (created > 0) {
+    log.info({ fragmentKey, wikiKey, relatedCount: created }, 'created RELATED_TO edges')
+  }
+
+  return created
 }
 
 /**
@@ -199,6 +297,11 @@ export async function classifyUnfiledFragments(
         { fragmentKey: frag.lookupKey, wikiKey, similarity: similarity.toFixed(3), method: 'cosine-auto' },
         'regen classify: auto-filed (above threshold)'
       )
+      try {
+        await createRelatedToEdges(database, frag.lookupKey, wikiKey)
+      } catch (relErr) {
+        log.warn({ fragmentKey: frag.lookupKey, err: relErr }, 'failed to create RELATED_TO edges')
+      }
     } catch (err) {
       log.warn({ fragmentKey: frag.lookupKey, err }, 'failed to auto-file fragment')
     }
@@ -272,6 +375,11 @@ export async function classifyUnfiledFragments(
               })
               .onConflictDoNothing()
             llmFiled++
+            try {
+              await createRelatedToEdges(database, frag.lookupKey, edge.wikiKey)
+            } catch (relErr) {
+              log.warn({ fragmentKey: frag.lookupKey, err: relErr }, 'failed to create RELATED_TO edges')
+            }
           }
         } else {
           llmRejected++

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -156,6 +156,8 @@ export async function createRelatedToEdges(
       .onConflictDoNothing()
     created++
 
+    // Emit audit events for both fragments so the timeline endpoint
+    // surfaces relationship detection from either side (Issue #165)
     await emitAuditEvent(database, {
       entityType: 'fragment',
       entityId: fragmentKey,
@@ -163,6 +165,14 @@ export async function createRelatedToEdges(
       source: 'system',
       summary: `Related fragment detected: ${neighbor.lookupKey} (${Math.round(similarity * 100)}%)`,
       detail: { fragmentKey, relatedKey: neighbor.lookupKey, similarity, wikiKey, method: 'cosine-regen' },
+    })
+    await emitAuditEvent(database, {
+      entityType: 'fragment',
+      entityId: neighbor.lookupKey,
+      eventType: 'related_detected',
+      source: 'system',
+      summary: `Related fragment detected: ${fragmentKey} (${Math.round(similarity * 100)}%)`,
+      detail: { fragmentKey: neighbor.lookupKey, relatedKey: fragmentKey, similarity, wikiKey, method: 'cosine-regen' },
     })
   }
 

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { eq, and, desc, isNull, inArray } from 'drizzle-orm'
+import { eq, and, desc, isNull, inArray, sql } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
 import { makeLookupKey, generateSlug } from '@robin/shared'
 import { resolveFragmentSlug } from '../db/slug.js'
@@ -96,12 +96,53 @@ fragmentsRouter.get('/:id', async (c) => {
     for (const r of rows) backlinks.push({ id: r.key, name: r.title, type: 'fragment' })
   }
 
+  // Resolve related fragments via FRAGMENT_RELATED_TO_FRAGMENT edges (both directions)
+  const relatedEdges = await db
+    .select({ srcId: edges.srcId, dstId: edges.dstId, attrs: edges.attrs })
+    .from(edges)
+    .where(
+      and(
+        eq(edges.edgeType, 'FRAGMENT_RELATED_TO_FRAGMENT'),
+        isNull(edges.deletedAt),
+        sql`(${edges.srcId} = ${id} OR ${edges.dstId} = ${id})`
+      )
+    )
+
+  const relatedKeySet = new Set<string>()
+  const relatedScores = new Map<string, number>()
+  for (const e of relatedEdges) {
+    const otherKey = e.srcId === id ? e.dstId : e.srcId
+    if (!relatedKeySet.has(otherKey)) {
+      relatedKeySet.add(otherKey)
+      const attrs = e.attrs as Record<string, unknown> | null
+      relatedScores.set(otherKey, typeof attrs?.score === 'number' ? attrs.score : 0)
+    }
+  }
+
+  const relatedFragments: { id: string; slug: string; title: string; similarity: number }[] = []
+  if (relatedKeySet.size > 0) {
+    const relatedRows = await db
+      .select({ lookupKey: fragments.lookupKey, slug: fragments.slug, title: fragments.title })
+      .from(fragments)
+      .where(and(inArray(fragments.lookupKey, [...relatedKeySet]), isNull(fragments.deletedAt)))
+    for (const r of relatedRows) {
+      relatedFragments.push({
+        id: r.lookupKey,
+        slug: r.slug,
+        title: r.title,
+        similarity: relatedScores.get(r.lookupKey) ?? 0,
+      })
+    }
+    relatedFragments.sort((a, b) => b.similarity - a.similarity)
+  }
+
   return c.json(
     fragmentDetailResponseSchema.parse({
       ...fragment,
       id: fragment.lookupKey,
       content: fragment.content ?? '',
       backlinks,
+      relatedFragments,
     })
   )
 })

--- a/core/src/schemas/fragments.schema.ts
+++ b/core/src/schemas/fragments.schema.ts
@@ -21,7 +21,7 @@ export const fragmentWithContentResponseSchema = fragmentResponseSchema.extend({
   content: z.string(),
 })
 
-/** Fragment detail with backlinks resolved from edges table */
+/** Fragment detail with backlinks and related fragments resolved from edges table */
 export const fragmentDetailResponseSchema = fragmentWithContentResponseSchema.extend({
   backlinks: z.array(
     z.object({
@@ -30,6 +30,14 @@ export const fragmentDetailResponseSchema = fragmentWithContentResponseSchema.ex
       type: z.string(),
     })
   ),
+  relatedFragments: z.array(
+    z.object({
+      id: z.string(),
+      slug: z.string(),
+      title: z.string(),
+      similarity: z.number(),
+    })
+  ).default([]),
 })
 
 export const fragmentListResponseSchema = z.object({

--- a/wiki/src/app/(shell)/explorer/page.tsx
+++ b/wiki/src/app/(shell)/explorer/page.tsx
@@ -61,7 +61,7 @@ function timeAgo(dateStr: string): string {
 function ExplorerInner() {
   const { filters, setFilter, clearFilters, hasActiveFilters } =
     useExplorerFilters();
-  const { items, isLoading, isError, groups } = useExplorerData(filters);
+  const { items, isLoading, isError, collections } = useExplorerData(filters);
 
   const [showFilters, setShowFilters] = useState(true);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -69,7 +69,7 @@ function ExplorerInner() {
   // Reset visible count when filters change
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [filters.types.join(","), filters.group, filters.sort]);
+  }, [filters.types.join(","), filters.collection, filters.sort]);
 
   // Infinite scroll
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -213,8 +213,8 @@ function ExplorerInner() {
               </div>
             </div>
 
-            {/* Group filters */}
-            {groups.length > 0 && (
+            {/* Collection filters */}
+            {collections.length > 0 && (
               <div style={{ marginBottom: 16 }}>
                 <span
                   style={{
@@ -226,33 +226,33 @@ function ExplorerInner() {
                     marginBottom: 8,
                   }}
                 >
-                  Group
+                  Collection
                 </span>
                 <div className="flex flex-wrap items-start" style={{ gap: 8 }}>
                   <Chip
-                    label="All groups"
-                    active={filters.group === null}
-                    onClick={() => setFilter("group", null)}
+                    label="All collections"
+                    active={filters.collection === null}
+                    onClick={() => setFilter("collection", null)}
                   />
-                  {groups.map((group) => (
+                  {collections.map((collection) => (
                     <Chip
-                      key={group.id}
+                      key={collection.id}
                       icon={
                         <span
                           className="inline-block h-2.5 w-2.5 rounded-full"
                           style={{
                             backgroundColor:
-                              group.color || "var(--wiki-count)",
+                              collection.color || "var(--wiki-count)",
                           }}
                           aria-hidden
                         />
                       }
-                      label={group.name}
-                      active={filters.group === group.id}
+                      label={collection.name}
+                      active={filters.collection === collection.id}
                       onClick={() =>
                         setFilter(
-                          "group",
-                          filters.group === group.id ? null : group.id,
+                          "collection",
+                          filters.collection === collection.id ? null : collection.id,
                         )
                       }
                     />
@@ -424,7 +424,7 @@ function ExplorerRow({ item }: { item: ExplorerItem }) {
         </Link>
       </div>
 
-      {/* Right: badge + group indicator + date */}
+      {/* Right: badge + collection indicator + date */}
       <div
         style={{
           display: "flex",
@@ -437,20 +437,20 @@ function ExplorerRow({ item }: { item: ExplorerItem }) {
           type={item.subtype ?? (item.type.charAt(0).toUpperCase() + item.type.slice(1))}
         />
 
-        {item.groupColor && item.groupName && (
+        {item.collectionColor && item.collectionName && (
           <div
             style={{ display: "flex", alignItems: "center", gap: 6 }}
           >
             <span
               className="inline-block h-2.5 w-2.5 rounded-full"
-              style={{ backgroundColor: item.groupColor }}
+              style={{ backgroundColor: item.collectionColor }}
               aria-hidden
             />
             <span
               className="hidden sm:inline"
               style={{ ...T.micro, color: "var(--wiki-count)" }}
             >
-              {item.groupName}
+              {item.collectionName}
             </span>
           </div>
         )}

--- a/wiki/src/app/(shell)/fragments/[id]/page.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/page.tsx
@@ -22,6 +22,7 @@ import type { FragmentWithContentResponseSchema } from "@/lib/generated/types.ge
 type FragmentData = Omit<FragmentWithContentResponseSchema, "entryId"> & {
   entryId: string | null;
   backlinks?: Array<{ id: string; name: string; type: string; bouncerMode?: string }>;
+  relatedFragments?: Array<{ id: string; slug: string; title: string; similarity: number }>;
 };
 
 function formatDate(iso: string) {
@@ -219,11 +220,68 @@ function BacklinksSection({ backlinks }: { backlinks: Array<{ id: string; name: 
   );
 }
 
+function RelatedFragmentsSection({ relatedFragments }: { relatedFragments: Array<{ id: string; slug: string; title: string; similarity: number }> }) {
+  if (relatedFragments.length === 0) return null;
+
+  return (
+    <section style={{ width: "100%" }}>
+      <WikiSectionH2 title="Related fragments" count={relatedFragments.length} />
+      <ul
+        style={{
+          ...T.bodySmall,
+          color: "var(--wiki-article-text)",
+          lineHeight: 1.6,
+          listStyle: "decimal",
+          paddingLeft: 20,
+          margin: "12px 0 0 0",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        {relatedFragments.map((rf) => (
+          <li key={rf.id}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <Link
+                href={ROUTES.fragment(rf.id)}
+                style={{
+                  color: "var(--wiki-fragment-link)",
+                  textDecoration: "underline",
+                  textDecorationSkipInk: "none",
+                }}
+              >
+                {rf.title}
+              </Link>
+              <span
+                style={{
+                  ...T.micro,
+                  color: "var(--wiki-count)",
+                  flexShrink: 0,
+                }}
+              >
+                {Math.round(rf.similarity * 100)}%
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
 function FragmentBottomSections({ fragment }: { fragment: FragmentData }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 40, width: "100%" }}>
       <EntryOriginSection entryId={fragment.entryId} />
       <BacklinksSection backlinks={fragment.backlinks ?? []} />
+      <RelatedFragmentsSection relatedFragments={fragment.relatedFragments ?? []} />
     </div>
   );
 }

--- a/wiki/src/components/layout/Sidebar.tsx
+++ b/wiki/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import { T } from "@/lib/typography";
 import { ROUTES } from "@/lib/routes";
 import { useEntries } from "@/hooks/useEntries";
 import { useWikis } from "@/hooks/useWikis";
+import { useCollections } from "@/hooks/useCollections";
 
 const ACTIVE_COLOR = "#000000";
 const ACTIVE_WEIGHT = 700;
@@ -73,6 +74,21 @@ function useEntriesData(): SidebarSectionData {
   }, [data]);
 
   return { title: "Entries", items, emptyText: "no entries added" };
+}
+
+function useCollectionsData(): SidebarSectionData {
+  const { data } = useCollections();
+  const items = useMemo<NavItem[]>(() => {
+    const collections = data;
+    if (!collections || collections.length === 0) return [];
+    return collections.map((c) => ({
+      label: c.name,
+      arrow: "none" as ArrowState,
+      count: c.wikiCount,
+    }));
+  }, [data]);
+
+  return { title: "Collections", items, emptyText: "no collections yet" };
 }
 
 function useContentsData(): SidebarSectionData {
@@ -453,6 +469,7 @@ function SidebarSection({
 
 export default function Sidebar() {
   const entriesData = useEntriesData();
+  const collectionsData = useCollectionsData();
   const contentsData = useContentsData();
 
   return (
@@ -460,6 +477,11 @@ export default function Sidebar() {
       <SidebarSection
         sectionId="nav"
         section={navigationData}
+        borderColor="var(--wiki-nav-border)"
+      />
+      <SidebarSection
+        sectionId="collections"
+        section={collectionsData}
         borderColor="var(--wiki-nav-border)"
       />
       <SidebarSection

--- a/wiki/src/hooks/useCollections.ts
+++ b/wiki/src/hooks/useCollections.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 
-export interface Group {
+export interface Collection {
   id: string
   name: string
   slug: string
@@ -12,14 +12,14 @@ export interface Group {
   wikiCount: number
 }
 
-export function useGroups() {
+export function useCollections() {
   return useQuery({
-    queryKey: ['groups'],
+    queryKey: ['collections'],
     queryFn: async () => {
       const res = await fetch('/api/groups', { credentials: 'include' })
-      if (!res.ok) throw new Error(`Groups fetch failed: ${res.status}`)
+      if (!res.ok) throw new Error(`Collections fetch failed: ${res.status}`)
       const data = await res.json()
-      return data.groups as Group[]
+      return data.groups as Collection[]
     },
     staleTime: 60_000,
   })

--- a/wiki/src/hooks/useExplorerData.ts
+++ b/wiki/src/hooks/useExplorerData.ts
@@ -5,7 +5,7 @@ import { useWikis } from '@/hooks/useWikis'
 import { useFragments } from '@/hooks/useFragments'
 import { usePeople } from '@/hooks/usePeople'
 import { useEntries } from '@/hooks/useEntries'
-import { useGroups, type Group } from '@/hooks/useGroups'
+import { useCollections, type Collection } from '@/hooks/useCollections'
 import type { ExplorerFilters } from '@/hooks/useExplorerFilters'
 import { ROUTES } from '@/lib/routes'
 
@@ -15,9 +15,9 @@ export interface ExplorerItem {
   type: 'fragment' | 'wiki' | 'person' | 'entry'
   subtype: string | null
   title: string
-  groupId: string | null
-  groupName: string | null
-  groupColor: string | null
+  collectionId: string | null
+  collectionName: string | null
+  collectionColor: string | null
   date: string
   href: string
 }
@@ -32,28 +32,28 @@ export function useExplorerData(filters: ExplorerFilters) {
   const fragmentsQuery = useFragments({ limit: 500 })
   const peopleQuery = usePeople({ limit: 500 })
   const entriesQuery = useEntries({ limit: 500 })
-  const groupsQuery = useGroups()
+  const collectionsQuery = useCollections()
 
   const isLoading =
-    wikisQuery.isLoading || fragmentsQuery.isLoading || peopleQuery.isLoading || entriesQuery.isLoading || groupsQuery.isLoading
+    wikisQuery.isLoading || fragmentsQuery.isLoading || peopleQuery.isLoading || entriesQuery.isLoading || collectionsQuery.isLoading
   const isError =
-    wikisQuery.isError || fragmentsQuery.isError || peopleQuery.isError || entriesQuery.isError || groupsQuery.isError
+    wikisQuery.isError || fragmentsQuery.isError || peopleQuery.isError || entriesQuery.isError || collectionsQuery.isError
 
   const items = useMemo(() => {
     const result: ExplorerItem[] = []
 
     // Wikis (threads)
     for (const wiki of wikisQuery.data?.wikis ?? []) {
-      // TODO: resolve group membership when API supports it
+      // TODO: resolve collection membership when API supports it
       result.push({
         id: wiki.id,
         lookupKey: wiki.lookupKey,
         type: 'wiki',
         subtype: capitalize(wiki.type),
         title: wiki.name,
-        groupId: null,
-        groupName: null,
-        groupColor: null,
+        collectionId: null,
+        collectionName: null,
+        collectionColor: null,
         date: wiki.updatedAt,
         href: `/wiki/${wiki.lookupKey}`,
       })
@@ -67,9 +67,9 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'fragment',
         subtype: capitalize(frag.type),
         title: frag.title,
-        groupId: null,
-        groupName: null,
-        groupColor: null,
+        collectionId: null,
+        collectionName: null,
+        collectionColor: null,
         date: frag.updatedAt,
         href: ROUTES.fragment(frag.lookupKey),
       })
@@ -83,9 +83,9 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'person',
         subtype: null,
         title: person.name,
-        groupId: null,
-        groupName: null,
-        groupColor: null,
+        collectionId: null,
+        collectionName: null,
+        collectionColor: null,
         date: person.updatedAt,
         href: ROUTES.person(person.lookupKey),
       })
@@ -99,9 +99,9 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'entry',
         subtype: null,
         title: entry.title,
-        groupId: null,
-        groupName: null,
-        groupColor: null,
+        collectionId: null,
+        collectionName: null,
+        collectionColor: null,
         date: entry.createdAt,
         href: ROUTES.entry(entry.lookupKey),
       })
@@ -113,9 +113,9 @@ export function useExplorerData(filters: ExplorerFilters) {
       filtered = filtered.filter((item) => filters.types.includes(item.type))
     }
 
-    // Apply group filter
-    if (filters.group) {
-      filtered = filtered.filter((item) => item.groupId === filters.group)
+    // Apply collection filter
+    if (filters.collection) {
+      filtered = filtered.filter((item) => item.collectionId === filters.collection)
     }
 
     // Apply sort
@@ -134,11 +134,11 @@ export function useExplorerData(filters: ExplorerFilters) {
     peopleQuery.data,
     entriesQuery.data,
     filters.types,
-    filters.group,
+    filters.collection,
     filters.sort,
   ])
 
-  const groups: Group[] = groupsQuery.data ?? []
+  const collections: Collection[] = collectionsQuery.data ?? []
 
-  return { items, isLoading, isError, groups }
+  return { items, isLoading, isError, collections }
 }

--- a/wiki/src/hooks/useExplorerFilters.ts
+++ b/wiki/src/hooks/useExplorerFilters.ts
@@ -8,7 +8,7 @@ export type ExplorerType = (typeof EXPLORER_TYPES)[number]
 
 export interface ExplorerFilters {
   types: string[]
-  group: string | null
+  collection: string | null
   sort: 'recent' | 'oldest' | 'alpha'
 }
 
@@ -28,9 +28,9 @@ export function useExplorerFilters() {
   const filters = useMemo<ExplorerFilters>(() => {
     const rawType = searchParams.get('type')
     const types = rawType ? rawType.split(',').filter(Boolean) : []
-    const group = searchParams.get('group') ?? null
+    const collection = searchParams.get('collection') ?? null
     const sort = parseSort(searchParams.get('sort'))
-    return { types, group, sort }
+    return { types, collection, sort }
   }, [searchParams])
 
   const setFilter = useCallback(
@@ -44,11 +44,11 @@ export function useExplorerFilters() {
         } else {
           next.set('type', arr.join(','))
         }
-      } else if (key === 'group') {
+      } else if (key === 'collection') {
         if (value === null || value === '') {
-          next.delete('group')
+          next.delete('collection')
         } else {
-          next.set('group', value as string)
+          next.set('collection', value as string)
         }
       } else if (key === 'sort') {
         if (value === 'recent' || value === null) {
@@ -69,7 +69,7 @@ export function useExplorerFilters() {
   }, [router])
 
   const hasActiveFilters = useMemo(() => {
-    return filters.types.length > 0 || filters.group !== null || filters.sort !== 'recent'
+    return filters.types.length > 0 || filters.collection !== null || filters.sort !== 'recent'
   }, [filters])
 
   return { filters, setFilter, clearFilters, hasActiveFilters }


### PR DESCRIPTION
## Summary

- **Rename Group to Collection** in the wiki frontend (hooks, explorer page, filters) -- clearer terminology for users (#185)
- **Add Collections section** to the sidebar between Navigation and Wiki Types, using live API data (#45)
- **Create RELATED_TO edges** at classification time when fragments are filed into wikis -- uses cosine similarity >= 0.75 threshold with bidirectional FRAGMENT_RELATED_TO_FRAGMENT edges (#163)
- **Surface related fragments** in the fragment detail API response and UI -- shows linked fragments with similarity scores below the backlinks section (#164)
- **Emit related_detected audit events** bidirectionally so the timeline endpoint surfaces when fragment relationships are detected (#165)

## Commits
1. `refactor(wiki): rename Group to Collection in frontend` (Fixes #185)
2. `feat(wiki): add Collections section to sidebar` (Fixes #45)
3. `feat(pipeline): create RELATED_TO edges at classification time` (Fixes #163)
4. `feat(api): surface related fragments in fragment detail` (Fixes #164)
5. `feat(pipeline): emit related_detected audit events for timeline` (Fixes #165)

## Test plan
- [ ] Verify explorer page renders with "Collection" labels instead of "Group"
- [ ] Verify sidebar shows Collections section between Navigation and Wiki Types
- [ ] Verify `?collection=` URL param works for filtering
- [ ] Verify fragment detail API returns `relatedFragments` array
- [ ] Verify Related Fragments section renders on fragment detail page with similarity percentages
- [ ] Verify audit_log table receives `related_detected` events for both fragments in a relationship
- [ ] Verify FRAGMENT_RELATED_TO_FRAGMENT edges are created bidirectionally during classification