### PR TITLE
docs(uat): amend plans 22 + 99 (covers #167, #160, favicon)

### DIFF
--- a/.uat/plans/22-onboarding-demo-seed.md
+++ b/.uat/plans/22-onboarding-demo-seed.md
@@ -432,6 +432,61 @@ else
   fail "7e. partial index missing or non-partial — retry scan will degrade"
 fi
 
+# ── 8. wikis.description column accepts INSERTs ────────────
+# Regression guard for #167. Pre-fix every wiki INSERT failed because
+# drizzle's insert lists the description column but no migration created
+# it (visible as a swallowed error in seedDemoWiki on first-user
+# provisioning, plus 500s on MCP create_wiki and HTTP POST /wikis).
+# This step proves the seeded wiki row is readable on .description AND
+# a fresh HTTP create_wiki round-trips through 2xx.
+
+# 8a. The seed succeeded — verified by step 2b/7a above. Strengthen it:
+# the description column is readable on the seeded row (i.e. migration
+# 0007 actually applied, not just present in the file).
+DESC_COL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" "$SERVER_URL/wikis?limit=50")
+DESC_COL_OK=$(psql -t -A -c "SELECT description IS NOT NULL FROM wikis WHERE slug='transformer-architecture' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+if [ "$DESC_COL_OK" = "t" ]; then
+  pass "8a. wikis.description column readable on seeded row (migration 0007 applied)"
+else
+  fail "8a. wikis.description column missing on seeded row — migration 0007 did not apply"
+fi
+
+# 8b. Cross-surface: HTTP POST /wikis succeeds. Pre-fix this 500'd
+# because the column referenced in the INSERT didn't exist in the DB.
+RESP_CODE=$(curl -s -o /tmp/uat-22-create-wiki.json -w "%{http_code}" -b "$COOKIE_JAR" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d '{"name":"UAT description test","type":"log"}' \
+  "$SERVER_URL/wikis")
+if [ "$RESP_CODE" = "200" ] || [ "$RESP_CODE" = "201" ]; then
+  pass "8b. HTTP POST /wikis returns $RESP_CODE (description column present in DB)"
+  # Cleanup: soft-delete the UAT row so downstream plans see a clean
+  # seeded fixture. Response shape carries both .lookupKey and .id —
+  # prefer lookupKey since that's the documented routing key.
+  KEY=$(jq -r '.lookupKey // .id' /tmp/uat-22-create-wiki.json 2>/dev/null)
+  if [ -n "$KEY" ] && [ "$KEY" != "null" ]; then
+    curl -s -o /dev/null -X DELETE -b "$COOKIE_JAR" \
+      -H "Origin: http://localhost:3000" "$SERVER_URL/wikis/$KEY" || true
+  fi
+else
+  fail "8b. HTTP POST /wikis returned $RESP_CODE — description column may be missing"
+fi
+
+# ── 9. Embedding retry execution ────────────────────────────
+# step 9 graduates from SKIP to a real assertion once /admin/scheduler/run-now/embedding-retry exists (PR D)
+#
+# Plan 22 step 7c only proves the unembedded count is observable. A real
+# assertion that the retry worker executes — i.e. the end-to-end
+# correctness of #151 — needs a force-trigger debug endpoint so UAT can
+# drive convergence to zero without waiting for the 15-min scheduler
+# tick. That endpoint (POST /admin/scheduler/run-now/:jobName, gated by
+# NODE_ENV !== 'production') is planned in PR D of this workstream.
+#
+# Until PR D lands, mark this step SKIP. The placeholder keeps the
+# numbering stable so PR D is a pure additive replacement.
+skip "9. embedding retry execution — debug endpoint not yet present"
+
 # ── Cleanup ──────────────────────────────────────────────────
 npx agent-browser close 2>/dev/null || true
 
@@ -452,6 +507,8 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 5 | Explorer lists the seeded wiki; click → detail page with rendered body | onboarding landing path |
 | 6 | Deleting the demo wiki + subsequent sign-in does NOT re-seed (intentional — `ensureFirstUser` only fires when users table is empty); CLI `seed-fixture` remains the documented recovery path | bootstrap gate policy |
 | 7 | Invariants: wiki RESOLVED; embedding retry scheduler registered; unembedded count observable; migration 0006 applied with partial index | #150 + #151 |
+| 8 | `wikis.description` column readable on the seeded row; fresh HTTP `POST /wikis` returns 2xx (cleanup deletes the UAT row) | #167 / migration 0007 |
+| 9 | Embedding retry worker actually heals NULL embeddings — SKIP until `POST /admin/scheduler/run-now/embedding-retry` debug endpoint lands (PR D) | #151 |
 
 ---
 

--- a/.uat/plans/22-onboarding-demo-seed.md
+++ b/.uat/plans/22-onboarding-demo-seed.md
@@ -372,7 +372,7 @@ fi
 # A seeded wiki that never reached RESOLVED means the seed path broke
 # before finalization — the wiki listing would show it but detail pages
 # would refuse to render.
-WIKI_STATE=$(psql -t -A -c "SELECT state FROM wikis WHERE slug='transformer-architecture' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+WIKI_STATE=$(psql "$DATABASE_URL" -t -A -c "SELECT state FROM wikis WHERE slug='transformer-architecture' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
 if [ "$WIKI_STATE" = "RESOLVED" ]; then
   pass "7a. seeded demo wiki is RESOLVED"
 else
@@ -406,7 +406,7 @@ fi
 # that long — but a SELECT that returns a definite integer proves the
 # index exists and the columns were migrated. Logs the count so a
 # soak test downstream can assert convergence to zero.
-UNEMBEDDED=$(psql -t -A -c "SELECT COUNT(*) FROM fragments WHERE embedding IS NULL AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+UNEMBEDDED=$(psql "$DATABASE_URL" -t -A -c "SELECT COUNT(*) FROM fragments WHERE embedding IS NULL AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
 if [[ "$UNEMBEDDED" =~ ^[0-9]+$ ]]; then
   pass "7c. unembedded-fragments count is observable (=$UNEMBEDDED)"
   echo "    ↳ soak target: this value should trend to 0 as the retry scheduler runs"
@@ -415,8 +415,8 @@ else
 fi
 
 # 7d. Columns added by migration 0006 exist on fragments.
-HAS_ATTEMPT_COL=$(psql -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_attempt_count'" 2>/dev/null | tr -d '[:space:]')
-HAS_LAST_COL=$(psql -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_last_attempt_at'" 2>/dev/null | tr -d '[:space:]')
+HAS_ATTEMPT_COL=$(psql "$DATABASE_URL" -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_attempt_count'" 2>/dev/null | tr -d '[:space:]')
+HAS_LAST_COL=$(psql "$DATABASE_URL" -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='fragments' AND column_name='embedding_last_attempt_at'" 2>/dev/null | tr -d '[:space:]')
 if [ "$HAS_ATTEMPT_COL" = "1" ] && [ "$HAS_LAST_COL" = "1" ]; then
   pass "7d. embedding retry bookkeeping columns present"
 else
@@ -425,7 +425,7 @@ fi
 
 # 7e. The partial index #151 added exists. Without it the retry scan
 # degrades to a table scan at scale.
-HAS_PARTIAL_IDX=$(psql -t -A -c "SELECT 1 FROM pg_indexes WHERE indexname='fragments_embedding_null_idx' AND indexdef LIKE '%WHERE%embedding IS NULL%deleted_at IS NULL%'" 2>/dev/null | tr -d '[:space:]')
+HAS_PARTIAL_IDX=$(psql "$DATABASE_URL" -t -A -c "SELECT 1 FROM pg_indexes WHERE indexname='fragments_embedding_null_idx' AND indexdef LIKE '%WHERE%embedding IS NULL%deleted_at IS NULL%'" 2>/dev/null | tr -d '[:space:]')
 if [ "$HAS_PARTIAL_IDX" = "1" ]; then
   pass "7e. fragments_embedding_null_idx is partial on embedding/deleted_at"
 else
@@ -441,15 +441,14 @@ fi
 # a fresh HTTP create_wiki round-trips through 2xx.
 
 # 8a. The seed succeeded — verified by step 2b/7a above. Strengthen it:
-# the description column is readable on the seeded row (i.e. migration
-# 0007 actually applied, not just present in the file).
-DESC_COL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE_JAR" \
-  -H "Origin: http://localhost:3000" "$SERVER_URL/wikis?limit=50")
-DESC_COL_OK=$(psql -t -A -c "SELECT description IS NOT NULL FROM wikis WHERE slug='transformer-architecture' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
-if [ "$DESC_COL_OK" = "t" ]; then
-  pass "8a. wikis.description column readable on seeded row (migration 0007 applied)"
+# the description column exists on wikis (i.e. migration 0007 applied,
+# not just present in the file). Use information_schema rather than a
+# value test — the seeded row's description may legitimately be NULL.
+HAS_DESC_COL=$(psql "$DATABASE_URL" -t -A -c "SELECT 1 FROM information_schema.columns WHERE table_name='wikis' AND column_name='description'" 2>/dev/null | tr -d '[:space:]')
+if [ "$HAS_DESC_COL" = "1" ]; then
+  pass "8a. wikis.description column exists (migration 0007 applied)"
 else
-  fail "8a. wikis.description column missing on seeded row — migration 0007 did not apply"
+  fail "8a. wikis.description column missing — migration 0007 did not apply"
 fi
 
 # 8b. Cross-surface: HTTP POST /wikis succeeds. Pre-fix this 500'd

--- a/.uat/plans/99-endpoint-sweep.md
+++ b/.uat/plans/99-endpoint-sweep.md
@@ -32,6 +32,7 @@ cd "${PROJECT_ROOT:-.}"
 source core/.env 2>/dev/null || true
 
 SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
 COOKIE_JAR=$(mktemp /tmp/uat-cookies-99-XXXXXX.txt)
 trap 'rm -f "$COOKIE_JAR"' EXIT
 
@@ -117,6 +118,37 @@ sweep() {
   pass "$step $path — 200, valid JSON, shape OK"
 }
 
+# ── Helper: sweep one binary endpoint ────────────────────────
+# Like sweep, but for binary responses — verifies status, content-type
+# prefix, and non-empty body. The base URL is configurable so the same
+# helper handles both core (favicon) and the wiki frontend (image
+# assets) without duplicating the curl shape.
+# Args: $1 = step id, $2 = URL path, $3 = expected content-type prefix,
+#       $4 = optional base URL (default: $SERVER_URL)
+sweep_binary() {
+  local step="$1"
+  local path="$2"
+  local expected_ct_prefix="$3"
+  local base="${4:-$SERVER_URL}"
+  local headers ct body_len
+  headers=$(curl -sI -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$base$path")
+  body_len=$(echo "$headers" | awk -F': ' 'tolower($1)=="content-length"{print $2}' | tr -d '\r')
+  ct=$(echo "$headers" | awk -F': ' 'tolower($1)=="content-type"{print $2}' | tr -d '\r')
+  if echo "$headers" | head -1 | grep -q ' 200'; then
+    if echo "$ct" | grep -q "^$expected_ct_prefix"; then
+      if [ -n "$body_len" ] && [ "$body_len" -gt "0" ]; then
+        pass "$step $base$path 200 + $expected_ct_prefix + ${body_len}B body"
+      else
+        fail "$step $base$path 200 + correct CT but empty body"
+      fi
+    else
+      fail "$step $base$path 200 but content-type='$ct' (expected prefix '$expected_ct_prefix')"
+    fi
+  else
+    fail "$step $base$path non-200: $(echo "$headers" | head -1)"
+  fi
+}
+
 # ── 1. Listing endpoints ─────────────────────────────────────
 sweep "1a." "/wikis?limit=10"                    '.wikis | type == "array"'
 sweep "1b." "/fragments?limit=10"                '.fragments | type == "array"'
@@ -168,6 +200,18 @@ sweep "4a." "/search?q=attention&limit=5"        '.results // .hits | type == "a
 # ── 5. System / misc ─────────────────────────────────────────
 sweep "5a." "/system/status"                     '.status | type == "string"'
 
+# 5b. Favicon — covers #156. The route was added so MCP clients (and
+# browsers hitting the core URL directly) stop falling back to an ugly
+# placeholder. Pre-fix this 404'd; the smoke is one-line on $SERVER_URL.
+sweep_binary "5b." "/favicon.ico" "image/x-icon"
+
+# 5c. Seeded demo image asset — covers #160. The Transformer fixture's
+# infobox.image.url points at /images/transformer-architecture.svg; the
+# asset is served by the wiki Next.js frontend (NOT core), so this sweep
+# targets $WIKI_URL. Pre-#160 the SVG didn't exist and the renderer's
+# image branch had nothing to load.
+sweep_binary "5c." "/images/transformer-architecture.svg" "image/svg+xml" "$WIKI_URL"
+
 # ── 6. Cross-kind: every response referenced by the sidecar parses ───
 # Walks the wiki detail's `refs` map — every person/fragment/wiki/entry
 # reference must resolve to a live detail endpoint. Catches "seed created
@@ -198,6 +242,26 @@ else
   fail "6. $BROKEN_REFS sidecar refs point at missing or erroring detail rows"
 fi
 
+# ── 7. Cross-asset linkage — sidecar infobox.image.url resolves ──
+# Covers #160. The wiki sidecar's infobox may carry an image URL; the
+# renderer's image branch is dead weight unless that URL is fetchable.
+# This step closes the loop: take the URL the API serves and confirm
+# it returns 200 from the wiki frontend (which is where /images/* is
+# hosted — NOT core). If the seeded fixture doesn't include an image,
+# this is a documented SKIP.
+IMAGE_URL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/wikis/$WIKI_KEY" | jq -r '.infobox.image.url // empty')
+if [ -n "$IMAGE_URL" ]; then
+  CODE=$(curl -sI -o /dev/null -w "%{http_code}" "$WIKI_URL$IMAGE_URL")
+  if [ "$CODE" = "200" ]; then
+    pass "7a. infobox.image.url ($IMAGE_URL) resolves 200 on \$WIKI_URL"
+  else
+    fail "7a. infobox.image.url $IMAGE_URL returned $CODE on \$WIKI_URL"
+  fi
+else
+  skip "7a. infobox.image.url not present on this wiki — nothing to resolve"
+fi
+
 echo ""
 echo "$PASS passed, $FAIL failed, $SKIP skipped"
 ```
@@ -213,8 +277,9 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 2 | Detail endpoints (`/wikis/:id` incl. sidecar keys, `/wikis/:id/timeline`, `/wikis/:id/history`, `/fragments/:id`, `/people/:id`) all 200 + shape | detail surface; #139 regression guard |
 | 3 | `/graph` returns valid nodes + edges; every node has a schema-known type | #153 regression guard |
 | 4 | `/search` returns results shape | search endpoint |
-| 5 | `/system/status` returns 200 + `.status` | system endpoint |
+| 5 | `/system/status` returns 200 + `.status`; `/favicon.ico` (5b) returns 200 + `image/x-icon` on `$SERVER_URL`; `/images/transformer-architecture.svg` (5c) returns 200 + `image/svg+xml` on `$WIKI_URL` | system endpoint; #156 (favicon); #160 (SVG asset) |
 | 6 | Every ref in the wiki sidecar resolves to a live detail endpoint | cross-kind integrity |
+| 7 | The wiki sidecar's `infobox.image.url`, when present, resolves 200 on `$WIKI_URL` (cross-asset linkage) | #160 |
 
 ---
 

--- a/.uat/plans/99-endpoint-sweep.md
+++ b/.uat/plans/99-endpoint-sweep.md
@@ -130,11 +130,17 @@ sweep_binary() {
   local path="$2"
   local expected_ct_prefix="$3"
   local base="${4:-$SERVER_URL}"
-  local headers ct body_len
-  headers=$(curl -sI -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$base$path")
-  body_len=$(echo "$headers" | awk -F': ' 'tolower($1)=="content-length"{print $2}' | tr -d '\r')
-  ct=$(echo "$headers" | awk -F': ' 'tolower($1)=="content-type"{print $2}' | tr -d '\r')
-  if echo "$headers" | head -1 | grep -q ' 200'; then
+  local body tmp_body http_code ct body_len
+  tmp_body=$(mktemp /tmp/uat-99-binary-XXXXXX)
+  # GET (not HEAD): some Hono static handlers omit Content-Length on
+  # HEAD responses (favicon does this), so measure the actual download.
+  http_code=$(curl -s -o "$tmp_body" -w "%{http_code}|%{content_type}|%{size_download}" \
+    -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$base$path")
+  ct=$(echo "$http_code" | awk -F'|' '{print $2}')
+  body_len=$(echo "$http_code" | awk -F'|' '{print $3}')
+  http_code=$(echo "$http_code" | awk -F'|' '{print $1}')
+  rm -f "$tmp_body"
+  if [ "$http_code" = "200" ]; then
     if echo "$ct" | grep -q "^$expected_ct_prefix"; then
       if [ -n "$body_len" ] && [ "$body_len" -gt "0" ]; then
         pass "$step $base$path 200 + $expected_ct_prefix + ${body_len}B body"
@@ -145,7 +151,7 @@ sweep_binary() {
       fail "$step $base$path 200 but content-type='$ct' (expected prefix '$expected_ct_prefix')"
     fi
   else
-    fail "$step $base$path non-200: $(echo "$headers" | head -1)"
+    fail "$step $base$path non-200: HTTP $http_code"
   fi
 }
 


### PR DESCRIPTION
## Summary

PR C of a 4-PR UAT workstream (see `__uat_workstream.md` Sections 3.3 + 3.4). Two amendments to existing UAT plans, one atomic commit each.

### Plan 22 — `.uat/plans/22-onboarding-demo-seed.md`

- **Step 8 (new)** — `wikis.description` insert smoke. Covers #167 / migration 0007. Reads `description` on the seeded row; round-trips `POST /wikis` (the path that 500'd pre-fix); cleans up the UAT row inline via `DELETE /wikis/$KEY`.
- **Step 9 (SKIP placeholder)** — reserves the slot for the embedding-retry execution assertion (#151) that graduates from SKIP once `POST /admin/scheduler/run-now/embedding-retry` lands. Header comment explicitly notes this lands in PR D so the upgrade is a pure additive replacement and avoids merge conflict with the parallel PR.
- Pass/Fail Summary table extended with rows 8 + 9.

### Plan 99 — `.uat/plans/99-endpoint-sweep.md`

- **`sweep_binary` helper (new)** — companion to the existing `sweep`, for binary endpoints. Asserts status + content-type prefix + non-empty body. Optional 4th arg overrides the base URL so the same helper drives both core (favicon) and the wiki frontend (image assets).
- **Step 5b** — favicon smoke against `$SERVER_URL` (covers #156's `/favicon.ico` route).
- **Step 5c** — `/images/transformer-architecture.svg` smoke against `$WIKI_URL` (covers #160's seeded SVG; the asset lives in `wiki/public/images/`, not core).
- **Step 7** — cross-asset linkage: takes the wiki sidecar's `infobox.image.url` and confirms it resolves 200 on `$WIKI_URL`. SKIPs cleanly when the fixture has no image.
- `WIKI_URL` env var added to the script preamble (default `http://localhost:8080`).
- Pass/Fail Summary table extended with row 7 and updated row 5.

## Drift adapted to

The workstream doc was authored against `4aec4ec`; `main` now has the thread→wiki rename and the bouncer/description follow-up commit. Verified before writing:

- `wikis.description` exists in `core/src/db/schema.ts:235` and migration `0007_wikis_add_description.sql` is present.
- Seeded fixture slug is still `transformer-architecture`.
- Wiki creation route is `POST /wikis` (NOT `/api/wikis`) — `app.route('/wikis', wikisRoutes)` in `core/src/index.ts:142`.
- Create-wiki body field is `name` (not `title`) per `createWikiBodySchema`.
- Response shape from `POST /wikis` carries both `id` and `lookupKey`, so `jq -r '.lookupKey // .id'` works as the doc snippet had it.
- Favicon route is `/favicon.ico` on `$SERVER_URL`, content-type `image/x-icon` (`core/src/index.ts:112`).
- Sidecar `infobox.image.url` shape is `z.object({ url, alt }).optional()` per `packages/shared/src/schemas/sidecar.ts:79`.
- `wiki/public/images/transformer-architecture.svg` exists.

## Test plan

- [x] `bash -n` clean on extracted bash blocks for both plans (`tmp/uat-22-wt.sh`, `tmp/uat-99-wt.sh`)
- [ ] Live sweep deferred to orchestrator (sequential live run after PR D + PR A/B)
- [ ] PR D will replace step 9's SKIP body with the real assertion logic from workstream Section 3.3