### PR TITLE
fix(queue): use typed comparison for embedding-retry cutoff

### DIFF
--- a/core/src/queue/embedding-retry-worker.test.ts
+++ b/core/src/queue/embedding-retry-worker.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { fragments as realFragments } from '../db/schema.js'
 
 // ── Module-level mocks ─────────────────────────────────────────────────────
 
@@ -14,21 +16,25 @@ vi.mock('../lib/openrouter-config.js', () => ({
   loadOpenRouterConfig: () => loadOpenRouterConfigMock(),
 }))
 
-// Captured DB writes so tests can assert on them. The drizzle chain stubs
-// below push into these arrays in order.
+// Captured DB calls so tests can assert on them. The drizzle chain stubs
+// below push into these in order.
 const selectReturns: Array<Array<Record<string, unknown>>> = []
 const updateCapture: Array<{ set: Record<string, unknown> }> = []
+const whereCapture: Array<unknown> = []
 
 vi.mock('../db/client.js', () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          orderBy: () => ({
-            limit: () =>
-              Promise.resolve(selectReturns.shift() ?? []),
-          }),
-        }),
+        where: (clause: unknown) => {
+          whereCapture.push(clause)
+          return {
+            orderBy: () => ({
+              limit: () =>
+                Promise.resolve(selectReturns.shift() ?? []),
+            }),
+          }
+        },
       }),
     }),
     update: () => ({
@@ -40,16 +46,10 @@ vi.mock('../db/client.js', () => ({
   },
 }))
 
-vi.mock('../db/schema.js', () => ({
-  fragments: {
-    lookupKey: 'lookupKey',
-    content: 'content',
-    embedding: 'embedding',
-    embeddingAttemptCount: 'embedding_attempt_count',
-    embeddingLastAttemptAt: 'embedding_last_attempt_at',
-    deletedAt: 'deleted_at',
-  },
-}))
+// Note: we intentionally do NOT mock '../db/schema.js'. Using the real
+// fragments table is required for issue #216's regression test, which feeds
+// the captured where expression into PgDialect to validate that the Date
+// cutoff binds without throwing TypeError [ERR_INVALID_ARG_TYPE].
 
 const { processEmbeddingRetryJob } = await import('./embedding-retry-worker.js')
 
@@ -70,6 +70,7 @@ beforeEach(() => {
   loadOpenRouterConfigMock.mockReset()
   selectReturns.length = 0
   updateCapture.length = 0
+  whereCapture.length = 0
   loadOpenRouterConfigMock.mockResolvedValue({
     apiKey: 'k',
     models: { extraction: 'x', classification: 'y', wikiGeneration: 'z', embedding: 'e' },
@@ -115,6 +116,33 @@ describe('processEmbeddingRetryJob — issue #151', () => {
     expect(res.success).toBe(true)
     expect(embedTextMock).not.toHaveBeenCalled()
     expect(updateCapture).toHaveLength(0)
+  })
+
+  // Regression test for issue #216: prior to the fix, the worker passed a
+  // raw Date into a `sql\`...\`` template literal, which made the pg driver
+  // throw `TypeError [ERR_INVALID_ARG_TYPE]` at every 15-min cron tick. The
+  // fix uses Drizzle's typed `lt()` comparison, which normalizes Date into
+  // an ISO string param the driver accepts.
+  it('issue #216: serializes Date cutoff in where clause without throwing', async () => {
+    selectReturns.push([])
+    await processEmbeddingRetryJob(baseJob())
+    expect(whereCapture).toHaveLength(1)
+    // Sanity check: the captured where targets the real schema column so
+    // PgDialect can resolve column references during compilation.
+    expect(realFragments.embeddingLastAttemptAt).toBeDefined()
+    const dialect = new PgDialect()
+    expect(() => dialect.sqlToQuery(whereCapture[0] as never)).not.toThrow()
+    const compiled = dialect.sqlToQuery(whereCapture[0] as never)
+    expect(compiled.sql).toMatch(/embedding_last_attempt_at/)
+    expect(compiled.sql).toMatch(/is null/i)
+    // The cutoff Date must reach the param array as an ISO timestamp string,
+    // not a JS Date instance (which would crash the pg driver). Find the
+    // ISO string corresponding to a Date param.
+    const isoCutoff = compiled.params.find(
+      (p): p is string =>
+        typeof p === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(p)
+    )
+    expect(isoCutoff).toBeDefined()
   })
 
   it('processes multiple rows per invocation', async () => {

--- a/core/src/queue/embedding-retry-worker.ts
+++ b/core/src/queue/embedding-retry-worker.ts
@@ -1,5 +1,5 @@
 import type { EmbeddingRetryJob, JobResult } from '@robin/queue'
-import { and, isNull, sql } from 'drizzle-orm'
+import { and, isNull, lt, or, sql } from 'drizzle-orm'
 import { embedText, takeLastEmbedFailure } from '@robin/agent'
 import { db } from '../db/client.js'
 import { fragments } from '../db/schema.js'
@@ -64,8 +64,11 @@ export async function processEmbeddingRetryJob(
       and(
         isNull(fragments.embedding),
         isNull(fragments.deletedAt),
-        sql`${fragments.embeddingAttemptCount} < ${MAX_ATTEMPTS}`,
-        sql`(${fragments.embeddingLastAttemptAt} IS NULL OR ${fragments.embeddingLastAttemptAt} < ${cutoff})`
+        lt(fragments.embeddingAttemptCount, MAX_ATTEMPTS),
+        or(
+          isNull(fragments.embeddingLastAttemptAt),
+          lt(fragments.embeddingLastAttemptAt, cutoff)
+        )
       )
     )
     .orderBy(sql`${fragments.embeddingLastAttemptAt} NULLS FIRST`)


### PR DESCRIPTION
Closes #216.

## Summary
- `core/src/queue/embedding-retry-worker.ts` passed a JS `Date` directly into a Drizzle `sql` template literal, causing `TypeError [ERR_INVALID_ARG_TYPE]` every 15-min cron tick (visible in 04-24+ production logs for 24h+).
- Replace the raw `sql` fragment with Drizzle's typed `or(isNull(col), lt(col, cutoff))`, which serializes the Date through Drizzle's parameter binding as an ISO timestamp string the pg driver accepts. `MAX_ATTEMPTS` predicate also moves from `sql` to `lt(...)` for consistency.
- Adds a regression test that captures the worker's `where` expression and feeds it through `PgDialect.sqlToQuery()` to assert the cutoff binds as an ISO string param (not a `Date` instance). Verified the test fails on the buggy code and passes on the fix.

## Verification
- `pnpm -C core typecheck` — clean
- `pnpm -C core test src/queue/embedding-retry-worker.test.ts` — 5 passed (4 existing + 1 new regression)
- `npx biome lint core/src/queue/embedding-retry-worker.ts` — clean

## Bug autopsy
The original test mocked the entire drizzle chain with stub functions, so the buggy `sql\`< ${cutoff}\`` was never compiled by a real dialect. The new regression test imports the real `fragments` schema and runs the captured where expression through `PgDialect`, which is the same path the production query takes. Pattern to prevent: when mocking ORM call chains, verify the *expression* the code under test produces, not just that the chain methods are invoked.