### PR TITLE
fix(wiki): public wiki page 404s immediately after unpublish

### DIFF
--- a/wiki/src/app/(public)/p/[nanoid]/page.tsx
+++ b/wiki/src/app/(public)/p/[nanoid]/page.tsx
@@ -11,8 +11,11 @@ const API_BASE =
 async function fetchPublishedWiki(
   nanoid: string,
 ): Promise<PublishedWikiData | null> {
+  // Always revalidate publish-state on every request — the API is the source
+  // of truth and sets `Cache-Control: no-store`. Caching here would let an
+  // unpublished wiki keep rendering 200 until the cache window expires.
   const res = await fetch(`${API_BASE}/published/wiki/${nanoid}`, {
-    next: { revalidate: 60 },
+    cache: "no-store",
   });
   if (!res.ok) return null;
   return res.json();


### PR DESCRIPTION
## Summary
- The public published-wiki page (`wiki/src/app/(public)/p/[nanoid]/page.tsx`) used `next: { revalidate: 60 }` on its SSR fetch. After a wiki was unpublished the core API correctly returned 404 but the Next page kept serving the previously cached 200 response for up to 60 seconds.
- Switch the fetch to `cache: "no-store"` so publish-state is reauthorized against the API on every request. The core API already sets `Cache-Control: no-store`, so this aligns the page with the source of truth.

## Test plan
- [x] `pnpm -C core typecheck` clean
- [x] `npx tsc --noEmit` in `wiki/` clean for the touched file
- [x] Plan 28 (`.uat/plans/28-password-change-and-public-wiki.md`) end-to-end: 40 P / 0 F / 0 S (was 39 P / 1 F / 0 S — §8d previously failed)
- [x] §8c API 404 still passes (gate already correct in `core/src/routes/published.ts`)
- [x] §8d page 404 now passes
- [x] Plan 28 cleanup restores INITIAL_PASSWORD and post-run sign-in returns 200

Closes #217.