### PR TITLE
feat(admin): debug scheduler run-now endpoint (dev-only)

### DIFF
--- a/core/src/routes/admin.test.ts
+++ b/core/src/routes/admin.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// Capture every queue.add() call so we can assert payload + options.
+const mockQueueAdd = vi
+  .fn<(name: string, data: unknown, opts?: unknown) => Promise<{ id: string }>>()
+  .mockImplementation(async (_name, _data, opts) => ({
+    id: (opts as { jobId?: string } | undefined)?.jobId ?? 'mock-bull-job-id',
+  }))
+
+const mockGetQueue = vi.fn().mockReturnValue({ add: mockQueueAdd })
+
+vi.mock('../queue/producer.js', () => ({
+  producer: {
+    getQueue: (...args: unknown[]) => mockGetQueue(...args),
+  },
+}))
+
+// admin.ts imports db + schemas, but the scheduler endpoint never touches them.
+// Stub minimally so module import succeeds.
+vi.mock('../db/client.js', () => ({
+  db: { execute: vi.fn() },
+}))
+
+vi.mock('../db/schema.js', () => ({
+  fragments: {},
+  entries: {},
+}))
+
+vi.mock('../schemas/admin.schema.js', () => ({
+  retryStuckDryRunResponseSchema: { parse: (x: unknown) => x },
+  retryStuckResponseSchema: { parse: (x: unknown) => x },
+}))
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * admin.ts registers the scheduler route at module-load time, gated by
+ * NODE_ENV. Each test resets modules + sets the env, then imports a fresh
+ * copy of the router so registration evaluates against the current env.
+ */
+async function loadAdminApp(nodeEnv: string) {
+  vi.resetModules()
+  process.env.NODE_ENV = nodeEnv
+  const { adminRoutes } = await import('./admin.js')
+  const app = new Hono()
+  app.route('/admin', adminRoutes)
+  return app
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('POST /admin/scheduler/run-now/:jobName', () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+
+  beforeEach(() => {
+    mockQueueAdd.mockClear()
+    mockGetQueue.mockClear()
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV
+  })
+
+  it('happy path — embedding-retry: enqueues job and returns ok + jobId', async () => {
+    const app = await loadAdminApp('development')
+
+    const res = await app.request('/admin/scheduler/run-now/embedding-retry', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; jobId: string }
+    expect(body.ok).toBe(true)
+    expect(typeof body.jobId).toBe('string')
+    expect(body.jobId.length).toBeGreaterThan(0)
+
+    // Queue resolved by canonical scheduler queue name.
+    expect(mockGetQueue).toHaveBeenCalledTimes(1)
+    expect(mockGetQueue).toHaveBeenCalledWith('regen-scheduler-queue')
+
+    // Bull job enqueued with the discriminated SchedulerJob payload the
+    // existing worker dispatches by job.type.
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1)
+    const firstCall = mockQueueAdd.mock.calls[0]
+    if (!firstCall) throw new Error('expected queue.add to have been called')
+    const [bullName, payload, options] = firstCall
+    expect(bullName).toBe('embedding-retry')
+    expect(payload).toMatchObject({
+      type: 'embedding-retry',
+      triggeredBy: 'scheduler',
+    })
+    expect(payload).toHaveProperty('jobId')
+    expect(payload).toHaveProperty('enqueuedAt')
+    expect(options).toMatchObject({ jobId: (payload as { jobId: string }).jobId })
+  })
+
+  it('happy path — regen-batch: enqueues with regen-batch type', async () => {
+    const app = await loadAdminApp('development')
+
+    const res = await app.request('/admin/scheduler/run-now/regen-batch', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; jobId: string }
+    expect(body.ok).toBe(true)
+
+    const firstCall = mockQueueAdd.mock.calls[0]
+    if (!firstCall) throw new Error('expected queue.add to have been called')
+    const [bullName, payload] = firstCall
+    expect(bullName).toBe('regen-batch')
+    expect(payload).toMatchObject({
+      type: 'regen-batch',
+      triggeredBy: 'scheduler',
+    })
+  })
+
+  it('rejects unknown job names with 400 + structured error', async () => {
+    const app = await loadAdminApp('development')
+
+    const res = await app.request('/admin/scheduler/run-now/totally-bogus', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: "unknown job 'totally-bogus'" })
+    expect(mockQueueAdd).not.toHaveBeenCalled()
+    expect(mockGetQueue).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 in production (route not registered at all)', async () => {
+    const app = await loadAdminApp('production')
+
+    const res = await app.request('/admin/scheduler/run-now/embedding-retry', {
+      method: 'POST',
+    })
+
+    // Hono's default 404 fires because the route does not exist when
+    // NODE_ENV === 'production' at module-load time.
+    expect(res.status).toBe(404)
+    expect(mockQueueAdd).not.toHaveBeenCalled()
+  })
+})

--- a/core/src/routes/admin.ts
+++ b/core/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { sql } from 'drizzle-orm'
-import type { LinkJob } from '@robin/queue'
+import type { LinkJob, SchedulerJob } from '@robin/queue'
+import { QUEUE_NAMES } from '@robin/queue'
 import { db } from '../db/client.js'
 import { fragments, entries } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
@@ -13,6 +14,69 @@ import {
 const log = logger.child({ component: 'admin' })
 
 export const adminRoutes = new Hono()
+
+/**
+ * Whitelist of scheduler job names that can be force-triggered via the
+ * debug endpoint. Restricting to these names prevents arbitrary
+ * job-name injection into the scheduler queue.
+ */
+const SCHEDULER_RUN_NOW_ALLOWED = ['embedding-retry', 'regen-batch'] as const
+type SchedulerRunNowJobName = (typeof SCHEDULER_RUN_NOW_ALLOWED)[number]
+
+/**
+ * POST /admin/scheduler/run-now/:jobName  (dev-only)
+ *
+ * Force-triggers a scheduled job (`embedding-retry` or `regen-batch`) by
+ * adding a one-shot job onto the scheduler queue with the same payload
+ * shape the cron-driven scheduler emits. The existing scheduler worker
+ * (see `core/src/queue/worker.ts`) dispatches by `job.type`, so this
+ * route just enqueues a payload that matches the discriminated union.
+ *
+ * Registration is gated on `NODE_ENV !== 'production'` so the route is
+ * literally absent in prod builds. A runtime 404 short-circuit protects
+ * against env-mutation-after-start as defense-in-depth.
+ *
+ * Used by `.uat/plans/22-onboarding-demo-seed.md` step 9 to assert the
+ * embedding-retry worker actually heals NULL embeddings.
+ */
+if (process.env.NODE_ENV !== 'production') {
+  adminRoutes.post('/scheduler/run-now/:jobName', async (c) => {
+    if (process.env.NODE_ENV === 'production') {
+      return c.json({ error: 'not available' }, 404)
+    }
+
+    const jobName = c.req.param('jobName')
+    if (!SCHEDULER_RUN_NOW_ALLOWED.includes(jobName as SchedulerRunNowJobName)) {
+      return c.json({ error: `unknown job '${jobName}'` }, 400)
+    }
+
+    const allowedName = jobName as SchedulerRunNowJobName
+    const debugId = `${allowedName}-debug-${Date.now()}`
+    const payload: SchedulerJob =
+      allowedName === 'regen-batch'
+        ? {
+            type: 'regen-batch',
+            jobId: debugId,
+            triggeredBy: 'scheduler',
+            enqueuedAt: new Date().toISOString(),
+          }
+        : {
+            type: 'embedding-retry',
+            jobId: debugId,
+            triggeredBy: 'scheduler',
+            enqueuedAt: new Date().toISOString(),
+          }
+
+    const queue = producer.getQueue(QUEUE_NAMES.scheduler)
+    const bullJob = await queue.add(allowedName, payload, { jobId: debugId })
+
+    log.info(
+      { jobName: allowedName, jobId: bullJob.id ?? debugId },
+      'scheduler run-now triggered'
+    )
+    return c.json({ ok: true, jobId: bullJob.id ?? debugId })
+  })
+}
 
 /**
  * POST /admin/retry-stuck


### PR DESCRIPTION
## Summary

Adds a dev-only HTTP endpoint that lets a UAT plan force-trigger a scheduler-queue cron job by name.

- **New route:** \`POST /admin/scheduler/run-now/:jobName\` in \`core/src/routes/admin.ts\`.
- **Whitelist:** \`['embedding-retry', 'regen-batch']\`. Anything else returns \`400 { error: \"unknown job '<name>'\" }\`. Prevents arbitrary job-name injection.
- **Prod gate (registration):** \`if (process.env.NODE_ENV !== 'production')\` wraps \`adminRoutes.post(...)\`, so the route literally does not exist in prod builds.
- **Prod gate (runtime):** the handler also short-circuits with \`404 { error: 'not available' }\` if NODE_ENV mutates after start. Defense in depth.
- **Payload:** matches the existing \`SchedulerJob\` discriminated union (\`{ type, jobId, triggeredBy: 'scheduler', enqueuedAt }\`) so the existing scheduler worker (\`core/src/queue/worker.ts\`) dispatches it the same way it handles cron firings.
- **Queue name:** sourced from \`QUEUE_NAMES.scheduler\` (\`'regen-scheduler-queue'\`) — no hardcoded string.
- **Success shape:** \`{ ok: true, jobId: <bull job id> }\`.

## Why

\`.uat/plans/22-onboarding-demo-seed.md\` step 9 (added in PR C) currently lives in SKIP form so it doesn't fail when no debug surface exists. With this endpoint live, step 9 can be upgraded to a real end-to-end assertion that the embedding-retry worker (#151) actually heals NULL embeddings. That upgrade is the follow-up tracked in #197 — out of scope here to avoid a merge conflict with PR C.

Workstream doc reference: \`__uat_workstream.md\` Section 3.5.

## Tests

\`core/src/routes/admin.test.ts\` (new):

1. Happy path \`embedding-retry\`: 200 + ok+jobId, queue resolved by canonical name, payload shape matches SchedulerJob.
2. Happy path \`regen-batch\`: 200 + ok+jobId, payload type \`'regen-batch'\`.
3. Unknown name: 400 + \`{ error: \"unknown job '<name>'\" }\`, no queue interaction.
4. Production: 404, route not registered.

Producer / getQueue / DB / admin.schema are mocked. Each test re-imports the router with a fresh \`NODE_ENV\` so the registration gate evaluates per case.

## Verification

- \`pnpm -C core typecheck\` — clean
- \`pnpm -C core test src/routes/admin.test.ts\` — 4/4 pass
- \`npx biome lint ./src/routes/admin.ts ./src/routes/admin.test.ts\` — clean
- Full \`pnpm -C core test\` has 9 pre-existing failing files (DB-bound suites, e.g. \`wiki-update.test.ts\`, \`mcp-log-entry.test.ts\`). Verified those fail identically on \`main\` without this branch's changes — unrelated.

## Drift notes

- Doc was authored against \`4aec4ec\`; current \`main\` is \`d799be7\` (post thread→wiki rename + bouncer/description fixes).
- Doc payload sketch matched the actual \`SchedulerJob\` union — no deviation.
- Queue name in doc was a guess (\"likely \`scheduler-queue\`\"); actual is \`'regen-scheduler-queue'\` via \`QUEUE_NAMES.scheduler\`. Used the constant.
- Existing scheduler worker dispatcher (\`dispatchSchedulerJob\` in \`core/src/queue/worker.ts\`) already routes by \`job.type\`, so no worker-side change is needed to consume \`run-now\` triggers.

## Follow-ups

- [#197](https://github.com/withrobinhq/robinwiki/issues/197): upgrade plan 22 step 9 from SKIP to a real assertion using this endpoint.

## Refs

- Closes nothing directly. Refs #151 (embedding retry worker, the consumer of the \`embedding-retry\` job) and unblocks #197.

