### PR TITLE
uat: regression coverage for 12 stability bugs (#222-#253, #257)

### DIFF
--- a/.uat/plans/08-wiki-crud.md
+++ b/.uat/plans/08-wiki-crud.md
@@ -13,9 +13,15 @@ SERVER_URL="${SERVER_URL:-http://localhost:3000}"
 COOKIE_JAR=$(mktemp /tmp/uat-cookies-XXXXXX.txt)
 trap 'rm -f "$COOKIE_JAR"' EXIT
 
-PASS=0; FAIL=0
+# Per-run salt — content posted via /entries is content-deduped by
+# hash. A bare-string entry collides on re-runs and the pipeline
+# silently swallows it, so every test write threads $RUN_ID.
+RUN_ID="$(date +%s)-$$"
+
+PASS=0; FAIL=0; SKIP=0
 pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
 
 echo "08 — Wiki CRUD"
 echo ""
@@ -107,6 +113,345 @@ GONE_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
   "$SERVER_URL/wikis/$WIKI_ID")
 [ "$GONE_HTTP" = "404" ] && pass "deleted wiki returns 404" || fail "deleted wiki returned $GONE_HTTP (expected 404)"
 
+# ── 10. Ghost wikis + zombie edges (regression #236) ─────────
+# Two stacked bugs (issue #236):
+#   (1) classifier worker queries `wikis` without isNull(deletedAt) at
+#       core/src/queue/worker.ts:378-401, so soft-deleted wikis stay in
+#       the candidate set and the LLM keeps routing new fragments into
+#       graveyards.
+#   (2) DELETE /wikis/:id at core/src/routes/wikis.ts:716-738 soft-
+#       deletes the wiki + hard-deletes group_wikis but leaves every
+#       FRAGMENT_IN_WIKI edge intact — old fragments still appear in
+#       the graph attached to a wiki that no longer exists.
+#
+# Edge-type inventory referencing wikis (verified against live DB):
+#   FRAGMENT_IN_WIKI  fragment → wiki   (the only edge that *names*
+#                                        a wiki via dst_id; bug-affected)
+#   FRAGMENT_MENTIONS_PERSON, FRAGMENT_RELATED_TO_FRAGMENT,
+#   ENTRY_HAS_FRAGMENT all reference fragments/people, not wikis
+#   directly — out of scope for the wiki-delete sweep.
+#   group_wikis is hard-deleted by the DELETE handler (no zombies).
+#
+# These assertions are EXPECTED-FAIL on uat/stability-bug-regressions
+# until the fix lands. They turn green after:
+#   (a) classifier filter:  isNull(wikis.deletedAt) in worker.ts:378-401
+#   (b) edge cascade:       UPDATE edges SET deleted_at=now()
+#                           WHERE (src_id=:key OR dst_id=:key)
+#                                 AND deleted_at IS NULL
+#       inside the DELETE handler
+#   (c) one-time backfill:  same UPDATE for every wiki where
+#                           wiki.deleted_at IS NOT NULL AND
+#                           edge.deleted_at IS NULL
+
 echo ""
-echo "$PASS passed, $FAIL failed"
+echo "── 10. Ghost wikis + zombie edges (#236) ──"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  skip "10. DATABASE_URL unset — entire ghost-wikis section skipped"
+else
+
+  GHOST_NAME="UAT08 Ghost Wiki $RUN_ID"
+  GHOST_TOPIC="parambi-family-travel-$RUN_ID"
+
+  # 10. Setup — create the wiki we're going to soft-delete. Make its
+  # description a strong classification signal so the bug (1) path —
+  # if present — will route a matching fragment INTO the deleted wiki.
+  GHOST_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" \
+    -X POST -d "$(jq -n --arg n "$GHOST_NAME" --arg t "$GHOST_TOPIC" \
+      '{name:$n, type:"log", description:("Travel planning notes for the Parambi family — flights, hotels, itineraries. Topic tag: " + $t), prompt:"Summarize travel plans."}')" \
+    "$SERVER_URL/wikis")
+  GHOST_KEY=$(echo "$GHOST_RESP" | jq -r '.lookupKey // .id // empty')
+
+  if [ -n "$GHOST_KEY" ] && [ "$GHOST_KEY" != "null" ]; then
+    pass "10.0a created ghost wiki ($GHOST_KEY) with topic=$GHOST_TOPIC"
+  else
+    fail "10.0a could not create ghost wiki: $GHOST_RESP"
+    GHOST_KEY=""
+  fi
+
+  # ── 10b setup — seed a FRAGMENT_IN_WIKI edge into the ghost wiki
+  # BEFORE the delete, so the post-delete cascade assertion isn't
+  # vacuous. We pick any existing fragment; the edge_type is the
+  # bug-affected one. Without this seed, a freshly-created wiki has
+  # zero edges and 10b would always pass even with the bug.
+  SEED_FRAG=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/fragments?limit=10" \
+    | jq -r '.fragments[0].lookupKey // .fragments[0].id // empty')
+
+  if [ -n "$GHOST_KEY" ] && [ -n "$SEED_FRAG" ]; then
+    SEED_EDGE_ID=$(psql "$DATABASE_URL" -t -A -c "SELECT gen_random_uuid()" 2>/dev/null | tr -d '[:space:]')
+    psql "$DATABASE_URL" -c "INSERT INTO edges (id, src_type, src_id, dst_type, dst_id, edge_type) VALUES ('$SEED_EDGE_ID', 'fragment', '$SEED_FRAG', 'wiki', '$GHOST_KEY', 'FRAGMENT_IN_WIKI') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+    EDGES_BEFORE=$(psql "$DATABASE_URL" -t -A -c "SELECT count(*) FROM edges WHERE dst_id='$GHOST_KEY' AND edge_type='FRAGMENT_IN_WIKI' AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+    if [ "${EDGES_BEFORE:-0}" -ge 1 ] 2>/dev/null; then
+      pass "10.0b seeded $EDGES_BEFORE FRAGMENT_IN_WIKI edge(s) into ghost wiki — pre-delete state non-vacuous"
+    else
+      fail "10.0b could not seed FRAGMENT_IN_WIKI edge — 10b would be vacuous"
+    fi
+
+    DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -X DELETE -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$GHOST_KEY")
+    if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "200" ]; then
+      pass "10.0c DELETE /wikis/$GHOST_KEY → HTTP $DEL_HTTP (wiki now soft-deleted)"
+    else
+      fail "10.0c DELETE /wikis/$GHOST_KEY → HTTP $DEL_HTTP (expected 204)"
+    fi
+
+    # Confirm the wiki row really is soft-deleted (defends against
+    # silent-failure of the DELETE handler).
+    DEL_TS=$(psql "$DATABASE_URL" -t -A -c "SELECT deleted_at IS NOT NULL FROM wikis WHERE lookup_key='$GHOST_KEY'" 2>/dev/null | tr -d '[:space:]')
+    [ "$DEL_TS" = "t" ] && pass "10.0d wikis.deleted_at populated for $GHOST_KEY" \
+      || fail "10.0d wikis.deleted_at NULL after DELETE — handler regressed"
+  else
+    skip "10.0b SEED_FRAG missing — 10b cascade assertion will be vacuous"
+    SEED_EDGE_ID=""
+  fi
+
+  # ── 10b — every edge referencing the just-deleted wiki must have
+  # deleted_at set. This is the cascade the DELETE handler currently
+  # FAILS to do (routes/wikis.ts:716-738 only updates the wiki row +
+  # hard-deletes group_wikis). Strict: zero live edges in either
+  # direction post-delete. Non-vacuous because of the seed in 10.0b.
+  if [ -n "${GHOST_KEY:-}" ]; then
+    LIVE_EDGES=$(psql "$DATABASE_URL" -t -A -c "SELECT count(*) FROM edges WHERE (src_id='$GHOST_KEY' OR dst_id='$GHOST_KEY') AND deleted_at IS NULL" 2>/dev/null | tr -d '[:space:]')
+    if [ "${LIVE_EDGES:-1}" = "0" ]; then
+      pass "10b post-delete: 0 live edges reference ghost wiki (cascade worked)"
+    else
+      fail "10b post-delete: $LIVE_EDGES zombie edge(s) STILL reference $GHOST_KEY (#236 bug 2 — DELETE handler doesn't soft-delete edges)"
+    fi
+  else
+    skip "10b GHOST_KEY missing — edge-cascade assertion skipped"
+  fi
+
+  # ── 10a — post a fragment whose content matches the deleted ghost
+  # wiki's topic. The classifier worker queries `wikis` for candidates
+  # without filtering deleted_at (worker.ts:378-401) so the LLM may
+  # route this new fragment INTO the deleted wiki — the regression.
+  # Strict assertion: post-pipeline, ZERO live FRAGMENT_IN_WIKI edges
+  # point at the deleted ghost wiki.
+  if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+    skip "10a OPENROUTER_API_KEY unset — classifier-route check skipped"
+  elif [ -n "${GHOST_KEY:-}" ]; then
+    ENTRY_CONTENT="UAT08 ghost-routing probe $RUN_ID. Parambi family travel planning for September trip — flights to Lisbon, hotel near Belem, day trips to Sintra. Topic: $GHOST_TOPIC. This entry should NOT classify into any soft-deleted wiki."
+
+    SUBMIT=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
+      -H "Content-Type: application/json" \
+      -H "Origin: http://localhost:3000" \
+      -d "$(jq -n --arg c "$ENTRY_CONTENT" '{content:$c}')" \
+      "$SERVER_URL/entries")
+    SUBMIT_HTTP=$(echo "$SUBMIT" | tail -1)
+    SUBMIT_BODY=$(echo "$SUBMIT" | sed '$d')
+    ENTRY_ID=$(echo "$SUBMIT_BODY" | jq -r '.id // .lookupKey // ""')
+
+    if [ "$SUBMIT_HTTP" = "202" ] && [ -n "$ENTRY_ID" ]; then
+      pass "10a.0 POST /entries → 202 (entry=$ENTRY_ID) — pipeline running"
+
+      # Poll for processed state (max 120s — ingest+extract+classify
+      # is multi-step LLM).
+      echo "    ⟳ polling entry classification (max 120s)..."
+      ELAPSED=0
+      MAX_WAIT=120
+      FINAL_STATUS=""
+      while [ $ELAPSED -lt $MAX_WAIT ]; do
+        sleep 5
+        ELAPSED=$((ELAPSED + 5))
+        ENTRY_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+          "$SERVER_URL/entries/$ENTRY_ID" 2>/dev/null)
+        STATE=$(echo "$ENTRY_RESP" | jq -r '.ingestStatus // .state // "unknown"')
+        if [ "$STATE" = "processed" ] || [ "$STATE" = "RESOLVED" ]; then
+          FINAL_STATUS="$STATE"; break
+        fi
+        if [ "$STATE" = "failed" ]; then
+          FINAL_STATUS="failed"; break
+        fi
+      done
+
+      if [ "$FINAL_STATUS" = "processed" ] || [ "$FINAL_STATUS" = "RESOLVED" ]; then
+        pass "10a.1 pipeline reached $FINAL_STATUS in ${ELAPSED}s"
+
+        # The classifier may run after ingest extraction; give it a
+        # short additional grace window for the wikiClassify job to
+        # land its edges.
+        sleep 5
+
+        # Strict: count live edges from THIS run's fragments into the
+        # ghost wiki. Re-uses src_id=fragment-of-entry. Constrain to
+        # fragments derived from the just-submitted entry.
+        ROUTED=$(psql "$DATABASE_URL" -t -A -c "
+          SELECT count(*) FROM edges e
+          WHERE e.dst_id = '$GHOST_KEY'
+            AND e.edge_type = 'FRAGMENT_IN_WIKI'
+            AND e.deleted_at IS NULL
+            AND e.src_id IN (
+              SELECT f.lookup_key FROM fragments f
+              JOIN edges eh ON eh.dst_id = f.lookup_key
+                            AND eh.edge_type = 'ENTRY_HAS_FRAGMENT'
+              WHERE eh.src_id = '$ENTRY_ID'
+            )
+        " 2>/dev/null | tr -d '[:space:]')
+
+        if [ "${ROUTED:-1}" = "0" ]; then
+          pass "10a.2 new fragment(s) did NOT classify into the deleted ghost wiki"
+        else
+          fail "10a.2 $ROUTED new fragment-edge(s) routed into deleted $GHOST_KEY (#236 bug 1 — classifier ignores wikis.deleted_at)"
+        fi
+      else
+        skip "10a.1 pipeline did not reach processed state in ${MAX_WAIT}s (status=$FINAL_STATUS) — classifier check skipped"
+        ENTRY_ID=""
+      fi
+    else
+      fail "10a.0 POST /entries → HTTP $SUBMIT_HTTP body=$SUBMIT_BODY"
+      ENTRY_ID=""
+    fi
+  else
+    skip "10a GHOST_KEY missing — classifier-route check skipped"
+    ENTRY_ID=""
+  fi
+
+  # ── 10c — global zombie hunt. ANY wiki where deleted_at is set must
+  # not appear in live edges. This catches the in-flight 45-edge dirty
+  # state observed during triage as well as anything seeded by 10a/10b
+  # if the bug is still live.
+  ZOMBIES=$(psql "$DATABASE_URL" -t -A -c "
+    SELECT count(*) FROM edges e
+    JOIN wikis w ON (e.src_id = w.lookup_key OR e.dst_id = w.lookup_key)
+    WHERE w.deleted_at IS NOT NULL
+      AND e.deleted_at IS NULL
+  " 2>/dev/null | tr -d '[:space:]')
+  if [ "${ZOMBIES:-1}" = "0" ]; then
+    pass "10c global zombie sweep: 0 live edges reference any soft-deleted wiki"
+  else
+    fail "10c $ZOMBIES zombie edge(s) reference soft-deleted wikis across the DB (#236 — needs fix + one-time backfill)"
+  fi
+
+  # ── 10d — negative paths. Even with zombie edges in the table, the
+  # READ paths already filter on isNull(wikis.deletedAt) — so the
+  # ghost wiki should be absent from /wikis (list), /wikis/:id (detail),
+  # /wikis/:id/timeline, and /search?q=... regardless of the bug. This
+  # confirms the bug is *purely* on the edges table side and the
+  # READ-side soft-delete invariants are intact. Both anon and authed.
+  if [ -n "${GHOST_KEY:-}" ]; then
+    # /wikis (authed list) — must not contain ghost
+    LIST_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis?limit=200")
+    LIST_HIT=$(echo "$LIST_BODY" | jq --arg k "$GHOST_KEY" \
+      '[.wikis[] | select(.lookupKey == $k or .id == $k)] | length')
+    [ "$LIST_HIT" = "0" ] && pass "10d.1 GET /wikis (authed) excludes ghost wiki" \
+      || fail "10d.1 GET /wikis still lists deleted ghost wiki (count=$LIST_HIT)"
+
+    # /wikis/:id detail — must 404
+    DETAIL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$GHOST_KEY")
+    [ "$DETAIL_HTTP" = "404" ] && pass "10d.2 GET /wikis/$GHOST_KEY (authed) → 404" \
+      || fail "10d.2 GET /wikis/$GHOST_KEY (authed) → $DETAIL_HTTP (expected 404)"
+
+    # /wikis/:id/timeline — must 404 (route guards on isNull(deletedAt))
+    TL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$GHOST_KEY/timeline")
+    [ "$TL_HTTP" = "404" ] && pass "10d.3 GET /wikis/$GHOST_KEY/timeline → 404" \
+      || fail "10d.3 GET /wikis/$GHOST_KEY/timeline → $TL_HTTP (expected 404)"
+
+    # /graph — fed by edges, NOT by wikis. So if zombie edges exist,
+    # the ghost wiki may still appear as a node here. Assert the
+    # invariant we want post-fix: ghost wiki must not be a node.
+    GRAPH_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/graph")
+    GRAPH_HIT=$(echo "$GRAPH_BODY" | jq --arg k "$GHOST_KEY" \
+      '[.nodes[] | select(.id == $k and .type == "wiki")] | length' 2>/dev/null)
+    if [ "${GRAPH_HIT:-0}" = "0" ]; then
+      pass "10d.4 GET /graph excludes ghost wiki node"
+    else
+      fail "10d.4 GET /graph still lists ghost wiki node (#236 bug 2 — zombie edges leak into /graph)"
+    fi
+
+    # /search — hybridSearch filters wikis.deleted_at IS NULL
+    # (core/src/lib/search.ts:62). Hit the most distinctive token
+    # from the description so BM25 finds it iff present.
+    SEARCH_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/search?q=$GHOST_TOPIC&tables=wikis&mode=bm25")
+    SEARCH_HIT=$(echo "$SEARCH_BODY" | jq --arg k "$GHOST_KEY" \
+      '[.results[] | select((.id // .lookupKey) == $k)] | length' 2>/dev/null)
+    [ "${SEARCH_HIT:-0}" = "0" ] && pass "10d.5 /search?q=$GHOST_TOPIC excludes ghost wiki" \
+      || fail "10d.5 /search returns ghost wiki for q=$GHOST_TOPIC (count=$SEARCH_HIT)"
+
+    # Anon (no cookie) — auth middleware should 401 these endpoints
+    # before even hitting the soft-delete filter, but assert the
+    # observable absence for completeness.
+    ANON_DETAIL=$(curl -s -o /dev/null -w "%{http_code}" \
+      -H "Origin: http://localhost:3000" \
+      "$SERVER_URL/wikis/$GHOST_KEY")
+    if [ "$ANON_DETAIL" = "401" ] || [ "$ANON_DETAIL" = "404" ]; then
+      pass "10d.6 anon GET /wikis/$GHOST_KEY → $ANON_DETAIL (no leak)"
+    else
+      fail "10d.6 anon GET /wikis/$GHOST_KEY → $ANON_DETAIL (expected 401 or 404)"
+    fi
+  else
+    skip "10d GHOST_KEY missing — negative-path assertions skipped"
+  fi
+
+  # ── 10 cleanup — hard-delete the ghost wiki + every edge that
+  # touched it + the test entry's fragment chain. Plan must be
+  # replayable, so we don't leave soft-deleted UAT08 rows behind.
+  if [ -n "${GHOST_KEY:-}" ]; then
+    psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$GHOST_KEY' OR dst_id='$GHOST_KEY'" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE lookup_key='$GHOST_KEY'" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${ENTRY_ID:-}" ]; then
+    # Drop derived fragments + their edges + the entry. Cascade by
+    # discovering fragment lookup_keys via the ENTRY_HAS_FRAGMENT edges.
+    psql "$DATABASE_URL" -c "
+      DELETE FROM edges WHERE src_id IN (
+        SELECT dst_id FROM edges WHERE src_id='$ENTRY_ID' AND edge_type='ENTRY_HAS_FRAGMENT'
+      ) OR dst_id IN (
+        SELECT dst_id FROM edges WHERE src_id='$ENTRY_ID' AND edge_type='ENTRY_HAS_FRAGMENT'
+      )" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "
+      DELETE FROM fragments WHERE lookup_key IN (
+        SELECT dst_id FROM edges WHERE src_id='$ENTRY_ID' AND edge_type='ENTRY_HAS_FRAGMENT'
+      )" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$ENTRY_ID' OR dst_id='$ENTRY_ID'" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE lookup_key='$ENTRY_ID'" >/dev/null 2>&1 || true
+  fi
+  # UAT08 name sweep — clears stragglers from a prior failed run so
+  # 10c is meaningful on subsequent invocations.
+  psql "$DATABASE_URL" -c "
+    DELETE FROM edges WHERE src_id IN (SELECT lookup_key FROM wikis WHERE name LIKE 'UAT08 Ghost Wiki %')
+                          OR dst_id IN (SELECT lookup_key FROM wikis WHERE name LIKE 'UAT08 Ghost Wiki %')" >/dev/null 2>&1 || true
+  psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE name LIKE 'UAT08 Ghost Wiki %'" >/dev/null 2>&1 || true
+  pass "10 cleanup: hard-deleted ghost wiki + edges + test entry chain"
+
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
 ```
+
+---
+
+## Pass/Fail Summary (section 10 only)
+
+| # | Assertion | Source |
+|---|-----------|--------|
+| 10.0 | Ghost wiki created + soft-deleted via DELETE handler; baseline edge count captured | `core/src/routes/wikis.ts:716-738` |
+| 10a | Fragment routed via POST /entries with topic-matching content does NOT acquire a live `FRAGMENT_IN_WIKI` edge to the deleted wiki | `core/src/queue/worker.ts:378-401` (missing `isNull(wikis.deletedAt)`) |
+| 10b | Post-DELETE: every edge with `src_id` or `dst_id = ghost_key` has `deleted_at IS NOT NULL` (strict 0 live edges) | `core/src/routes/wikis.ts:716-738` (handler doesn't cascade to edges) |
+| 10c | Global invariant: 0 zombie edges DB-wide (`edges.deleted_at IS NULL` while joined wiki has `deleted_at IS NOT NULL`) — triage observed 45 today | edges + wikis JOIN |
+| 10d | Deleted ghost wiki absent from `/wikis`, `/wikis/:id`, `/wikis/:id/timeline`, `/graph`, `/search?q=...`; anon path returns 401 or 404 | `core/src/routes/wikis.ts:70`, `:220`, `:344`, `core/src/lib/search.ts:62`, `core/src/routes/graph.ts:38` |
+| Cleanup | Ghost wiki + edges + test entry chain hard-deleted; UAT08 name sweep clears stragglers from failed runs | psql cleanup block |
+
+---
+
+## Notes — section 10
+
+- **Expected-fail today.** On `uat/stability-bug-regressions` (HEAD = main) this section is designed to fail at 10b, 10c, and 10d.4. That's the regression test working. The fix turns them green:
+  1. Add `isNull(wikis.deletedAt)` to both `searchCandidates` and `loadThreads` in `core/src/queue/worker.ts:378-401` — fixes 10a.
+  2. Inside the DELETE handler at `core/src/routes/wikis.ts:716-738`, soft-delete every edge where `src_id = :id OR dst_id = :id AND deleted_at IS NULL` — fixes 10b.
+  3. One-time SQL backfill: same UPDATE for every wiki where `deleted_at IS NOT NULL` — clears the 45-edge dirty state and turns 10c green.
+- **Edge-type inventory.** Only `FRAGMENT_IN_WIKI` edges directly reference wikis (verified: `SELECT DISTINCT edge_type, src_type, dst_type FROM edges WHERE src_type='wiki' OR dst_type='wiki'` returns exactly one row, `FRAGMENT_IN_WIKI | fragment | wiki`). `WIKI_MENTIONS_PERSON` does not exist. `group_wikis` is hard-deleted by the handler so no zombies there. The orchestrator's wider sweep in 10b (`src_id OR dst_id`) is defensive — it would catch any future `WIKI_RELATED_TO_WIKI` style edge if ever added.
+- **Cross-wiki transitive ghosts (out of scope).** A separate class of latent zombie: `FRAGMENT_RELATED_TO_FRAGMENT` edges between live fragments and fragments whose only `FRAGMENT_IN_WIKI` is to a deleted wiki. The live fragment is reachable to ghost-content via the relation graph. Live count today: 78. Not in #236's scope (issue is specifically about wiki-direct edges) but worth flagging for a follow-up.
+- **`/graph` is the canary.** Read paths against the `wikis` table all filter on `isNull(deletedAt)` and were never broken by #236. The only externally-observable leak is `/graph`, which builds nodes off the `edges` table — so a zombie edge resurrects a deleted wiki as a node. 10d.4 is the assertion that catches it.
+- **Pipeline timing.** 10a polls up to 120s for the entry to reach `processed` and grants an extra 5s for the wikiClassify job to land its edges. If the system is under load and classification finishes after the poll window, 10a degrades to skip rather than spurious-fail.
+- **Cleanup hard-deletes.** Other UAT plans soft-delete; this one MUST hard-delete the ghost wiki because soft-deleting it after the test would itself create the zombie state we're hunting on the next run. The UAT08 name sweep at the end clears stragglers from prior failed runs.

--- a/.uat/plans/21-wiki-sidecar-rendering.md
+++ b/.uat/plans/21-wiki-sidecar-rendering.md
@@ -664,6 +664,152 @@ fi
 # Restore the canonical fixture body for downstream steps and plan 22.
 pnpm -C core seed-fixture >/dev/null 2>&1 || true
 
+# ── 15. Rendering polish — issue #251 ────────────────────────
+# Three small visual bugs caught in one polish pass. They share no root
+# cause but each materially degrades the rendered surface:
+#   - Hero title: the wiki home page renders `session.user.name` as a
+#     giant <h1> ("phyl"). Just visual noise on a page whose value is the
+#     search box and filter chips. Expected: no user-name hero on first
+#     paint.
+#   - Infobox width: the rich `.winfo` table (width: 100%) was rendering
+#     inside the 217px `.wiki-aside-infobox` flex aside. With no width
+#     constraint on the table the body got squeezed into a ~5-character
+#     left column. Expected: when sidecar carries a structured infobox,
+#     it renders ABOVE the body at full content width; the 217px aside is
+#     reserved for the legacy simple infoboxes only.
+#   - H1 dedup: SectionedMarkdownBody.tsx:156 already skips H1 in the
+#     section loop (fixed in #152). This sub-step is a regression guard
+#     to ensure that fix survives — only ONE H1 carrying the wiki title
+#     in the rendered DOM.
+#
+# Each sub-step is deterministic on the seeded Transformer fixture (which
+# carries a structured sidecar infobox with all four valueKinds) and the
+# authenticated wiki home route.
+
+# 15a. Hero absence — wiki home does NOT render a user-name <h1> hero.
+# Sign in fresh so session.user.name is populated, then load /wiki.
+npx agent-browser open "$WIKI_URL/login"
+npx agent-browser wait --load networkidle
+npx agent-browser fill '#email' "${INITIAL_USERNAME:-uat@robin.test}"
+npx agent-browser fill '#password' "${INITIAL_PASSWORD:-uat-password-123}"
+npx agent-browser click 'button[type="submit"]'
+npx agent-browser wait --load networkidle
+
+npx agent-browser open "$WIKI_URL/wiki"
+npx agent-browser wait --load networkidle
+# Wiki home is React-hydrated — wait long enough for the hero <h1> (if
+# any) to render. The hero check below probes the live DOM via eval.
+sleep 3
+HOME_SNAP=$(npx agent-browser snapshot)
+npx agent-browser eval "document.documentElement.outerHTML" > /tmp/uat-21-15-home-dom.html
+npx agent-browser screenshot /tmp/uat-21-15-home.png
+
+# The fork's fix removes the entire WikiHomeHero <h1>. Detection is
+# twofold: no element with class `wiki-home-title` in the live DOM, AND
+# the logged-in user's display name does not appear inside any <h1>. The
+# class check uses agent-browser eval (not grep) because eval returns
+# the JSON-escaped outerHTML where attribute quotes become \" and break
+# naive regex; querySelectorAll walks the live DOM and is reliable.
+USER_NAME=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/api/auth/get-session" \
+  | jq -r '.user.name // .user.email // ""')
+
+HOME_TITLE_COUNT=$(npx agent-browser eval \
+  "document.querySelectorAll('h1.wiki-home-title').length")
+if [ "$HOME_TITLE_COUNT" = "0" ]; then
+  pass "15a. No <h1.wiki-home-title> hero on /wiki"
+else
+  fail "15a. $HOME_TITLE_COUNT <h1.wiki-home-title> hero(es) still on /wiki"
+fi
+
+# 15b. Belt-and-suspenders: even if the class were renamed, the user
+# display name should not appear inside any <h1> on the home page. Pull
+# h1 textContents via eval and filter in shell — keeps the eval JS
+# free of bash interpolation hazards.
+H1_TEXTS=$(npx agent-browser eval \
+  "Array.from(document.querySelectorAll('h1')).map(h => h.textContent).join('|||')")
+if [ -n "$USER_NAME" ] && echo "$H1_TEXTS" | grep -qF "$USER_NAME"; then
+  fail "15b. User name '$USER_NAME' appears inside an <h1> on /wiki — hero not removed"
+else
+  pass "15b. User name does not appear inside any <h1> on /wiki"
+fi
+
+# 15c. Infobox-above-body at full content width.
+# Trigger state: the seeded Transformer wiki has a structured sidecar
+# infobox (verified at step 0d). The fork's fix renders that .winfo table
+# OUTSIDE any side-aside slot — as a block above the article body, full
+# content width.
+npx agent-browser open "$WIKI_URL/wiki/$TRANSFORMER_KEY"
+npx agent-browser wait --load networkidle
+sleep 1
+npx agent-browser eval "document.documentElement.outerHTML" > /tmp/uat-21-15-infobox-dom.html
+npx agent-browser screenshot /tmp/uat-21-15-infobox.png
+
+# 15c. The .winfo must not live in any aside slot. Two failure modes:
+# (1) descendant of .wiki-aside-infobox (legacy 217px aside class), or
+# (2) flex sibling of .wiki-article-content inside .wiki-article-layout.
+# Both squeeze the body. Render-above-body fix puts the .winfo OUTSIDE
+# .wiki-article-layout entirely.
+WINFO_IN_ASIDE_SLOT=$(npx agent-browser eval \
+  "(() => { const w = document.querySelector('.winfo'); if (!w) return 'no-winfo'; if (w.closest('.wiki-aside-infobox')) return 'in-legacy-aside'; const layout = w.closest('.wiki-article-layout'); const body = document.querySelector('.wiki-article-content'); if (layout && body && layout.contains(body)) return 'sibling-of-body'; return 'outside'; })()")
+if [ "$WINFO_IN_ASIDE_SLOT" = "outside" ]; then
+  pass "15c. Structured .winfo renders outside any aside slot"
+elif [ "$WINFO_IN_ASIDE_SLOT" = "no-winfo" ]; then
+  fail "15c. No .winfo element found on Transformer page — sidecar regression?"
+else
+  fail "15c. .winfo trapped in aside slot (got: $WINFO_IN_ASIDE_SLOT)"
+fi
+
+# 15d. The .winfo must render at content-width, not squeezed. Floor:
+# 600px on a 1280px viewport. Anything below 600 means it's still in
+# a flex slot competing with .wiki-article-content for width.
+WINFO_WIDTH=$(npx agent-browser eval \
+  "(() => { const el = document.querySelector('.winfo'); return el ? Math.round(el.getBoundingClientRect().width) : 0; })()")
+VIEWPORT_W=$(npx agent-browser eval "window.innerWidth")
+if [ -n "$WINFO_WIDTH" ] && [ "$WINFO_WIDTH" -ge 600 ] 2>/dev/null; then
+  pass "15d. Structured .winfo renders at content width (${WINFO_WIDTH}px on ${VIEWPORT_W}px viewport)"
+elif [ "$WINFO_WIDTH" = "0" ]; then
+  fail "15d. No .winfo element found"
+else
+  fail "15d. .winfo width is ${WINFO_WIDTH}px (viewport ${VIEWPORT_W}px) — still squeezed"
+fi
+
+# 15e. The .winfo renders ABOVE the article body — DOM order precedes
+# .wiki-article-content. compareDocumentPosition with the body returns
+# DOCUMENT_POSITION_FOLLOWING (bit 4 = 4) when the infobox is above.
+WINFO_BEFORE_BODY=$(npx agent-browser eval \
+  "(() => { const w = document.querySelector('.winfo'); const b = document.querySelector('.wiki-article-content'); if (!w || !b) return 'missing'; return (w.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) ? 'above' : 'below'; })()")
+if [ "$WINFO_BEFORE_BODY" = "above" ]; then
+  pass "15e. Structured .winfo renders above .wiki-article-content"
+elif [ "$WINFO_BEFORE_BODY" = "missing" ]; then
+  fail "15e. Could not locate .winfo or .wiki-article-content for ordering check"
+else
+  fail "15e. Structured .winfo renders below the body (got: $WINFO_BEFORE_BODY)"
+fi
+
+# 15f. H1 dedup regression guard — exactly ONE <h1> in the rendered DOM
+# carries the wiki title text. The H1 belongs to page chrome
+# (.wiki-article-h1); the markdown body must NOT also emit an <h1>. This
+# protects the SectionedMarkdownBody.tsx:156 fix (`if (section.level === 1)
+# continue`) from being re-introduced by future refactors. Use eval so
+# the count walks live DOM, immune to JSON-escaped outerHTML quirks.
+H1_TITLE_COUNT=$(npx agent-browser eval \
+  "Array.from(document.querySelectorAll('h1')).filter(h => h.textContent && h.textContent.includes('Transformer Architecture')).length")
+if [ "$H1_TITLE_COUNT" = "1" ]; then
+  pass "15f. Exactly ONE <h1> contains the wiki title (H1 dedup holds)"
+else
+  fail "15f. $H1_TITLE_COUNT <h1> elements contain the wiki title (expected 1) — H1 dedup regressed"
+fi
+
+# 15g. The single title <h1> belongs to page chrome, not the markdown
+# body. SectionedMarkdownBody must not emit any <h1> at all.
+BODY_H1_COUNT=$(npx agent-browser eval \
+  "document.querySelectorAll('.wiki-article-content h1, .wiki-richtext-rendered h1').length")
+if [ "$BODY_H1_COUNT" = "0" ]; then
+  pass "15g. Markdown body emits no <h1> (H1 only in page chrome)"
+else
+  fail "15g. Markdown body emits $BODY_H1_COUNT <h1> element(s) — should be 0"
+fi
+
 # ── Cleanup ──────────────────────────────────────────────────
 npx agent-browser close 2>/dev/null || true
 
@@ -692,6 +838,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 12 | Entry detail page resolves tokens and has no infobox | useEntry + EntryArticle |
 | 13 | Person detail page renders server-derived .winfo infobox with Relationship row | usePerson + derivePersonInfobox |
 | 14 | H1 + intro + H2 shape: intro renders exactly once, H2 bodies render exactly once, no body-level H1 — regression guard for #152 + 061c3a6 | SectionedMarkdownBody preamble + H1 skip |
+| 15 | Rendering polish (issue #251): no user-name hero on /wiki; structured .winfo renders above body at full width (not in 217px aside); H1 dedup guard — exactly one title <h1>, none from markdown body | WikiHomeHero, WikiEntityArticle infobox slot, SectionedMarkdownBody.tsx:156 |
 
 ---
 
@@ -701,3 +848,4 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 - Step 9 mutates the wiki body via `PUT /api/content/wiki/<key>` to simulate a concurrent regen. The script reseeds the fixture afterward so the overall suite leaves the DB clean.
 - Step 10 also mutates the body (to an HTML string) to force the Tiptap-saved branch, then reseeds.
 - If the `agent-browser eval document.querySelector('#notes-1 a.wedit')?.click()` selector misses because the `[edit]` link sits outside the section anchor wrapper rather than inside it, step 8 reports a deterministic fail rather than silently passing — adjust the selector to match the rendered DOM structure in `/tmp/uat-21-dom.html`.
+- Step 15 covers issue #251 (rendering polish): three fork-only fixes — drop the giant user-name hero on `/wiki`, render the rich infobox above the body at full width when sidecar carries structured data, and guard the existing H1 dedup at `SectionedMarkdownBody.tsx:156`. 15a–15b detect the hero by class and by the user name appearing inside any `<h1>`. 15c–15e use `agent-browser eval` to walk the DOM (`closest`, `getBoundingClientRect`, `compareDocumentPosition`) so the assertions don't depend on serialized markup ordering. 15f–15g count title `<h1>` elements in the source HTML and probe for body-level `<h1>` via querySelectorAll. The hero check requires `session.user.name` to be populated — sign-in happens at the top of the step.

--- a/.uat/plans/24-mcp-description-and-dedup.md
+++ b/.uat/plans/24-mcp-description-and-dedup.md
@@ -183,10 +183,69 @@ if [ -n "${DATABASE_URL:-}" ]; then
   else
     fail "1c. fragments_dedup_hash_idx missing — dedup lookup will table-scan at scale"
   fi
+
+  # ── 1d. Partial dedup index used by hot-path query ──
+  # Existence of the index (1c) is necessary but not sufficient. The
+  # index in core/src/db/schema.ts:225-227 is PARTIAL (`WHERE deleted_at
+  # IS NULL`). For Postgres to use it, the planner needs the predicate
+  # `deleted_at IS NULL` IN the query. findDuplicateFragment in
+  # core/src/db/dedup.ts:42-49 currently emits only
+  # `WHERE dedup_hash = $1` — no deleted_at filter — so the planner
+  # falls back to a Seq Scan. This regression fires until #223 is
+  # closed by adding `isNull(fragments.deletedAt)` to the .where()
+  # chain.
+  # `enable_seqscan = off` is critical: on a tiny `fragments` table the
+  # planner picks Seq Scan even when the index is fully usable (cost
+  # ~6.51 vs index ~8.15). Forcing the planner to consider indices
+  # decouples the assertion from row count — if the partial-index
+  # predicates aren't met, the planner STILL won't use it (it picks Seq
+  # Scan with disable-cost ~1e10), and we score that as a fail. With
+  # the deleted_at predicate added (post-#223), the same query flips to
+  # `Index Scan using fragments_dedup_hash_idx`.
+  EXPLAIN_HASH="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff${RUN_ID:0:2}"
+  # psql -t -A still emits a `SET` line for the SET command before the
+  # JSON body — strip everything before the opening `[` so jq parses
+  # only the EXPLAIN payload.
+  EXPLAIN_RAW=$(psql "$DATABASE_URL" -t -A -c \
+    "SET enable_seqscan=off; EXPLAIN (FORMAT JSON) SELECT * FROM fragments WHERE dedup_hash = '$EXPLAIN_HASH'" \
+    2>/dev/null)
+  EXPLAIN_JSON=$(echo "$EXPLAIN_RAW" | sed -n '/^\[/,$p')
+
+  if [ -n "$EXPLAIN_JSON" ]; then
+    NODE_TYPE=$(echo "$EXPLAIN_JSON" | jq -r '.[0].Plan."Node Type" // empty' 2>/dev/null)
+    INDEX_NAME=$(echo "$EXPLAIN_JSON" | jq -r '
+      [.[0].Plan."Index Name",
+       (.[0].Plan.Plans // [])[]?."Index Name"]
+      | map(select(. != null and . != ""))
+      | .[0] // empty' 2>/dev/null)
+
+    case "$NODE_TYPE" in
+      "Index Scan"|"Index Only Scan"|"Bitmap Heap Scan")
+        if [ "$INDEX_NAME" = "fragments_dedup_hash_idx" ]; then
+          pass "1d. findDuplicateFragment hot-path uses fragments_dedup_hash_idx ($NODE_TYPE) — partial index hit"
+        else
+          fail "1d. plan is $NODE_TYPE on '$INDEX_NAME' (expected fragments_dedup_hash_idx) — wrong index chosen"
+        fi
+        ;;
+      "Seq Scan")
+        fail "1d. findDuplicateFragment hot-path is Seq Scan — partial index unused (#223 — handler missing isNull(fragments.deletedAt) so planner can't match the WHERE deleted_at IS NULL partial)"
+        ;;
+      "")
+        echo "$EXPLAIN_JSON" > /tmp/uat-24-explain.json
+        skip "1d. EXPLAIN returned no parseable JSON — see /tmp/uat-24-explain.json"
+        ;;
+      *)
+        fail "1d. unexpected plan node type '$NODE_TYPE' (index='$INDEX_NAME') — investigate EXPLAIN manually"
+        ;;
+    esac
+  else
+    skip "1d. EXPLAIN query returned empty — psql/jq unavailable or fragments table absent"
+  fi
 else
   skip "1a. DATABASE_URL unset — wikis.description column check skipped"
   skip "1b. DATABASE_URL unset — fragments.dedup_hash column check skipped"
   skip "1c. DATABASE_URL unset — fragments_dedup_hash_idx check skipped"
+  skip "1d. DATABASE_URL unset — partial-index hot-path EXPLAIN skipped"
 fi
 
 # ── 2. create_wiki tool description text mentions persistence (#168) ──
@@ -487,6 +546,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 1a | `wikis.description` column exists in DB (migration 0007 applied) | #168 dependency |
 | 1b | `fragments.dedup_hash` column exists (`baseColumns()` in `0000_init.sql`) | #184 dependency |
 | 1c | `fragments_dedup_hash_idx` index exists (PR #187 schema diff) | PR #187 |
+| 1d | `findDuplicateFragment` hot-path query is planned as Index Scan over `fragments_dedup_hash_idx` (not Seq Scan) — partial index actually used | #223 — `core/src/db/dedup.ts:42-49` vs `schema.ts:225-227` |
 | 2a | `tools/list` advertises the new `description` schema text containing 'persisted on the wiki row' | PR #187 — `core/src/mcp/server.ts:108` |
 | 3a | `create_wiki` with explicit valid `type` + `description` returns `{slug, lookupKey, type, inferredType: undefined}` | #168 acceptance test #1 |
 | 3b | DB row's `description` column matches input verbatim | #168 acceptance test #1 |
@@ -509,6 +569,26 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 
 ## Notes
 
+- **§1d is expected to FAIL until #223 is fixed.** `core/src/db/dedup.ts:42-49`
+  filters only on `dedup_hash`. The index at `core/src/db/schema.ts:225-227`
+  is partial `WHERE deleted_at IS NULL`, so the planner needs
+  `deleted_at IS NULL` in the query predicate to use it. Fix is one
+  line: add `isNull(fragments.deletedAt)` to the `.where()` chain
+  (with an `and(...)` wrapper). After fix, EXPLAIN emits
+  `Index Scan using fragments_dedup_hash_idx`. Asserting on planner
+  shape — not raw timing — keeps the signal stable across DB sizes
+  and `random_page_cost` tuning.
+- **§1d uses `SET enable_seqscan=off`.** Live confirmation against
+  the `.dev/postgres` instance with a tiny `fragments` table showed
+  Seq Scan for both query shapes (cost ~6.51) — the planner is too
+  cheap on small tables to pick the index regardless of predicate
+  fitness. With `enable_seqscan=off`, the planner is forced to
+  consider indices; if the partial-index predicate `deleted_at IS NULL`
+  is missing from the query, the planner has no usable index and
+  falls back to Seq Scan with disable-cost ~1e10. With the predicate
+  present, the same query flips to `Index Scan using
+  fragments_dedup_hash_idx` (cost ~8.15). This makes §1d deterministic
+  on any DB size including a freshly-bootstrapped staging DB.
 - **Tools/list-as-contract.** Step 2 leans on `tools/list` to assert the
   schema-text change in `core/src/mcp/server.ts:108`. If a future change
   inlines or rephrases that text, step 2a regresses — update the grep

--- a/.uat/plans/27-wiki-settings-and-history.md
+++ b/.uat/plans/27-wiki-settings-and-history.md
@@ -562,6 +562,158 @@ else
   fail "8c. Frontend SDK missing getWikiEditHistory — codegen out of sync"
 fi
 
+# ── 9. Tiptap save scope — sidebar chrome must NOT bake into wikis.content (#241) ──
+# When the user clicks Edit, `WikiEntityArticle` captures
+# `readContentRef.current.innerHTML` and seeds the Tiptap editor with it.
+# Today that ref wraps Member Fragments + Mentioned People + section
+# editor — so a no-op edit/save round-trip rewrites `wikis.content` with
+# all that chrome. Subsequent reads then render the chrome inside the
+# body AND outside it (duplicate sections accumulate per save cycle).
+#
+# Bug present: after save, `wikis.content` contains 'Member Fragments',
+# 'Mentioned People', '/fragments/frag', and the wedit class — none of
+# which were in the markdown source body.
+#
+# Fix (fork commit 23b68a8): wrap the body in <div data-wiki-body> on the
+# shell page and scope the innerHTML capture to that subtree.
+#
+# Use a fresh UAT-only wiki so this section never mutates the shared
+# Transformer fixture. Cleanup tears it down at the end.
+
+UAT9_WIKI_NAME="UAT-27 Tiptap Chrome $(date +%s)"
+CREATE_WIKI_HTTP=$(curl -s -o /tmp/uat-27-09-create.json -w "%{http_code}" -b "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg n "$UAT9_WIKI_NAME" '{name:$n, type:"project", prompt:""}')" \
+  "$SERVER_URL/wikis")
+
+if [ "$CREATE_WIKI_HTTP" = "200" ] || [ "$CREATE_WIKI_HTTP" = "201" ]; then
+  pass "9a. Created UAT-only wiki for chrome-bake test (HTTP $CREATE_WIKI_HTTP)"
+else
+  fail "9a. Could not create UAT wiki (HTTP $CREATE_WIKI_HTTP) — section 9 will use Transformer fixture instead"
+fi
+UAT9_KEY=$(jq -r '.lookupKey // .id // empty' /tmp/uat-27-09-create.json)
+if [ -z "${UAT9_KEY:-}" ] || [ "$UAT9_KEY" = "null" ]; then
+  # Fall back to Transformer wiki — cleanup will re-seed.
+  UAT9_KEY="$WIKI_KEY"
+  skip "9a-fallback. Using Transformer fixture (cleanup will re-seed)"
+fi
+
+# Seed the wiki with a known markdown body via the API the same way the
+# Tiptap save does (PUT /api/content/wiki/:key). Body has NO chrome
+# strings — anything chrome-flavoured we find later came from the editor
+# capture, not our seed.
+UAT9_BODY=$'# Tiptap Chrome Bake Probe\n\nUAT-27 §9 body marker — only this text and the heading should land in wikis.content after a no-op Tiptap save.\n\n## Subsection\n\nLine for the body.\n'
+SEED_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE_JAR" -X PUT \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg body "$UAT9_BODY" --arg name "$UAT9_WIKI_NAME" '{frontmatter:{name:$name,type:"project",prompt:""},body:$body}')" \
+  "$SERVER_URL/api/content/wiki/$UAT9_KEY")
+if [ "$SEED_HTTP" = "200" ] || [ "$SEED_HTTP" = "204" ]; then
+  pass "9b. Seeded UAT wiki with chrome-free markdown body (HTTP $SEED_HTTP)"
+else
+  fail "9b. PUT seed failed (HTTP $SEED_HTTP) — assertions below may be unreliable"
+fi
+
+# Open the wiki, click Edit, click Save (no edits). The bug fires on
+# enterEditMode whether or not the user edits — what matters is the
+# innerHTML scope at the moment Edit is clicked.
+npx agent-browser open "$WIKI_URL/wiki/$UAT9_KEY"
+npx agent-browser wait --load networkidle
+sleep 1
+
+# 9c. Confirm baseline DOM has chrome rendered around the body — this is
+# what the buggy capture would slurp up. Skip with a warning if the
+# fixture has no fragments/people; without chrome to leak the assertion
+# becomes vacuous.
+DOM_HAS_CHROME=$(npx agent-browser eval "(() => { const t = document.body.innerText || ''; return JSON.stringify({mf: t.includes('Member Fragments'), mp: t.includes('Mentioned People')}); })()" | tr -d '"' | tr -d '\\')
+if echo "$DOM_HAS_CHROME" | grep -q "mf:true"; then
+  pass "9c. Page chrome (Member Fragments) present in DOM — bake risk realistic"
+else
+  skip "9c. No Member Fragments in DOM ($DOM_HAS_CHROME) — UAT wiki has no fragments; falling through but assertion power is reduced"
+fi
+
+# 9d. Click Edit and assert the editor body is scoped to the wiki body
+# only — Member Fragments / Mentioned People must NOT appear in the
+# Tiptap editor's innerText. This is the fix's primary contract.
+npx agent-browser find text "Edit" click
+npx agent-browser wait --load networkidle
+sleep 1
+EDITOR_BODY=$(npx agent-browser eval "document.querySelector('.tiptap')?.innerText || ''")
+if echo "$EDITOR_BODY" | grep -qE "Member Fragments|Mentioned People|/fragments/frag"; then
+  fail "9d. Tiptap editor contains chrome strings (capture not scoped to data-wiki-body) — fix not applied"
+else
+  pass "9d. Tiptap editor body has no chrome strings — capture scoped correctly"
+fi
+
+# 9e. Click Save and round-trip the body through PUT /api/content/wiki.
+npx agent-browser find text "Save" click
+npx agent-browser wait --load networkidle
+sleep 2
+
+# 9f. Read back wikis.content and assert NONE of the chrome substrings
+# leaked into the persisted body. These four are deterministic markers
+# rendered by the article shell (page.tsx:521-622) but never present in
+# a real markdown body.
+if command -v psql >/dev/null 2>&1 && [ -n "${DATABASE_URL:-}" ]; then
+  SAVED_CONTENT=$(psql "$DATABASE_URL" -t -A -c "SELECT content FROM wikis WHERE lookup_key='$UAT9_KEY'" 2>/dev/null || echo "")
+  CHROME_LEAKS=0
+  for marker in "Member Fragments" "Mentioned People" "/fragments/frag" "wedit"; do
+    if echo "$SAVED_CONTENT" | grep -qF "$marker"; then
+      fail "9f. wikis.content contains chrome substring: '$marker' (Tiptap save baked sidebar chrome — #241 still present)"
+      CHROME_LEAKS=$((CHROME_LEAKS+1))
+    fi
+  done
+  if [ "$CHROME_LEAKS" = "0" ]; then
+    pass "9f. wikis.content has no chrome substrings (Member Fragments / Mentioned People / /fragments/frag / wedit)"
+  fi
+
+  # 9g. Positive: the body marker we seeded should still be present.
+  if echo "$SAVED_CONTENT" | grep -qF "UAT-27 §9 body marker"; then
+    pass "9g. Body marker preserved after Tiptap save round-trip"
+  else
+    fail "9g. Body marker missing after save — round-trip dropped legitimate body content"
+  fi
+
+  # 9h. Length sanity: the persisted content should be on the order of
+  # the seed body (~200 bytes), not the chromed-up DOM (~5–10 KB). Use a
+  # generous ceiling so editor whitespace normalisation doesn't trip it.
+  SAVED_LEN=${#SAVED_CONTENT}
+  if [ "$SAVED_LEN" -le 2000 ] 2>/dev/null; then
+    pass "9h. Persisted content length $SAVED_LEN bytes ≤ 2000 (no chrome bloat)"
+  else
+    fail "9h. Persisted content length $SAVED_LEN bytes > 2000 (chrome bloat suspected — #241 regression)"
+  fi
+else
+  skip "9f-h. psql or DATABASE_URL unavailable — chrome-bake DB checks skipped"
+fi
+
+# 9i. Re-render the wiki in Read mode and confirm the live page does NOT
+# show duplicate Member Fragments listings. The bug surface is "two of
+# everything" — one from the article shell, one from the baked content.
+# Count <h2> nodes whose text starts with 'Member Fragments'.
+npx agent-browser open "$WIKI_URL/wiki/$UAT9_KEY"
+npx agent-browser wait --load networkidle
+sleep 1
+MF_H2_COUNT=$(npx agent-browser eval "Array.from(document.querySelectorAll('h2')).filter(h => (h.textContent || '').includes('Member Fragments')).length" | tr -d '"')
+if [ "${MF_H2_COUNT:-0}" -le 1 ] 2>/dev/null; then
+  pass "9i. ≤1 'Member Fragments' h2 on the page (no duplicate from baked chrome) — got $MF_H2_COUNT"
+else
+  fail "9i. Found $MF_H2_COUNT 'Member Fragments' h2 nodes — chrome was baked and is rendering twice"
+fi
+
+# 9j. Cleanup: delete the UAT wiki if we created one. If we fell back to
+# the Transformer fixture, the bottom-of-plan re-seed restores it.
+if [ "$UAT9_KEY" != "$WIKI_KEY" ]; then
+  DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE_JAR" -X DELETE \
+    -H "Origin: http://localhost:3000" "$SERVER_URL/wikis/$UAT9_KEY")
+  if [ "$DEL_HTTP" = "200" ] || [ "$DEL_HTTP" = "204" ]; then
+    pass "9j. Cleaned up UAT wiki (HTTP $DEL_HTTP)"
+  else
+    skip "9j. UAT wiki delete returned HTTP $DEL_HTTP — bottom-of-plan re-seed will not touch it"
+  fi
+fi
+
 # ── Cleanup ──────────────────────────────────────────────────
 # Re-seed to restore a clean fixture body / description for downstream plans.
 pnpm -C core seed-fixture >/dev/null 2>&1 || true
@@ -586,8 +738,9 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 6 | View history tab hydrates from `useWikiEditHistory`; timeline shows server revisions on fresh load with You/Robin author labels | `useWikiEditHistory.ts`, `WikiEntityArticle.tsx:382-396` (serverRevisions seed), `useWikiEntityEditMode.ts:115-121` |
 | 7 | People page renders custom infobox after `onSettingsClick` was removed from the callback signature; gear still appears for showSettings:true | `wiki/src/app/(shell)/people/[id]/page.tsx:311-330` |
 | 8 | OpenAPI manifest registers `/wikis/{id}/history`; `editHistoryResponseSchema` component exposed; frontend SDK regenerated with `getWikiEditHistory` | `core/openapi-manifest.json`, `core/openapi.json`, `wiki/src/lib/generated/sdk.gen.ts` |
+| 9 | #241 — Tiptap save scoped to `data-wiki-body`: Tiptap editor seeded without chrome; after no-op save, `wikis.content` contains body marker but none of `Member Fragments` / `Mentioned People` / `/fragments/frag` / `wedit`; persisted length stays small; no duplicate Member Fragments h2 in Read mode | `wiki/src/components/wiki/WikiEntityArticle.tsx:671` (capture scope), `wiki/src/app/(shell)/wiki/[id]/page.tsx:294-623` (chrome render around `data-wiki-body`) |
 
-Target: ~32 numbered assertions across 9 sections (sections 0–8).
+Target: ~42 numbered assertions across 10 sections (sections 0–9).
 
 ---
 
@@ -600,3 +753,4 @@ Target: ~32 numbered assertions across 9 sections (sections 0–8).
 - Step 5c uses a JS setter cast to bypass React's controlled-input bookkeeping. If the modal uses a custom input component that ignores raw value mutations, the assertion will fail and a manual check via `/tmp/uat-27-05-settings-open.png` is the fallback.
 - Step 6c's DOM selector is heuristic — `WikiHistoryTimeline.tsx` uses ad-hoc class names. The script falls back to counting "Regenerated"/"Edited" labels in the snapshot if no `[class*="revision"]` matches.
 - The PR's `useWikiEditHistory` hook only seeds revisions on first load when `revisions.length === 0`. This UAT relies on a fresh navigation to `/wiki/:id`; do not chain it after a session that already populated revisions in-memory or step 6 will appear to pass even if the API call regressed.
+- Section 9 reproduces #241 (Tiptap save bakes sidebar chrome into `wikis.content`). The four chrome substrings — `Member Fragments`, `Mentioned People`, `/fragments/frag`, `wedit` — are all rendered by the article shell (`wiki/src/app/(shell)/wiki/[id]/page.tsx:521-622` for the lists, `wedit` by the inline `[edit]` link inside `MarkdownContent`). None of them ever appear in a freshly-seeded markdown body, so finding any of them in `wikis.content` after a no-op Tiptap save is a deterministic positive for the bug. The fix (fork commit `23b68a8`) wraps the body in `<div data-wiki-body>` and scopes the `enterEditMode` capture to that subtree. Section 9 creates and tears down its own UAT wiki so it never mutates the shared Transformer fixture; if the create call fails (older API surface) it falls back to the Transformer wiki and the bottom-of-plan `seed-fixture` re-seed restores it.

--- a/.uat/plans/28-password-change-and-public-wiki.md
+++ b/.uat/plans/28-password-change-and-public-wiki.md
@@ -411,6 +411,150 @@ else
   skip "9. agent-browser not available — UI flow skipped"
 fi
 
+# ── 9b. Public page renders HTML-saved bodies as DOM, not literal text (#253) ──
+# The public page (`wiki/src/app/(public)/p/[nanoid]/page.tsx`) currently
+# routes the body through `<MarkdownContent>` unconditionally. Tiptap-edited
+# wikis store HTML in `wikis.content`; ReactMarkdown then renders the raw
+# `<p>...</p>` etc. as escaped text (`&lt;p&gt;`) for any external viewer.
+# The shell wiki page already detects HTML bodies via leading-`<` and
+# branches to `<HtmlWikiBody>`; the public page must mirror that branch.
+#
+# Bug present (current main): the rendered HTML response contains escaped
+# tags (`&lt;p&gt;`, `&lt;strong&gt;`, `&lt;ul&gt;`, `&lt;li&gt;`).
+# Fix (fork commit 1e294cb): leading-`<` body short-circuits to
+# `dangerouslySetInnerHTML`, producing real `<p>` / `<strong>` DOM nodes.
+
+# 9b-i. Create a UAT-only wiki, write a deterministic HTML body via the
+# Tiptap save endpoint, publish it. Anonymous-curl the public page and
+# assert HTML renders as DOM. Tear down at the end.
+
+UAT9B_NAME="UAT-28 HTML Render $(date +%s)"
+CREATE9B_HTTP=$(curl -s -o /tmp/uat-28-9b-create.json -w "%{http_code}" \
+  -b "$NEW_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $ORIGIN" \
+  -d "$(jq -n --arg n "$UAT9B_NAME" '{name:$n, type:"project", prompt:""}')" \
+  "$SERVER_URL/wikis")
+
+if [ "$CREATE9B_HTTP" = "200" ] || [ "$CREATE9B_HTTP" = "201" ]; then
+  pass "9b-i. Created UAT wiki for HTML-render test (HTTP $CREATE9B_HTTP)"
+else
+  fail "9b-i. Could not create UAT wiki (HTTP $CREATE9B_HTTP) — section 9b will be skipped"
+fi
+UAT9B_KEY=$(jq -r '.lookupKey // .id // empty' /tmp/uat-28-9b-create.json)
+
+if [ -n "${UAT9B_KEY:-}" ] && [ "$UAT9B_KEY" != "null" ]; then
+  # Deterministic HTML body — leading `<` triggers the branch the fix introduces.
+  # `UAT-28-§9b-marker` is a unique anchor we grep for.
+  UAT9B_HTML='<p>UAT-28-§9b-marker hello</p><p><strong>BoldChunk9b</strong> and <em>ItalicChunk9b</em></p><ul><li>list-item-9b-one</li><li>list-item-9b-two</li></ul>'
+  HTML_PUT_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -b "$NEW_JAR" -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Origin: $ORIGIN" \
+    -d "$(jq -n --arg body "$UAT9B_HTML" --arg name "$UAT9B_NAME" '{frontmatter:{name:$name,type:"project",prompt:""},body:$body}')" \
+    "$SERVER_URL/api/content/wiki/$UAT9B_KEY")
+  if [ "$HTML_PUT_HTTP" = "200" ] || [ "$HTML_PUT_HTTP" = "204" ]; then
+    pass "9b-ii. Seeded UAT wiki with HTML body via PUT /api/content/wiki (HTTP $HTML_PUT_HTTP)"
+  else
+    fail "9b-ii. PUT HTML body failed (HTTP $HTML_PUT_HTTP)"
+  fi
+
+  # Sanity: confirm wikis.content actually starts with `<` (so isHtmlBody
+  # branch will fire on a fixed page; bug or fix, the input is the same).
+  if command -v psql >/dev/null 2>&1 && [ -n "${DATABASE_URL:-}" ]; then
+    DB_HEAD=$(psql "$DATABASE_URL" -t -A -c "SELECT substring(content from 1 for 1) FROM wikis WHERE lookup_key='$UAT9B_KEY'" 2>/dev/null || echo "")
+    if [ "$DB_HEAD" = "<" ]; then
+      pass "9b-iii. wikis.content starts with '<' (HTML body confirmed at DB layer)"
+    else
+      fail "9b-iii. wikis.content does NOT start with '<' (got '$DB_HEAD') — Tiptap save did not persist HTML, downstream assertions invalid"
+    fi
+  else
+    skip "9b-iii. psql/DATABASE_URL unavailable — DB layer body-shape check skipped"
+  fi
+
+  # Publish the wiki for the public surface.
+  PUB9B_HTTP=$(curl -s -o /tmp/uat-28-9b-pub.json -w "%{http_code}" \
+    -b "$NEW_JAR" -X POST \
+    -H "Content-Type: application/json" \
+    -H "Origin: $ORIGIN" \
+    "$SERVER_URL/wikis/$UAT9B_KEY/publish")
+  UAT9B_SLUG=$(jq -r '.publishedSlug // empty' /tmp/uat-28-9b-pub.json)
+  if [ "$PUB9B_HTTP" = "200" ] && [ -n "$UAT9B_SLUG" ]; then
+    pass "9b-iv. Published UAT wiki (slug=$UAT9B_SLUG)"
+  else
+    fail "9b-iv. Publish failed (HTTP $PUB9B_HTTP, slug='$UAT9B_SLUG') — page assertions will be skipped"
+    UAT9B_SLUG=""
+  fi
+
+  if [ -n "$UAT9B_SLUG" ]; then
+    # 9b-v. Anon-curl the public page (no cookies, no auth).
+    PAGE9B_HTTP=$(curl -s -o /tmp/uat-28-9b-page.html -w "%{http_code}" "$WIKI_URL/p/$UAT9B_SLUG")
+    [ "$PAGE9B_HTTP" = "200" ] && pass "9b-v. Anon GET $WIKI_URL/p/$UAT9B_SLUG → 200" \
+                              || fail "9b-v. Anon GET returned HTTP $PAGE9B_HTTP"
+
+    # 9b-vi. Body marker text is present (proves the body reached the page
+    # at all — both branches of the fix should pass this).
+    if grep -qF "UAT-28-§9b-marker" /tmp/uat-28-9b-page.html; then
+      pass "9b-vi. Body marker text 'UAT-28-§9b-marker' is in the rendered page"
+    else
+      fail "9b-vi. Body marker missing from rendered page — body never reached the public surface"
+    fi
+
+    # 9b-vii. NEGATIVE: escaped HTML tags ('&lt;p&gt;', '&lt;strong&gt;',
+    # '&lt;ul&gt;') must NOT appear in the page body. ReactMarkdown
+    # escapes raw HTML — finding any of these is a deterministic positive
+    # for #253. We restrict the search to the article body region by
+    # scoping to lines containing the marker substring chunks, then sweep
+    # the whole response as a coarse fallback.
+    ESCAPED_LEAKS=0
+    for tag in "&lt;p&gt;" "&lt;strong&gt;" "&lt;ul&gt;" "&lt;li&gt;"; do
+      if grep -qF "$tag" /tmp/uat-28-9b-page.html; then
+        ESCAPED_LEAKS=$((ESCAPED_LEAKS+1))
+        fail "9b-vii. Escaped HTML tag found in public page: '$tag' — #253 still present (MarkdownContent rendered HTML body as literal text)"
+      fi
+    done
+    if [ "$ESCAPED_LEAKS" = "0" ]; then
+      pass "9b-vii. No escaped HTML tags ('&lt;p&gt;' etc.) in the public page — HTML body branch fired"
+    fi
+
+    # 9b-viii. POSITIVE: the rendered DOM should contain real `<strong>`
+    # and `<em>` nodes wrapping our marker chunks. Use agent-browser to
+    # parse the page and look for the actual elements.
+    if command -v npx >/dev/null 2>&1 && npx --no -- agent-browser --help >/dev/null 2>&1; then
+      npx agent-browser open "$WIKI_URL/p/$UAT9B_SLUG"
+      npx agent-browser wait --load networkidle
+      sleep 1
+      DOM_STRONG=$(npx agent-browser eval "Array.from(document.querySelectorAll('strong')).some(n => (n.textContent || '').includes('BoldChunk9b'))" | tr -d '"')
+      DOM_LI=$(npx agent-browser eval "Array.from(document.querySelectorAll('li')).filter(n => (n.textContent || '').includes('list-item-9b')).length" | tr -d '"')
+      [ "$DOM_STRONG" = "true" ] && pass "9b-viii. <strong>BoldChunk9b</strong> rendered as a real DOM node" \
+                                || fail "9b-viii. <strong> with BoldChunk9b not in DOM — HTML body still rendered as literal text"
+      if [ "${DOM_LI:-0}" = "2" ] 2>/dev/null; then
+        pass "9b-ix. <li> elements rendered (count=$DOM_LI, expected 2)"
+      else
+        fail "9b-ix. Expected 2 <li> nodes containing 'list-item-9b', got $DOM_LI"
+      fi
+      npx agent-browser close 2>/dev/null || true
+    else
+      skip "9b-viii/ix. agent-browser unavailable — DOM-shape assertions skipped (escaped-tag check above is the load-bearing one)"
+    fi
+
+    # 9b-x. Cleanup: unpublish.
+    UNPUB9B_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -b "$NEW_JAR" -X POST -H "Origin: $ORIGIN" "$SERVER_URL/wikis/$UAT9B_KEY/unpublish")
+    [ "$UNPUB9B_HTTP" = "200" ] && pass "9b-x. Unpublished UAT wiki (HTTP $UNPUB9B_HTTP)" \
+                               || skip "9b-x. Unpublish returned HTTP $UNPUB9B_HTTP — wiki delete below also tears down public access"
+  fi
+
+  # 9b-xi. Cleanup: delete the UAT wiki.
+  DEL9B_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -b "$NEW_JAR" -X DELETE -H "Origin: $ORIGIN" "$SERVER_URL/wikis/$UAT9B_KEY")
+  if [ "$DEL9B_HTTP" = "200" ] || [ "$DEL9B_HTTP" = "204" ]; then
+    pass "9b-xi. Deleted UAT wiki (HTTP $DEL9B_HTTP)"
+  else
+    skip "9b-xi. UAT wiki delete returned HTTP $DEL9B_HTTP — wiki may linger as an orphan"
+  fi
+fi
+
 # ── 10. CLEANUP — restore INITIAL_PASSWORD ────────────────────────
 # CRITICAL: if this fails, every subsequent UAT plan that signs in with
 # INITIAL_PASSWORD will lock out. We try the API path first, and fall
@@ -476,6 +620,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 7 | Anon `GET $WIKI_URL/p/<slug>` returns 200 HTML with wiki name, `og:title` + `og:type=article` meta, "Robin Wiki" branding, no authenticated chrome | `wiki/src/app/(public)/p/[nanoid]/page.tsx` + `PublishedWikiArticle.tsx` |
 | 8 | Anon mutating call (unpublish) returns 401; after authed unpublish, anon JSON + page both 404; bogus slug also 404 | `wikis.ts:503-525` + `published.ts:29-31` |
 | 9 | Profile UI renders Security → Change password section with three fields and mismatch validation message (skipped if agent-browser unavailable) | `wiki/src/app/profile/page.tsx` (PR #191) |
+| 9b | #253 — Public page renders HTML-saved bodies as DOM, not literal text: PUT an HTML body via `/api/content/wiki`, publish, anon-curl `/p/<slug>`; assert no escaped HTML tags (`&lt;p&gt;` etc.) in response, real `<strong>` / `<li>` DOM nodes present. Cleanup unpublishes + deletes the UAT wiki. | `wiki/src/components/wiki/PublishedWikiArticle.tsx:84` (current unconditional `MarkdownContent`), shell branch `wiki/src/app/(shell)/wiki/[id]/page.tsx:259-261` (`isHtmlBody` via leading `<`) |
 | 10 | Cleanup: `change-password` restores `INITIAL_PASSWORD`; `/auth/recover` fallback if step fails; final sign-in with `INITIAL_PASSWORD` confirms subsequent UAT plans are unblocked | better-auth + plan 07 fallback |
 
 ---
@@ -489,3 +634,4 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 - **OG metadata assertion.** `generateMetadata` in `page.tsx` emits `openGraph: { title, description, type: "article", publishedTime, siteName }`. Step 7c/7d look for `og:title` and `og:type=article`. Next.js renders these as `<meta property="og:title" ...>` in the SSR HTML — the assertion uses `property="..."` matching first, then falls back to `name="..."` for tooling that emits the older form.
 - **Cleanup is mandatory.** Step 10 uses two paths: the API restore (preferred — exercises the feature symmetrically) and the `/auth/recover` fallback from plan 07. The final assertion 10c is the gate: if `INITIAL_PASSWORD` does not sign in at the end of this plan, every later plan that depends on baseline auth (03, 04, 05, 06, 09, 16, 21, 22, …) will fail. A failing 10c should halt the suite.
 - **Storage is Postgres-only.** Password hashes live in `accounts.password` (bcrypt via better-auth). Published wiki rows live in `wikis` with `published`, `published_slug`, `published_at` columns. No filesystem state on either feature.
+- **Section 9b reproduces #253** (public page renders HTML-saved bodies as literal text via `MarkdownContent`). The deterministic input is an HTML body that begins with `<p>` — we PUT it through the same `/api/content/wiki/:key` endpoint Tiptap save uses. The bug-present signature is `&lt;p&gt;`, `&lt;strong&gt;`, `&lt;ul&gt;`, `&lt;li&gt;` appearing in the SSR HTML response (ReactMarkdown escapes raw HTML). The bug-fixed signature is real `<strong>` and `<li>` DOM nodes wrapping our chunks. Both halves are asserted: the escaped-tag grep is the load-bearing negative; the DOM-shape check via agent-browser is the load-bearing positive (skipped only if agent-browser is unavailable, in which case the negative carries the section). Section 9b creates and tears down its own UAT wiki — it never publishes the Transformer fixture, so it composes cleanly with section 5/6/7 which target the seeded Transformer.

--- a/.uat/plans/29-collections-and-similarity.md
+++ b/.uat/plans/29-collections-and-similarity.md
@@ -61,6 +61,12 @@ curl -s -c "$COOKIE_JAR" -X POST \
   "$SERVER_URL/api/auth/sign-in/email" >/dev/null
 
 UAT_TAG="uat29-$(date +%s)"
+# Anchor for strict count assertions in §5g and §8g. Anything created BEFORE
+# this timestamp belongs to a previous run; anything AFTER must satisfy the
+# §5/§8 invariants. Use ISO-8601 epoch so the literal can be quoted into psql
+# without worrying about embedded spaces — `now()::text` includes a space
+# between the date and time, and any tr -d ' ' would mangle the timestamp.
+TEST_START=$(psql "$DATABASE_URL" -t -A -c "SELECT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')" 2>/dev/null | tr -d '[:space:]')
 
 # ── 1. Issue #185 — Frontend relabel: Group → Collection ─────────
 # Backend stays at /groups (server contract). The frontend hook is renamed
@@ -467,6 +473,29 @@ else
   fail "5g. Edge attrs.method missing or wrong ($EDGE_ATTRS)"
 fi
 
+# 5g-strict. EVERY similarity edge created in the test window must carry
+# method='cosine-regen'. Catches BOTH callsites in one shot:
+#   - core/src/lib/regen.ts createRelatedToEdges (the regen-time path,
+#     which writes { score, method:'cosine-regen' })
+#   - packages/agent/src/stages/index.ts ~lines 217-234 (the linking-stage
+#     worker path, which currently writes { score } only — Issue #227).
+# Any edge in the window with NULL method or any other method value fails
+# the assertion. Live evidence: 100/100 edges currently lack method, so this
+# expected-fails today and turns green only when both insertEdge sites in
+# stages/index.ts gain `method:'cosine-regen'` in their attrs payloads.
+WINDOW_BAD_METHOD=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT COUNT(*) FROM edges
+  WHERE edge_type = 'FRAGMENT_RELATED_TO_FRAGMENT'
+    AND deleted_at IS NULL
+    AND created_at > '$TEST_START'::timestamptz
+    AND (attrs->>'method') IS DISTINCT FROM 'cosine-regen'
+" 2>/dev/null | tr -d ' ')
+if [ "${WINDOW_BAD_METHOD:-1}" = "0" ]; then
+  pass "5g-strict. All test-window FRAGMENT_RELATED_TO_FRAGMENT edges carry method='cosine-regen'"
+else
+  fail "5g-strict. $WINDOW_BAD_METHOD test-window edge(s) missing method='cosine-regen' — worker path (stages/index.ts) regression"
+fi
+
 EDGE_SCORE=$(echo "$EDGE_ATTRS" | jq -r '.score // 0' 2>/dev/null)
 if awk "BEGIN{exit !($EDGE_SCORE >= 0.75)}" 2>/dev/null; then
   pass "5h. Edge attrs.score = $EDGE_SCORE (>= 0.75 threshold)"
@@ -555,6 +584,121 @@ if [ -z "$POST_HAS_B" ]; then
 else
   fail "6c. Soft-deleted fragment still surfaces in relatedFragments ($POST_HAS_B)"
 fi
+
+# ── 6.5 Issue #228 — DELETE /fragments/:id route + edge cascade ──
+# The route must:
+#   1. exist (HTTP 204 on a real key)
+#   2. soft-delete the fragment row (fragments.deleted_at NOT NULL)
+#   3. soft-delete every edge referencing the fragment in either direction:
+#      FRAGMENT_IN_WIKI, FRAGMENT_RELATED_TO_FRAGMENT (both src and dst),
+#      FRAGMENT_MENTIONS_PERSON, ENTRY_HAS_FRAGMENT.
+# Live evidence today: HTTP 404 — the handler is absent from
+# core/src/routes/fragments.ts. This whole subsection expected-fails until
+# the route lands. Pattern to match: DELETE /wikis/:id at
+# core/src/routes/wikis.ts:715-739 (lookup → 404 if missing → soft-delete
+# row + cascade related joins → audit emit → c.body(null, 204)).
+
+# 6d. Create a fresh UAT fragment to exercise the delete in isolation —
+#     do NOT reuse FRAG_A/FRAG_B/FRAG_D from earlier so cleanup paths in §11
+#     don't have to special-case it.
+FRAG_TEXT_DEL="Self-attention, the heart of transformers, lets every position attend to every other position in one parallel pass. [run=$UAT_TAG]"
+ENTRY_DEL=$(curl -s -X POST -b "$COOKIE_JAR" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg c "$FRAG_TEXT_DEL" --arg t "uat29-frag-del-$UAT_TAG" '{title:$t,content:$c}')" \
+  "$SERVER_URL/entries")
+ENTRY_DEL_KEY=$(echo "$ENTRY_DEL" | jq -r '.lookupKey // .id // ""')
+
+# Wait for pipeline to land the fragment + at least one outgoing edge so the
+# cascade assertion below has something non-trivial to chew on (60s budget;
+# embeddings + classification + fragRelate must complete).
+DEADLINE=$(($(date +%s) + 60))
+FRAG_DEL_KEY=""
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  FRAG_DEL_KEY=$(psql "$DATABASE_URL" -t -A -c "
+    SELECT lookup_key FROM fragments
+    WHERE entry_id = '$ENTRY_DEL_KEY' AND deleted_at IS NULL AND state = 'RESOLVED'
+    LIMIT 1
+  " 2>/dev/null | tr -d ' ')
+  [ -n "$FRAG_DEL_KEY" ] && break
+  sleep 3
+done
+
+if [ -n "$FRAG_DEL_KEY" ]; then
+  pass "6d. UAT delete-target fragment created and resolved ($FRAG_DEL_KEY)"
+else
+  fail "6d. delete-target fragment never resolved within 60s — pipeline regression masked the §6.5 test"
+fi
+
+# 6e. Snapshot the edge graph BEFORE the delete so the cascade assertion
+#     can compare against a known surface. Count active edges that reference
+#     FRAG_DEL_KEY in EITHER direction across all five edge types we care about.
+PRE_EDGE_COUNT=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT COUNT(*) FROM edges
+  WHERE deleted_at IS NULL
+    AND edge_type IN (
+      'FRAGMENT_IN_WIKI',
+      'FRAGMENT_RELATED_TO_FRAGMENT',
+      'FRAGMENT_MENTIONS_PERSON',
+      'ENTRY_HAS_FRAGMENT'
+    )
+    AND ('$FRAG_DEL_KEY' IN (src_id, dst_id))
+" 2>/dev/null | tr -d ' ')
+echo "  (pre-delete: $PRE_EDGE_COUNT active edge(s) reference $FRAG_DEL_KEY)"
+
+# 6f. DELETE /fragments/:lookupKey returns 204.
+DEL_FRAG_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE -b "$COOKIE_JAR" \
+  -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments/$FRAG_DEL_KEY")
+if [ "$DEL_FRAG_HTTP" = "204" ]; then
+  pass "6f. DELETE /fragments/:lookupKey → 204"
+else
+  fail "6f. DELETE /fragments/:lookupKey → HTTP $DEL_FRAG_HTTP (expected 204) — Issue #228 route missing"
+fi
+
+# 6g. fragments.deleted_at IS NOT NULL after delete.
+DEL_AT=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT deleted_at IS NOT NULL FROM fragments WHERE lookup_key = '$FRAG_DEL_KEY'
+" 2>/dev/null | tr -d ' ')
+if [ "$DEL_AT" = "t" ]; then
+  pass "6g. fragments.deleted_at IS NOT NULL after delete"
+else
+  fail "6g. fragments.deleted_at still null (got '$DEL_AT') — soft-delete didn't land"
+fi
+
+# 6h. Strict cascade: ALL edges that referenced FRAG_DEL_KEY (in either
+#     direction, across the four relevant edge types) must have
+#     deleted_at IS NOT NULL. Asserts zero rows where the fragment is
+#     referenced AND the edge is still active. Catches the case where the
+#     route soft-deletes the row but leaves dangling edges live.
+ACTIVE_REFS=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT COUNT(*) FROM edges
+  WHERE deleted_at IS NULL
+    AND edge_type IN (
+      'FRAGMENT_IN_WIKI',
+      'FRAGMENT_RELATED_TO_FRAGMENT',
+      'FRAGMENT_MENTIONS_PERSON',
+      'ENTRY_HAS_FRAGMENT'
+    )
+    AND ('$FRAG_DEL_KEY' IN (src_id, dst_id))
+" 2>/dev/null | tr -d ' ')
+if [ "${ACTIVE_REFS:-1}" = "0" ]; then
+  pass "6h. All $PRE_EDGE_COUNT edges referencing $FRAG_DEL_KEY soft-deleted (cascade complete)"
+else
+  fail "6h. $ACTIVE_REFS edge(s) still active after fragment delete — cascade incomplete"
+fi
+
+# 6i. Cleanup: hard-delete the §6.5 UAT fragment + its edges + its entry +
+#     its raw_source so subsequent runs don't accumulate near-duplicate
+#     transformer corpus rows. Hard delete on this single row is safe
+#     because the §11 cleanup already covers the wider $UAT_TAG sweep.
+psql "$DATABASE_URL" -v ON_ERROR_STOP=0 <<SQL >/dev/null 2>&1
+  DELETE FROM edges
+  WHERE '$FRAG_DEL_KEY' IN (src_id, dst_id);
+  DELETE FROM fragments WHERE lookup_key = '$FRAG_DEL_KEY';
+  DELETE FROM raw_sources WHERE lookup_key = '$ENTRY_DEL_KEY';
+SQL
 
 # ── 7. Issue #164 — relatedFragments in /fragments/:id ───────────
 
@@ -776,6 +920,34 @@ else
   skip "8f. FRAG_A has no FRAGMENT_IN_WIKI edge — cannot resolve owning wiki"
 fi
 
+# 8g. Strict pairing: every test-window FRAGMENT_RELATED_TO_FRAGMENT edge
+#     must have produced exactly two related_detected audit rows (one per
+#     direction — emitAuditEvent fires once for each fragment in the pair).
+#     Catches BOTH callsites in one shot:
+#       - core/src/lib/regen.ts (already emits both directions correctly)
+#       - packages/agent/src/stages/index.ts ~lines 217-234 (worker path
+#         currently emits ZERO audit events — Issue #229)
+#     Live evidence: ~100 worker-path edges exist with 0 audit pairs and ~2
+#     regen.ts edges with 2 audit rows (1 pair). When the worker path is
+#     fixed, audit_count must equal 2 * edge_count for the test window.
+WINDOW_EDGE_COUNT=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT COUNT(*) FROM edges
+  WHERE edge_type = 'FRAGMENT_RELATED_TO_FRAGMENT'
+    AND deleted_at IS NULL
+    AND created_at > '$TEST_START'::timestamptz
+" 2>/dev/null | tr -d ' ')
+WINDOW_AUDIT_COUNT=$(psql "$DATABASE_URL" -t -A -c "
+  SELECT COUNT(*) FROM audit_log
+  WHERE event_type = 'related_detected'
+    AND created_at > '$TEST_START'::timestamptz
+" 2>/dev/null | tr -d ' ')
+EXPECTED_AUDIT=$((2 * ${WINDOW_EDGE_COUNT:-0}))
+if [ "${WINDOW_AUDIT_COUNT:-0}" = "$EXPECTED_AUDIT" ] && [ "$EXPECTED_AUDIT" -gt 0 ]; then
+  pass "8g. Strict audit pairing: $WINDOW_AUDIT_COUNT audit rows = 2 * $WINDOW_EDGE_COUNT edges"
+else
+  fail "8g. Audit pairing mismatch: $WINDOW_AUDIT_COUNT audit rows vs expected $EXPECTED_AUDIT (2 × $WINDOW_EDGE_COUNT edges) — worker path missing emitAuditEvent"
+fi
+
 # ── 9. Schema invariants — RELATED edge uniqueness ───────────────
 # edges has a UNIQUE (src_type, src_id, dst_type, dst_id, edge_type) index;
 # repeating classification must not create duplicate edges (idempotency).
@@ -876,8 +1048,10 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 3 | `/groups` list/detail/error contracts | #45/#185 | core/routes/groups.ts |
 | 4 | Membership CRUD (add, remove, count, negatives) | #45  | groups membership routes |
 | 5 | Bidirectional FRAGMENT_RELATED_TO_FRAGMENT edges, ≥0.75 score | #163 | createRelatedToEdges in regen.ts |
+| 5g-strict | EVERY test-window similarity edge has attrs.method='cosine-regen' | #227 | both callsites must agree |
 | 5j | Below-threshold pair NOT linked | #163 | RELATED_FRAGMENT_THRESHOLD |
 | 6 | Soft-deleted partner excluded from related-fragments response | #163/#164 | fragments route filter |
+| 6.5 | DELETE /fragments/:id route + edge cascade | #228 | fragments.ts DELETE handler (currently absent) |
 | 7 | `/fragments/:id` returns relatedFragments[] with correct shape | #164 | fragmentDetailResponseSchema |
 | 7d | relatedFragments sorted by similarity desc | #164 | fragments route sort |
 | 7e | Frontend renders 'Related fragments' section with %, links | #164 | fragments/[id]/page.tsx |
@@ -885,6 +1059,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 8 | `related_detected` audit events on both fragments | #165 | emitAuditEvent in regen.ts |
 | 8c | audit detail jsonb shape (fragmentKey/relatedKey/sim/wikiKey) | #165 | audit emit payload |
 | 8f | timeline endpoint surfaces related_detected | #165 | wikis/:id/timeline |
+| 8g | Strict audit pairing: audit count = 2 × edge count in window | #229 | both callsites must emit |
 | 9 | onConflictDoNothing keeps edges unique per (src,dst) | #163 | edges_src_dst_type_uidx |
 | 9b | Edge attrs key is `score` (matches PR), not `similarity` | #163 | regen.ts attrs payload |
 | 10| Unauthenticated /groups + /fragments → 401 | all | sessionMiddleware |
@@ -907,11 +1082,24 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
   field name on the API response. The underlying edge `attrs` jsonb,
   however, uses the key `score` (not `similarity`); section 9b pins this
   so future readers don't conflate the two.
-- **Issue #163 trigger surface.** PR #192 adds `createRelatedToEdges` calls
-  inside `classifyUnfiledFragments()` only — the ticket also mentioned the
-  `worker.ts` `insertEdge` callback. This plan exercises the
-  classifier-time path; the worker path is not shipped in #192 and is
-  out of scope here.
+- **Issue #163 trigger surface — TWO callsites, both in scope.** Similarity
+  edges land via two independent paths and the `attrs.method` + audit-event
+  contract must hold on both:
+  1. `core/src/lib/regen.ts` `createRelatedToEdges()` — the regen-time path
+     used when `classifyUnfiledFragments()` files a previously-unfiled
+     fragment into a wiki. This path was patched in PR #192's follow-ups
+     and currently writes `{ score, method:'cosine-regen' }` plus emits
+     `related_detected` audit events for both fragments.
+  2. `packages/agent/src/stages/index.ts` `runLinking` orchestrator
+     (~lines 217-234) — the live worker path that runs on every fresh
+     fragment via `fragRelate`. Currently writes `{ score }` only and
+     emits zero audit events. This is the dual root cause of #227 + #229.
+  Sections **5g-strict** and **8g** assert the contract across the test
+  window without naming a callsite, so a regression in either path fails.
+- **Issue #228 — DELETE /fragments/:id is absent.** §6.5 expected-fails
+  today (HTTP 404 + cascade impossible). Pattern to mirror lives at
+  `core/src/routes/wikis.ts:715-739` (DELETE /wikis/:id soft-delete +
+  cascade + audit emit + `c.body(null, 204)`).
 - **Embedding lag.** Sections 5/7 poll up to 90s for the entry pipeline to
   produce embeddings + classification. On a slow stack increase the
   `DEADLINE` budget rather than asserting failure.

--- a/.uat/plans/31-test-suite-fidelity.md
+++ b/.uat/plans/31-test-suite-fidelity.md
@@ -1,0 +1,351 @@
+# 31 — Test Suite Fidelity
+
+## What it proves
+
+Three facets of issue #222 (closes the false-green gap surfaced in PR
+#214 review):
+
+**(A) `regen.test.ts` runs without swallowed `TypeError`.** A vitest run
+of `core/src/lib/regen.test.ts` produces zero `TypeError` lines on
+stderr/stdout. Specifically the line
+`TypeError: database.select(...).from(...).where(...).limit is not a function`
+emitted from `core/src/lib/regen.ts:211` (inside
+`classifyUnfiledFragments`) must be absent. Today every one of the 10
+tests triggers this error and the throw is swallowed by the
+`try/catch` at `core/src/lib/regen.ts:381` (`'unfiled fragment
+classification failed — continuing with existing fragments'`), so the
+suite passes 10/10 green while the classification pre-step is never
+actually exercised under test.
+
+**(B) The classify codepath is mechanically reachable from at least
+one test.** Static check on `core/src/lib/regen.test.ts`: the fake DB
+chain returned from `selectChain().from().where()` exposes a `.limit`
+function (the missing terminal that `classifyUnfiledFragments` calls
+at `regen.ts:211`). This is the structural fix the issue asks for.
+Belt-and-braces, the test file should also stage at least one
+DB-response queue entry intended to be popped by `.limit(1)` — i.e.
+the suite must demonstrate awareness that `classifyUnfiledFragments`
+runs. Without this, fixing the mock alone could still leave the
+codepath unverified.
+
+**(C) Codebase-wide warn-and-continue surface is documented.** Hunt
+for `} catch (...) { log.warn(...) }` patterns elsewhere in `core/src/`
+that could mask similar false-greens (an exception is swallowed, a
+warn is logged, execution continues — and tests against that codepath
+report green). This section does not fail the plan; it emits SKIP
+entries for each instance so the surface is documented for future
+hardening. The output is the artifact.
+
+## Prerequisites
+
+- Repo at the commit being audited; `pnpm install` has run at the
+  workspace root.
+- `pnpm` available; vitest runs via `pnpm -C core test` (the package's
+  configured test script under `core/package.json`).
+- No running stack required — vitest is a unit-test runner and these
+  tests fully mock `../db/client.js` and `@robin/agent`.
+
+## Fixture identity this plan references
+
+- Target test file: `core/src/lib/regen.test.ts` (10 tests, all
+  exercise `regenerateWiki` which calls `classifyUnfiledFragments`).
+- Production code under test: `core/src/lib/regen.ts:200-244`
+  (`classifyUnfiledFragments`, the function whose `.limit(1)` call at
+  line 211 throws against the current mock).
+- Swallow site: `core/src/lib/regen.ts:381-383`.
+- Vitest output capture: `/tmp/uat-31-vitest.log` (overwritten each
+  run).
+
+## Restoring downstream-plan state
+
+Read-only — no DB writes, no stack changes, no env mutation. Leaves no
+residue for downstream plans.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "31 — Test Suite Fidelity (#222 false-green audit)"
+echo ""
+
+VITEST_LOG=/tmp/uat-31-vitest.log
+: > "$VITEST_LOG"
+
+# ── 0. Sanity: target files exist ────────────────────────────
+# If the test file or its production target moved, every assertion below
+# would skip silently — fail loud here so the operator notices.
+
+if [ -f core/src/lib/regen.test.ts ]; then
+  pass "0a. core/src/lib/regen.test.ts exists"
+else
+  fail "0a. core/src/lib/regen.test.ts missing — file moved or renamed?"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+if [ -f core/src/lib/regen.ts ]; then
+  pass "0b. core/src/lib/regen.ts exists"
+else
+  fail "0b. core/src/lib/regen.ts missing — file moved or renamed?"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Confirm the swallow site still matches the issue's quoted location.
+# If line 381 no longer holds the catch+warn, the assertions below may
+# be auditing the wrong surface.
+SWALLOW_LINE=$(grep -n "unfiled fragment classification failed" core/src/lib/regen.ts | head -1 | cut -d: -f1)
+if [ -n "$SWALLOW_LINE" ]; then
+  pass "0c. swallow site found at core/src/lib/regen.ts:$SWALLOW_LINE"
+else
+  skip "0c. swallow site log message not found — fix may already be in"
+fi
+
+# ── 1. §1 — vitest run produces ZERO TypeError lines ─────────
+# This is the behavioral assertion. Run regen.test.ts in isolation,
+# capture combined stdout+stderr, and grep for TypeError. The bug is
+# present iff the swallowed TypeError is logged. The test suite is
+# expected to PASS green either way (that's the whole bug); the
+# fidelity signal is the absence of TypeError lines.
+#
+# We DO NOT fail on test exit code here — a green suite with TypeError
+# logs is exactly the false-green condition we're auditing. The
+# assertion is on the log shape.
+
+echo "  ▸ running pnpm -C core test src/lib/regen.test.ts (capturing to $VITEST_LOG)..."
+pnpm -C core test src/lib/regen.test.ts > "$VITEST_LOG" 2>&1
+VITEST_EXIT=$?
+
+# Sanity: the test suite should at least have RUN (exit 0 or 1, not
+# crashed mid-collection). A crash means the mock fix introduced a
+# different failure we want to surface.
+if [ $VITEST_EXIT -eq 0 ] || [ $VITEST_EXIT -eq 1 ]; then
+  pass "1a. vitest produced a result (exit=$VITEST_EXIT)"
+else
+  fail "1a. vitest crashed (exit=$VITEST_EXIT) — see $VITEST_LOG"
+fi
+
+# Primary assertion: the specific TypeError signature from #222 is gone.
+TYPE_ERR_HITS=$(grep -c 'database\.select(\.\.\.)\.from(\.\.\.)\.where(\.\.\.)\.limit is not a function' "$VITEST_LOG" || true)
+if [ "${TYPE_ERR_HITS:-0}" -eq 0 ]; then
+  pass "1b. zero '.where(...).limit is not a function' lines in vitest output (#222 fixed)"
+else
+  fail "1b. found $TYPE_ERR_HITS '.where(...).limit is not a function' lines — #222 still present (mock chain missing .limit())"
+fi
+
+# Broader assertion: any TypeError anywhere in the vitest output is a
+# false-green smell. Pino logs the type on one line and the message on
+# the next, so we count BOTH 'TypeError:' (message line) and
+# '"type": "TypeError"' (pino-formatted err object line) and require
+# both to be zero.
+TYPE_ERR_MSG=$(grep -cE '^[[:space:]]*TypeError:' "$VITEST_LOG" || true)
+TYPE_ERR_PINO=$(grep -cE '"type":[[:space:]]*"TypeError"' "$VITEST_LOG" || true)
+TOTAL_TYPE_ERRS=$((TYPE_ERR_MSG + TYPE_ERR_PINO))
+if [ "$TOTAL_TYPE_ERRS" -eq 0 ]; then
+  pass "1c. zero TypeError lines in vitest output (msg=$TYPE_ERR_MSG, pino-err=$TYPE_ERR_PINO)"
+else
+  fail "1c. found $TOTAL_TYPE_ERRS TypeError lines (msg=$TYPE_ERR_MSG, pino-err=$TYPE_ERR_PINO) — false-green vector"
+fi
+
+# Belt-and-braces: the swallow log itself ('unfiled fragment
+# classification failed — continuing with existing fragments') should
+# also be absent under a real fix. If the mock now lets .limit() run
+# clean, the catch block at regen.ts:381 should never trigger.
+SWALLOW_HITS=$(grep -c 'unfiled fragment classification failed' "$VITEST_LOG" || true)
+if [ "${SWALLOW_HITS:-0}" -eq 0 ]; then
+  pass "1d. zero 'unfiled fragment classification failed' warns — catch block at regen.ts:381 never fired"
+else
+  fail "1d. found $SWALLOW_HITS swallow-warn lines — classify path still throwing under the hood"
+fi
+
+# Suite must still be green. A fix that makes regen.test.ts go red is
+# itself a regression — the production code's behavior under correct
+# mocks is the new bar.
+PASSING=$(grep -E 'Tests +[0-9]+ passed' "$VITEST_LOG" | head -1)
+if echo "$PASSING" | grep -q 'passed'; then
+  pass "1e. vitest summary reports tests passed: '$PASSING'"
+else
+  fail "1e. vitest summary missing or shows failures — see $VITEST_LOG"
+fi
+
+# ── 2. §2 — classify codepath is reachable from the mock ─────
+# Static check: the fake DB chain in regen.test.ts must expose .limit()
+# on the .where() return. Without this, classifyUnfiledFragments throws
+# at regen.ts:211 and the codepath stays unverified.
+#
+# Strategy: parse the test file. The selectChain mock starts at the
+# `function selectChain()` declaration. .where()'s return must include
+# a `limit:` key (function or arrow). If it's only `then:`, `orderBy:`,
+# `groupBy:`, the bug is still present.
+
+# Pull the lines of regen.test.ts that contain the selectChain inner
+# return and check for a `limit:` key DIRECTLY inside the .where()
+# return object (depth=1 relative to the `return {` after `.where(...)`).
+# Naive grep would false-positive on the nested `orderBy: () => ({ limit: ... })`
+# which is depth=2 — different scope. Track brace depth manually.
+WHERE_RETURN_HAS_LIMIT=$(awk '
+  function count_char(s, c,    n, i) {
+    n = 0
+    for (i = 1; i <= length(s); i++) if (substr(s, i, 1) == c) n++
+    return n
+  }
+  /function selectChain/ { in_chain = 1 }
+  in_chain && !in_where && /where:[[:space:]]*\(/ {
+    in_where = 1
+    depth = 0
+    next
+  }
+  in_where {
+    opens = count_char($0, "{")
+    closes = count_char($0, "}")
+    # Detect the where-handlers return-object opener: `return {` on the
+    # line AFTER the deferred-promise plumbing. Once depth > 0, we are
+    # INSIDE the returned object; depth==1 entries are siblings of `then`.
+    if (depth == 1 && $0 ~ /^[[:space:]]*limit:/) { found = 1; exit }
+    depth += opens - closes
+    if (depth < 0) { in_where = 0; depth = 0 }
+  }
+  END { print (found ? "yes" : "no") }
+' core/src/lib/regen.test.ts)
+
+if [ "$WHERE_RETURN_HAS_LIMIT" = "yes" ]; then
+  pass "2a. regen.test.ts selectChain.where() returns a .limit (mock now realistic)"
+else
+  fail "2a. regen.test.ts selectChain.where() return is missing .limit — #222's structural fix not applied"
+fi
+
+# Classifier-awareness: at least one stage in the response queue should
+# be intended for the .limit(1) wiki lookup at regen.ts:201-211. We
+# can't directly attribute a queue entry to a specific call, but we
+# can check that the test file references either `classifyUnfiledFragments`
+# directly OR has a comment block describing the classify pre-step's
+# response staging.
+CLASSIFY_AWARE=$(grep -cE 'classifyUnfiledFragments|classify (pre-)?step|wiki lookup.*limit\(1\)|unfiled' core/src/lib/regen.test.ts || true)
+if [ "${CLASSIFY_AWARE:-0}" -ge 1 ]; then
+  pass "2b. regen.test.ts shows awareness of classify pre-step ($CLASSIFY_AWARE references)"
+else
+  fail "2b. regen.test.ts has zero references to the classify pre-step — fix may have patched the mock without staging responses for the new codepath"
+fi
+
+# ── 3. §3 — warn-and-continue surface (SKIP-with-log only) ───
+# Codebase-wide hunt for `} catch (...) { log.warn(...) }` blocks in
+# core/src/. Each is a candidate for the same false-green class as
+# #222: an exception is swallowed, a warn is logged, the test (if any)
+# sees green even though the codepath is broken.
+#
+# We DO NOT fail on count — every one of these may be intentional
+# best-effort behavior (audit emit, cleanup-on-error, etc.). The point
+# is to surface the surface for future hardening and to make any new
+# warn-and-continue addition grep-able later.
+
+echo ""
+echo "  ── §3 surface scan: catch + log.warn blocks in core/src/ ──"
+SURFACE_COUNT=0
+while IFS= read -r line; do
+  SURFACE_COUNT=$((SURFACE_COUNT+1))
+  # Each line is "<file>-<lineno>-  } catch (<var>) {" — strip to file:line.
+  LOC=$(echo "$line" | sed -E 's/^([^-]+)-([0-9]+)-.*/\1:\2/')
+  skip "    $LOC — catch+log.warn block"
+done < <(grep -rn -B2 'log\.warn' core/src/ --include='*.ts' 2>/dev/null | grep -E 'catch \(' || true)
+
+echo "  ▸ surfaced $SURFACE_COUNT catch+log.warn block(s) in core/src/"
+
+# Of those, the regen.ts:381 swallow specifically — call it out by name
+# because it's the one #222 names and the one that masks the
+# classifyUnfiledFragments throw. If/when the test suite asserts on the
+# warn (or the swallow is replaced with a re-throw), this entry can move
+# from SKIP to PASS.
+REGEN_SWALLOW_PRESENT=$(grep -n 'unfiled fragment classification failed' core/src/lib/regen.ts | head -1 | cut -d: -f1)
+if [ -n "$REGEN_SWALLOW_PRESENT" ]; then
+  skip "  §3-named: core/src/lib/regen.ts:$REGEN_SWALLOW_PRESENT — the #222 swallow itself; consider re-throwing or asserting on the warn in tests"
+else
+  pass "  §3-named: core/src/lib/regen.ts swallow log removed (re-throw or warn-asserted)"
+fi
+
+# ── Cleanup — none required ──────────────────────────────────
+# Vitest writes only to /tmp/uat-31-vitest.log; downstream plans don't
+# read it. No DB writes, no stack mutation. Plan is read-only.
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```
+
+---
+
+## Pass/Fail Summary
+
+| # | Assertion | Source |
+|---|-----------|--------|
+| 0 | `regen.test.ts` and `regen.ts` exist; swallow site at `regen.ts:381` still matches | `core/src/lib/regen.{ts,test.ts}` |
+| 1a | vitest produces a result (no mid-collection crash) | `pnpm -C core test src/lib/regen.test.ts` |
+| 1b | Zero `'.where(...).limit is not a function'` lines in vitest output | `core/src/lib/regen.ts:211` |
+| 1c | Zero `TypeError` stack frames originating in `regen.ts` | vitest stderr |
+| 1d | Zero `'unfiled fragment classification failed'` warns — catch at `regen.ts:381` never fires | `core/src/lib/regen.ts:381-383` |
+| 1e | vitest summary reports tests passed (suite stays green under the fix) | vitest summary line |
+| 2a | `selectChain.where()` return in test file exposes a `.limit` key (mock realistic) | `core/src/lib/regen.test.ts:79-101` |
+| 2b | Test file references the classify pre-step (`classifyUnfiledFragments`, `unfiled`, etc.) — proves awareness, not just mechanical mock patch | `core/src/lib/regen.test.ts` |
+| 3 | Each `} catch { log.warn() }` block in `core/src/` is surfaced as a SKIP entry; the `regen.ts:381` swallow is named explicitly | `grep -rn -B2 'log\.warn' core/src/` |
+| Cleanup | None — read-only plan | n/a |
+
+---
+
+## Notes
+
+- **§1 is expected to FAIL until #222 is fixed.** That's the point. A
+  passing §1 means either the mock chain now exposes `.limit()` (the
+  structural fix) or the swallow at `regen.ts:381` has been replaced
+  with a re-throw or a warn-assertion — both are acceptable resolutions
+  of #222. A green §1 on current `main` would indicate the assertion is
+  matching the wrong substring; verify the literal grep against the
+  vitest log if that ever happens.
+- **§1d is the deeper signal.** §1b checks the literal TypeError
+  message; §1d checks the warn line that the catch emits. A fix that
+  changes the error type (e.g. typed mock returns `undefined` instead
+  of throwing) could pass §1b while §1d still flags. The combination
+  is harder to false-pass.
+- **§2a uses awk, not jq, to parse the test file.** TypeScript isn't
+  JSON; the cheap structural check is "between `where: (` and the
+  matching `})`, does a `limit:` key appear?". This catches the common
+  fix shape but accepts variations (function, arrow, async). If the
+  test file is restructured (e.g. extracted into a helper), §2a may
+  false-fail; the operator should re-check by hand and update the awk
+  block.
+- **§3 is intentionally a SKIP list, not a pass/fail.** Most catch +
+  log.warn blocks in `core/src/` are intentional best-effort handlers
+  (audit emit at `db/audit.ts:31-33`, regen-on-accept enqueue at
+  `routes/fragments.ts:298-300`, embedding-retry at
+  `queue/embedding-retry-worker.ts:40`, etc.). Failing the plan on
+  these would punish correct code. The artifact value is the list
+  itself — when adding a new test that asserts on a codepath behind
+  one of these handlers, check this list first.
+- **Why not just run all of `pnpm -C core test`?** Two reasons. First,
+  `regen.test.ts` is the file #222 names — focusing on it keeps the
+  signal strong and the run fast (~1s vs ~30s for the full suite).
+  Second, other test files have their own DB mocks with their own
+  quirks; broadening §1 to the full suite would mix #222's signal
+  with unrelated noise from other modules. A future plan can extend
+  to the full suite once §3's surface scan is hardened.
+- **Live confirmation on `main` at the plan-write commit.** Before
+  writing this plan, the operator ran
+  `pnpm -C core test src/lib/regen.test.ts` and observed: 10/10 tests
+  pass green AND every `regenerateWiki` call (one per test) emits the
+  swallowed TypeError on stderr. The error count scales linearly with
+  test count — confirming the path is silently broken in every test,
+  not just one edge case. §1b on current `main` should report ~10
+  hits and FAIL; that's the assertion design working as intended.
+- **Storage is Postgres-only for the production code under test.** The
+  classify path queries `wikis`, `fragments`, `edges` — all DB rows.
+  No filesystem reads, no git-backed markdown. The mock under audit
+  reflects that: it stubs `../db/client.js`, nothing else.

--- a/.uat/plans/32-search-recall.md
+++ b/.uat/plans/32-search-recall.md
@@ -1,0 +1,482 @@
+# 32 — Search Recall (BM25 OR-join + tags woven into search_vector + trigger fires on edits)
+
+## What it proves
+
+Issue #249 — three independent recall gaps in BM25 search, all visible to
+users as "I know I wrote that — why doesn't it surface?":
+
+**(§1) BM25 OR-join.** `core/src/lib/search.ts:82` calls
+`plainto_tsquery('english', q)` which **AND-joins** every stem. A query
+`"divya europe travel"` requires *every* stem to match, so a fragment
+titled `"Divya in Europe"` (no "travel" stem) does not surface even
+though it's the obvious top hit. The fix replaces `plainto_tsquery` with
+a sanitized `to_tsquery('a | b | c')`. `ts_rank` continues to score
+all-terms-matched docs higher than partial-match docs, so quality stays
+intact while recall opens up.
+
+**(§2) Tag-vectorisation.** `fragments_search_vector_update()` (defined
+in `core/drizzle/migrations/0000_init.sql` line 340) covers `title`+
+`content` only. Fragment **tags** are never woven in — tag-only queries
+are silently broken. The fix weaves tags at weight C and adds a one-time
+backfill so deployed rows recover.
+
+**(§3) Trigger on content edit.** Live `pg_trigger.tgattr` confirms each
+table fires only on a partial column set:
+- `fragments_search_vector_trigger` UPDATE OF **{title}** — content
+  edits drift the index.
+- `wikis_search_vector_trigger` UPDATE OF **{name, prompt}** — content
+  edits drift the index.
+- `people_search_vector_trigger` UPDATE OF **{name, relationship}** —
+  content (and aliases) edits drift the index.
+The fix expands each trigger's UPDATE-OF list to cover content (and
+tags, on fragments).
+
+**(§4) Same shape on wikis and people.** Per the issue: trigger-on-
+content gap applies identically to `wikis` and `people`. (Tag-vector-
+isation is fragments-specific; wikis/people have no tags column — but
+they DO have analogous columns the trigger silently misses on UPDATE.)
+
+**(§5) Rank stability.** Regression guard: after the OR-join change, an
+all-terms-matched doc must still rank strictly above a partial-match
+doc. Otherwise OR-join silently flattens the ranking signal and we've
+traded recall for a worse user experience. Live probe shows `ts_rank`
+returns 0.0608 (3-match) > 0.0405 (2-match) > 0.0203 (1-match) — clean
+separation, so this guard is real, not vacuous.
+
+## Pre-fix expectations
+
+This plan is **written before** PR-249 is merged. On the current
+`main`, sections §1, §2, §3a/§3b/§3c, §4a, §4b are expected to **fail**.
+§5 (rank-stability) and the "AND-strict still works for fully-matched
+queries" sub-cases are expected to **pass** on both pre- and post-fix.
+After PR-249 merges, every assertion should pass.
+
+## Prerequisites
+
+- Core running on `SERVER_URL` with PR-249 merged (or pre-fix to confirm
+  assertions fail in the documented places).
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` set in `core/.env`.
+- `jq` and `curl` installed.
+- `psql` with `DATABASE_URL` configured. Tag-vector and trigger checks
+  read `search_vector` directly from the row; without psql those
+  sections degrade to skip.
+
+## Fixture identity this plan references
+
+- Per-run salt `RUN_ID="$(date +%s)-$$"` woven into every title/content
+  string so the shared search corpus stays predictable across reruns.
+- Per-run UAT raw_source (entry): `uat32-recall-<RUN_ID>` — the parent
+  `entryId` every fragment created here points to.
+- Per-run UAT fragments (fragments table):
+  - `Divya in Europe <RUN_ID>` — §1 AND-strict probe.
+  - `ML Tagged Note <RUN_ID>` (tags=`["machine-learning"]`) — §2 tag
+    probe. Body deliberately lacks the tag stem.
+  - `Edit Probe <RUN_ID>` — §3 trigger-on-content probe; content gets
+    rewritten via psql to bypass the orthogonal `PUT /fragments/:id`
+    bug (see "Notes" — that route currently never writes
+    `updates.content`, only `updates.dedupHash`, so an API-level edit
+    couldn't isolate the trigger gap).
+  - `RankAll <RUN_ID>` / `RankPartial <RUN_ID>` — §5 rank-stability
+    probes.
+- Per-run UAT wiki: `UAT32 Wiki <RUN_ID>` — §4 trigger-on-content for
+  wikis.
+- Per-run UAT person: `UAT32 Person <RUN_ID>` (slug salted) — §4
+  trigger-on-content for people.
+
+## Restoring downstream-plan state
+
+Cleanup at the end deletes every per-RUN_ID row (fragments, wiki,
+person) and the per-RUN_ID raw_source. Plans 08–10 / 22 / 29 / 99 see
+no drift; the seeded corpus they depend on is untouched.
+
+## Notes — orthogonal bugs observed during plan-write
+
+- `PUT /fragments/:id` (`core/src/routes/fragments.ts:213`) handles a
+  `body.content` field by writing `updates.dedupHash =
+  computeContentHash(body.content)` but **never** sets
+  `updates.content` itself. Live confirmed: a PUT with content sets
+  dedupHash, leaves content unchanged. This is **not** what #249 fixes
+  — flagged separately. The plan deliberately uses a direct psql
+  UPDATE to mutate content for §3 so it isolates the trigger gap.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:${PORT:-3000}}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-32-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+# Per-run salt — search corpus is shared across plans, so every probe
+# string carries RUN_ID to keep matches deterministic across reruns.
+RUN_ID="$(date +%s)-$$"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "32 — Search Recall (BM25 OR-join + tags + trigger-on-edit)"
+echo ""
+
+# ── 0. Sign in (web cookie) ──────────────────────────────────
+curl -s -o /dev/null -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+
+if [ -s "$COOKIE_JAR" ]; then
+  pass "0a. sign-in established a session cookie"
+else
+  fail "0a. sign-in failed — every step below would skip"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Create the parent entry (raw_source) every fragment will hang off.
+ENTRY_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+  -H "Content-Type: application/json" \
+  -X POST -d "$(jq -n --arg c "uat32-recall-$RUN_ID" '{content:$c}')" \
+  "$SERVER_URL/entries")
+ENTRY_ID=$(echo "$ENTRY_RESP" | jq -r '.lookupKey // .id // empty')
+if [ -n "$ENTRY_ID" ] && [ "$ENTRY_ID" != "null" ]; then
+  pass "0b. created parent entry ($ENTRY_ID) — fragments will FK here"
+else
+  fail "0b. could not create parent entry: $ENTRY_RESP"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Helper — POST /fragments with a uniform shape.
+mk_fragment() {
+  local title="$1" content="$2" tags_json="$3"
+  curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+    -H "Content-Type: application/json" \
+    -X POST -d "$(jq -n \
+      --arg t "$title" --arg c "$content" --arg e "$ENTRY_ID" \
+      --argjson tg "$tags_json" \
+      '{title:$t, content:$c, entryId:$e, tags:$tg}')" \
+    "$SERVER_URL/fragments"
+}
+
+# Helper — issue a BM25-only search and echo results JSON.
+bm25_search() {
+  local q="$1" tables="${2:-fragment}"
+  curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+    --get \
+    --data-urlencode "q=$q" \
+    --data-urlencode "mode=bm25" \
+    --data-urlencode "tables=$tables" \
+    "$SERVER_URL/search"
+}
+
+# ── §1. BM25 OR-join — "divya europe travel" must surface "Divya in Europe" ──
+# Fragment title contains divya + europe but NOT travel. With current
+# plainto_tsquery this misses (AND-strict). After fix: hit returned.
+
+F1_RESP=$(mk_fragment \
+  "Divya in Europe $RUN_ID" \
+  "Recent itinerary across multiple cities $RUN_ID." \
+  '[]')
+F1_KEY=$(echo "$F1_RESP" | jq -r '.lookupKey // empty')
+if [ -n "$F1_KEY" ]; then
+  pass "§1a. created §1 fragment '$F1_KEY' (title 'Divya in Europe $RUN_ID')"
+else
+  fail "§1a. could not create §1 fragment: $F1_RESP"
+fi
+
+# Sanity — exact-AND query (subset stems already present) should hit
+# regardless of OR/AND. Guards against unrelated breakage.
+SUBSET_HITS=$(bm25_search "divya europe $RUN_ID" \
+  | jq --arg k "$F1_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${SUBSET_HITS:-0}" -ge 1 ]; then
+  pass "§1b. AND-OK control: 'divya europe $RUN_ID' returns the §1 fragment (sanity)"
+else
+  fail "§1b. AND-OK control failed — even subset query missed; investigate before §1c"
+fi
+
+# Real probe — the failing one on pre-fix.
+ORJOIN_HITS=$(bm25_search "divya europe travel $RUN_ID" \
+  | jq --arg k "$F1_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${ORJOIN_HITS:-0}" -ge 1 ]; then
+  pass "§1c. OR-join: 'divya europe travel $RUN_ID' surfaces 'Divya in Europe' fragment"
+else
+  fail "§1c. OR-join: 'divya europe travel $RUN_ID' returned 0 hits for §1 fragment (CURRENTLY FAILS pre-#249)"
+fi
+
+# ── §2. Tag-vectorisation — search by tag returns the tagged fragment ──
+# Tag is "machine-learning"; body is deliberately unrelated so the only
+# possible stem-source is the tags array. Pre-fix: tags never enter
+# search_vector → 0 hits.
+
+F2_RESP=$(mk_fragment \
+  "ML Tagged Note $RUN_ID" \
+  "An unrelated body that says nothing useful $RUN_ID." \
+  '["machine-learning"]')
+F2_KEY=$(echo "$F2_RESP" | jq -r '.lookupKey // empty')
+if [ -n "$F2_KEY" ]; then
+  pass "§2a. created §2 fragment '$F2_KEY' (tags=['machine-learning'])"
+else
+  fail "§2a. could not create §2 fragment: $F2_RESP"
+fi
+
+# Direct DB inspection: vector should mention 'machin' / 'learn' stems
+# post-fix. Pre-fix: it won't.
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$F2_KEY" ]; then
+  VEC=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT search_vector::text FROM fragments WHERE lookup_key='$F2_KEY'")
+  if echo "$VEC" | grep -qE "machin|learn"; then
+    pass "§2b. fragments.search_vector for §2 row contains tag stems (machin/learn)"
+  else
+    fail "§2b. fragments.search_vector for §2 row LACKS tag stems — vec='${VEC:0:120}' (CURRENTLY FAILS pre-#249)"
+  fi
+else
+  skip "§2b. DATABASE_URL unset or §2 fragment missing — vector inspection skipped"
+fi
+
+# Search probe: BM25 query for the tag returns the §2 fragment.
+TAG_HITS=$(bm25_search "machine-learning" \
+  | jq --arg k "$F2_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${TAG_HITS:-0}" -ge 1 ]; then
+  pass "§2c. BM25 search 'machine-learning' returns the §2 tagged fragment"
+else
+  fail "§2c. BM25 search 'machine-learning' returned 0 hits for §2 fragment (CURRENTLY FAILS pre-#249)"
+fi
+
+# ── §3. Trigger fires on content edit — fragments ────────────
+# We mutate content via direct psql UPDATE (the API PUT is broken on a
+# different axis — see Notes — and would not isolate the trigger gap).
+# Post-fix: trigger UPDATE-OF list includes content, so the vector
+# rebuilds and the new stem becomes searchable. Pre-fix: vector is
+# stale; the new stem is invisible.
+
+F3_RESP=$(mk_fragment \
+  "Edit Probe $RUN_ID" \
+  "Original content placeholder $RUN_ID." \
+  '[]')
+F3_KEY=$(echo "$F3_RESP" | jq -r '.lookupKey // empty')
+if [ -n "$F3_KEY" ]; then
+  pass "§3a. created §3 fragment '$F3_KEY' (original body has no 'zinfandel' stem)"
+else
+  fail "§3a. could not create §3 fragment: $F3_RESP"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$F3_KEY" ]; then
+  # Direct DB content update — bypasses PUT /fragments bug. Only the
+  # trigger decides whether search_vector follows.
+  psql "$DATABASE_URL" -q -c \
+    "UPDATE fragments SET content='Updated body now mentions zinfandel-$RUN_ID.' WHERE lookup_key='$F3_KEY'"
+  VEC=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT search_vector::text FROM fragments WHERE lookup_key='$F3_KEY'")
+  if echo "$VEC" | grep -q "zinfandel"; then
+    pass "§3b. content edit propagated to fragments.search_vector (zinfandel stem present)"
+  else
+    fail "§3b. content edit did NOT propagate — vec='${VEC:0:120}' (CURRENTLY FAILS pre-#249)"
+  fi
+else
+  skip "§3b. DATABASE_URL unset or §3 fragment missing — direct content edit probe skipped"
+fi
+
+# Search probe through the API.
+EDIT_HITS=$(bm25_search "zinfandel-$RUN_ID" \
+  | jq --arg k "$F3_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${EDIT_HITS:-0}" -ge 1 ]; then
+  pass "§3c. BM25 search 'zinfandel-$RUN_ID' returns §3 fragment after content edit"
+else
+  fail "§3c. BM25 search 'zinfandel-$RUN_ID' returned 0 hits — vector stale (CURRENTLY FAILS pre-#249)"
+fi
+
+# ── §4. Same shape on wikis and people — trigger-on-content ──
+# wikis and people have no tags column, so the tag-vector probe doesn't
+# port. The trigger-on-content gap does — pg_trigger.tgattr currently
+# lists {name, prompt} for wikis and {name, relationship} for people.
+
+# §4a — wikis
+WIKI_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+  -H "Content-Type: application/json" \
+  -X POST -d "$(jq -n --arg n "UAT32 Wiki $RUN_ID" \
+    '{name:$n, description:"UAT32 search-recall wiki probe", type:"log"}')" \
+  "$SERVER_URL/wikis")
+WIKI_KEY=$(echo "$WIKI_RESP" | jq -r '.lookupKey // .id // empty')
+if [ -n "$WIKI_KEY" ] && [ "$WIKI_KEY" != "null" ]; then
+  pass "§4a-i. created §4 wiki '$WIKI_KEY'"
+else
+  fail "§4a-i. could not create §4 wiki: $WIKI_RESP"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$WIKI_KEY" ] && [ "$WIKI_KEY" != "null" ]; then
+  psql "$DATABASE_URL" -q -c \
+    "UPDATE wikis SET content = 'Updated wiki body mentions xerophyte-$RUN_ID.' WHERE lookup_key='$WIKI_KEY'"
+  VEC=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT search_vector::text FROM wikis WHERE lookup_key='$WIKI_KEY'")
+  if echo "$VEC" | grep -q "xerophyt"; then
+    pass "§4a-ii. wiki content edit propagated to wikis.search_vector"
+  else
+    fail "§4a-ii. wiki content edit did NOT propagate — vec='${VEC:0:120}' (CURRENTLY FAILS pre-#249)"
+  fi
+else
+  skip "§4a-ii. DATABASE_URL unset or §4 wiki missing — wiki content-edit probe skipped"
+fi
+
+# §4b — people. Insert directly via psql (no public POST /people route
+# exists; people are created by the pipeline). We can synthesise one
+# row safely; the §4b cleanup deletes it.
+if [ -n "${DATABASE_URL:-}" ]; then
+  PERSON_KEY="person_uat32_$(echo "$RUN_ID" | tr -c 'A-Za-z0-9' '_')"
+  psql "$DATABASE_URL" -q -c "
+    INSERT INTO people (lookup_key, slug, name, summary, relationship,
+                        canonical_name, aliases, content)
+    VALUES ('$PERSON_KEY',
+            'uat32-person-$RUN_ID',
+            'UAT32 Person $RUN_ID',
+            '', '', 'UAT32 Person $RUN_ID',
+            ARRAY[]::text[],
+            'Original person body $RUN_ID.')
+  " 2>/dev/null
+
+  # Confirm row exists.
+  EXISTS=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT 1 FROM people WHERE lookup_key='$PERSON_KEY'")
+  if [ "$EXISTS" = "1" ]; then
+    pass "§4b-i. created §4 person '$PERSON_KEY' via psql"
+
+    # Mutate content; check trigger fires.
+    psql "$DATABASE_URL" -q -c \
+      "UPDATE people SET content = 'Updated person body mentions yodelling-$RUN_ID.' WHERE lookup_key='$PERSON_KEY'"
+    VEC=$(psql "$DATABASE_URL" -t -A -c \
+      "SELECT search_vector::text FROM people WHERE lookup_key='$PERSON_KEY'")
+    if echo "$VEC" | grep -q "yodel"; then
+      pass "§4b-ii. person content edit propagated to people.search_vector"
+    else
+      fail "§4b-ii. person content edit did NOT propagate — vec='${VEC:0:120}' (CURRENTLY FAILS pre-#249)"
+    fi
+  else
+    skip "§4b. could not insert §4 person row — schema may have shifted; section skipped"
+    PERSON_KEY=""
+  fi
+else
+  skip "§4b. DATABASE_URL unset — person trigger probe skipped"
+  PERSON_KEY=""
+fi
+
+# ── §5. Rank stability — all-terms-matched > partial-match ───
+# Regression guard against the OR-join change accidentally flattening
+# rank. We create two fragments:
+#   RankAll      — title + body match all 3 stems "alpha bravo charlie"
+#   RankPartial  — title + body match only 1 stem "alpha"
+# Then BM25-search "alpha bravo charlie". Both should appear; RankAll
+# must score strictly higher than RankPartial. Live ts_rank check
+# (during plan-write) showed 3-match=0.0608 vs 1-match=0.0203 — clean
+# separation, so the assertion is real.
+
+R1_RESP=$(mk_fragment \
+  "RankAll $RUN_ID alpha bravo charlie" \
+  "Body for rank test alpha bravo charlie $RUN_ID." \
+  '[]')
+R1_KEY=$(echo "$R1_RESP" | jq -r '.lookupKey // empty')
+
+R2_RESP=$(mk_fragment \
+  "RankPartial $RUN_ID alpha" \
+  "Body for rank test alpha only $RUN_ID." \
+  '[]')
+R2_KEY=$(echo "$R2_RESP" | jq -r '.lookupKey // empty')
+
+if [ -n "$R1_KEY" ] && [ -n "$R2_KEY" ]; then
+  pass "§5a. created §5 fragments (R1=$R1_KEY, R2=$R2_KEY)"
+else
+  fail "§5a. could not create §5 fragments (R1='$R1_KEY' R2='$R2_KEY')"
+fi
+
+# Pull both scores out of the response.
+RANK_RESP=$(bm25_search "alpha bravo charlie $RUN_ID")
+S1=$(echo "$RANK_RESP" | jq --arg k "$R1_KEY" '.results[] | select(.id==$k) | .score' | head -1)
+S2=$(echo "$RANK_RESP" | jq --arg k "$R2_KEY" '.results[] | select(.id==$k) | .score' | head -1)
+S1="${S1:-0}"; S2="${S2:-0}"
+
+# Both rows should be present in the result set (post-fix, OR-join
+# admits partial matches). Pre-fix, R2 may be absent (AND-strict drops
+# it because body has no "bravo" / "charlie" stem) — we record that
+# as a fail too, since it's the same recall gap as §1.
+if [ "$(echo "$RANK_RESP" | jq --arg k "$R1_KEY" '[.results[] | select(.id==$k)] | length')" -ge 1 ]; then
+  pass "§5b. all-terms-matched fragment R1 present in result set"
+else
+  fail "§5b. all-terms-matched fragment R1 missing — search broken upstream of rank check"
+fi
+if [ "$(echo "$RANK_RESP" | jq --arg k "$R2_KEY" '[.results[] | select(.id==$k)] | length')" -ge 1 ]; then
+  pass "§5c. partial-match fragment R2 present in result set (OR-join admits partials)"
+else
+  fail "§5c. partial-match fragment R2 missing — likely AND-strict path (pre-#249)"
+fi
+
+# Strict ordering: R1 score > R2 score. Use awk for float compare.
+if awk -v a="$S1" -v b="$S2" 'BEGIN{ exit !(a > b) }'; then
+  pass "§5d. R1 score ($S1) > R2 score ($S2) — rank preserved (regression guard intact)"
+else
+  fail "§5d. R1 score ($S1) NOT > R2 score ($S2) — OR-join flattened ranking (regression)"
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────
+# Every per-RUN_ID row is removed so the shared corpus stays clean.
+
+if [ -n "${DATABASE_URL:-}" ]; then
+  for k in "$F1_KEY" "$F2_KEY" "$F3_KEY" "$R1_KEY" "$R2_KEY"; do
+    [ -n "$k" ] && psql "$DATABASE_URL" -q -c \
+      "DELETE FROM fragments WHERE lookup_key='$k'" >/dev/null 2>&1
+  done
+  [ -n "${WIKI_KEY:-}" ] && [ "$WIKI_KEY" != "null" ] && \
+    psql "$DATABASE_URL" -q -c "DELETE FROM wikis WHERE lookup_key='$WIKI_KEY'" >/dev/null 2>&1
+  [ -n "${PERSON_KEY:-}" ] && \
+    psql "$DATABASE_URL" -q -c "DELETE FROM people WHERE lookup_key='$PERSON_KEY'" >/dev/null 2>&1
+  if [ -n "${ENTRY_ID:-}" ]; then
+    # raw_sources may have FK references in pipeline_events / processed_jobs.
+    # Tear those down first, then delete the row itself.
+    psql "$DATABASE_URL" -q -c "DELETE FROM pipeline_events WHERE entry_id='$ENTRY_ID'" >/dev/null 2>&1
+    psql "$DATABASE_URL" -q -c "DELETE FROM processed_jobs WHERE job_id='$ENTRY_ID'" >/dev/null 2>&1
+    psql "$DATABASE_URL" -q -c "DELETE FROM raw_sources WHERE lookup_key='$ENTRY_ID'" >/dev/null 2>&1
+  fi
+  pass "cleanup. per-RUN_ID rows deleted (fragments / wiki / person / raw_source)"
+else
+  skip "cleanup. DATABASE_URL unset — per-RUN_ID rows left in place"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```
+
+## Expected outcome (pre-#249 vs post-#249)
+
+| Section | Pre-#249 | Post-#249 |
+| --- | --- | --- |
+| §1a / §1b (sanity, control) | pass | pass |
+| §1c (OR-join probe) | **fail** | pass |
+| §2a (create) | pass | pass |
+| §2b (vector contains tag stems) | **fail** | pass |
+| §2c (search by tag) | **fail** | pass |
+| §3a (create) | pass | pass |
+| §3b (vector after content edit) | **fail** | pass |
+| §3c (search by edited body) | **fail** | pass |
+| §4a-i (create wiki) | pass | pass |
+| §4a-ii (wiki content edit propagates) | **fail** | pass |
+| §4b-i (create person) | pass | pass |
+| §4b-ii (person content edit propagates) | **fail** | pass |
+| §5a / §5b (creates, R1 hit) | pass | pass |
+| §5c (R2 hit — partial match admitted) | **fail** | pass |
+| §5d (rank ordering preserved) | pass (vacuously: only R1 in set, comparison default) | pass |
+| cleanup | pass | pass |
+
+§5d's pre-fix outcome depends on the score-default: `S2` falls back to
+`0` when R2 isn't in the result set, so `S1 > 0` still holds — the
+pre-fix run shows §5d pass even though §5c fails. That's the intended
+shape: §5c proves OR-join expanded recall, §5d independently proves
+rank order didn't collapse. Both must pass post-fix.

--- a/.uat/plans/33-quill-writer.md
+++ b/.uat/plans/33-quill-writer.md
@@ -1,0 +1,343 @@
+# 33 — Quill Writer Agent (regen output)
+
+## What it proves
+
+Four facets of issue #257 — wiki regeneration ("Quill") is currently
+piggy-backing on the wiki-classifier agent (Haiku-class, 4k default
+output cap), which silently truncates large wikis on regen:
+
+**(A) Source-level: regen.ts no longer routes through `wikiClassifier`.**
+Today `core/src/lib/regen.ts:393-396` constructs the regen caller with
+`agents.wikiClassifier`:
+
+```
+const callLlm = createTypedCaller(
+  agents.wikiClassifier,
+  regenOutputSchema as unknown as ...,
+)
+```
+
+That agent is wired to the `models.classification` slot in
+`packages/agent/src/openrouter-config.ts:5` — Haiku-class. The fix is a
+new `wikiWriter` (or similarly-named) agent backed by the
+`models.wikiGeneration` slot, with a higher output cap. §1 asserts the
+regen.ts callsite no longer references `wikiClassifier` AND does
+reference a writer-class agent name.
+
+**(B) `caller.ts` AGENT_MODEL_SETTINGS exposes a 16k output cap.**
+`packages/agent/src/agents/caller.ts:25-27` currently ships
+`AGENT_MODEL_SETTINGS = { maxRetries: ... }` — no `maxOutputTokens`.
+That falls through to the OpenRouter SDK's default (~4096), so any
+generated wiki content longer than ~4k tokens gets cut mid-sentence.
+The fix surfaces a `maxOutputTokens: 16000` somewhere reachable by
+the writer agent — either as a per-agent override or as the global
+default. §2 greps for the literal `16000` (or `16_000`) within
+`caller.ts` or the agent factory.
+
+**(C) Functional: a regen on a content-bloated wiki returns text that
+ends on a sensible boundary.** The classic failure mode is a
+mid-sentence cutoff: `"...the architecture combines self-attention
+with feed-forw"` — last 200 chars end mid-word. We seed extra content
+into a wiki, trigger regen, and assert the result's last 200 chars
+end on punctuation OR a whitespace-followed word. We snap the wiki
+content back at the end so downstream plans see the original. Note:
+regen is gated by `wikis.regenerate = true`; we toggle if needed and
+restore.
+
+**(D) Wiki-type yaml has the double-quote → single-quote/italics rule.**
+The issue body recommends adding a typography rule to wiki-type
+prompts so the LLM doesn't emit smart-quote-collision artifacts. §4
+greps `packages/shared/src/prompts/specs/wiki-types/log.yaml` (and
+peers) for a rule mentioning `quote` + (`single` OR `italic`).
+
+## Prerequisites
+
+- Plan 22 has run (Transformer fixture seeded) so a regen-eligible
+  wiki exists.
+- Core server reachable at `SERVER_URL` (default `http://localhost:3000`).
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` set in `core/.env`.
+- `psql` with `DATABASE_URL` from `core/.env`.
+- `jq`, `grep` installed.
+- OpenRouter API key configured (regen calls the live LLM).
+
+## Fixture identity this plan references
+
+- regen callsite: `core/src/lib/regen.ts:393-396`.
+- agent factory: `packages/agent/src/agent-factory.ts` (whatever
+  exports `createIngestAgents`).
+- agent caller: `packages/agent/src/agents/caller.ts:25` (the
+  `AGENT_MODEL_SETTINGS` const).
+- model config: `packages/agent/src/openrouter-config.ts:1-9` (the
+  `models.wikiGeneration` slot).
+- wiki-type prompts: `packages/shared/src/prompts/specs/wiki-types/*.yaml`.
+- target wiki: the seeded Transformer wiki (or any wiki with
+  `regenerate=true` or one we can flip).
+
+## Restoring downstream-plan state
+
+§3 takes a snapshot of the target wiki's `content`, `description`,
+`updated_at` before mutating, then restores at the end. If §3 had to
+flip `regenerate` from false to true, we flip it back. No fragments
+created, no cascades touched.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-33-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "33 — Quill Writer Agent (#257)"
+echo ""
+
+# ── 0. Sanity: target files exist ────────────────────────────
+for f in core/src/lib/regen.ts packages/agent/src/agents/caller.ts \
+         packages/agent/src/openrouter-config.ts; do
+  if [ -f "$f" ]; then pass "0a. $f exists"
+  else fail "0a. $f missing"; fi
+done
+
+# Sign in for §3.
+curl -s -o /dev/null -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email"
+if [ -s "$COOKIE_JAR" ]; then
+  pass "0b. signed in"
+else
+  fail "0b. login failed — §3 will skip"
+fi
+
+# ── 1. §1 — regen.ts no longer routes through wikiClassifier ─
+# Look at the createTypedCaller call inside regen.ts. The current line
+# is `agents.wikiClassifier` — after fix, this should reference a
+# writer agent. We grep with line context.
+REGEN_CALLSITE=$(grep -nE 'createTypedCaller\(\s*agents\.[A-Za-z]+' \
+  core/src/lib/regen.ts | head -1)
+echo "  ▸ regen callsite: $REGEN_CALLSITE"
+if echo "$REGEN_CALLSITE" | grep -q 'wikiClassifier'; then
+  fail "1a. regen.ts still uses agents.wikiClassifier (#257 unfixed)"
+else
+  pass "1a. regen.ts no longer references agents.wikiClassifier"
+fi
+
+# Stronger: assert it references a writer-class agent name (writer/
+# generator/quill/wikiGeneration). If the fix renames the agent,
+# allow any of these candidates.
+WRITER_REF=$(grep -cE 'agents\.(wikiWriter|wikiGenerator|quill|wikiGeneration|writer)' \
+  core/src/lib/regen.ts || true)
+if [ "${WRITER_REF:-0}" -ge 1 ]; then
+  pass "1b. regen.ts references a writer-class agent ($WRITER_REF match(es))"
+else
+  skip "1b. regen.ts has no writer-class agent name yet — fix may use a new name; review manually"
+fi
+
+# ── 2. §2 — 16k output cap surfaced ──────────────────────────
+# AGENT_MODEL_SETTINGS at caller.ts:25 currently ships only maxRetries.
+# A correct fix exposes maxOutputTokens: 16000 either there or in the
+# agent factory where the writer agent is constructed.
+CAP_HITS_CALLER=$(grep -cE '16[_]?000|16384' packages/agent/src/agents/caller.ts || true)
+CAP_HITS_FACTORY=$(grep -cE 'maxOutputTokens.*16[_]?000|16[_]?000.*maxOutputTokens' \
+  packages/agent/src/agent-factory.ts 2>/dev/null || true)
+TOTAL_CAP=$((CAP_HITS_CALLER + CAP_HITS_FACTORY))
+if [ "$TOTAL_CAP" -ge 1 ]; then
+  pass "2a. 16k output cap present (caller=$CAP_HITS_CALLER, factory=$CAP_HITS_FACTORY)"
+else
+  fail "2a. no 16k output cap found in caller.ts or agent-factory.ts (#257 cap unraised)"
+fi
+
+# Numeric extract: print the actual maxOutputTokens value found, if any.
+ACTUAL_CAP=$(grep -EhoR 'maxOutputTokens[[:space:]]*:[[:space:]]*[0-9_]+' \
+  packages/agent/src 2>/dev/null | grep -oE '[0-9_]+' | head -1)
+if [ -n "$ACTUAL_CAP" ]; then
+  pass "2b. maxOutputTokens literal found: $ACTUAL_CAP"
+else
+  skip "2b. no maxOutputTokens literal found in packages/agent/src — fix may surface elsewhere"
+fi
+
+# ── 3. §3 — large-content regen doesn't truncate mid-word ────
+# Pick a regen-eligible wiki, snapshot, bloat content past 4k tokens,
+# trigger regen, inspect output. Restore at the end.
+if [ -s "$COOKIE_JAR" ]; then
+  WIKI_KEY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis?limit=1" | jq -r '.wikis[0].id // empty')
+  if [ -z "$WIKI_KEY" ]; then
+    skip "3a. no wiki to regen — Transformer fixture missing"
+  else
+    # Snapshot ORIGINAL state for restore.
+    ORIG_CONTENT=$(psql "$DATABASE_URL" -tA -c \
+      "SELECT content FROM wikis WHERE lookup_key = '$WIKI_KEY'")
+    ORIG_REGEN=$(psql "$DATABASE_URL" -tA -c \
+      "SELECT regenerate FROM wikis WHERE lookup_key = '$WIKI_KEY'")
+
+    # Ensure regenerate is enabled.
+    if [ "$ORIG_REGEN" != "t" ]; then
+      psql "$DATABASE_URL" -c \
+        "UPDATE wikis SET regenerate = true WHERE lookup_key = '$WIKI_KEY'" \
+        > /dev/null
+    fi
+
+    # Bloat: prepend ≥5k tokens of filler content to push past 4k cap.
+    # ~5 chars/token average; 30000 chars ≈ 6k tokens. We'll generate
+    # a deterministic-ish blob (no special chars to avoid yaml/markdown
+    # escaping issues).
+    FILLER=$(python3 -c \
+      'print(("The architecture combines self-attention with feed-forward layers across many transformer blocks. " * 320))' \
+      2>/dev/null || \
+      yes "The architecture combines self-attention with feed-forward layers across many transformer blocks." | head -320 | tr '\n' ' ')
+    BLOATED="${ORIG_CONTENT}
+
+${FILLER}"
+    psql "$DATABASE_URL" -c \
+      "UPDATE wikis SET content = \$\$${BLOATED}\$\$ WHERE lookup_key = '$WIKI_KEY'" \
+      > /dev/null
+
+    # Trigger regen.
+    REGEN_RES=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      -X POST "$SERVER_URL/wikis/$WIKI_KEY/regenerate")
+    REGEN_OK=$(echo "$REGEN_RES" | jq -r '.ok // false')
+    if [ "$REGEN_OK" = "true" ]; then
+      pass "3a. regen API returned ok=true"
+    else
+      fail "3a. regen failed: $REGEN_RES"
+    fi
+
+    # Inspect new content. Last 200 chars must end on punctuation or a
+    # complete word (whitespace + word + .!?). Mid-word cutoff is the
+    # truncation signature.
+    NEW_CONTENT=$(psql "$DATABASE_URL" -tA -c \
+      "SELECT content FROM wikis WHERE lookup_key = '$WIKI_KEY'")
+    NEW_LEN=${#NEW_CONTENT}
+    TAIL=${NEW_CONTENT: -200}
+    LAST_CHAR=${TAIL: -1}
+    case "$LAST_CHAR" in
+      .|!|\?|\"|\'|\)|\]|\}|\>) BOUNDARY=ok ;;
+      *) BOUNDARY=mid ;;
+    esac
+    echo "  ▸ new content ${NEW_LEN}B; last char=[$LAST_CHAR]; tail: ...${TAIL: -80}"
+    if [ "$BOUNDARY" = "ok" ]; then
+      pass "3b. regen output ends on a sensible boundary (last char='$LAST_CHAR')"
+    else
+      fail "3b. regen output ends mid-word (last char='$LAST_CHAR') — 4k truncation signature"
+    fi
+
+    # Length sanity: a fix that uplifts the cap to 16k should produce
+    # output noticeably larger than the historical 4k cap (≥4500 chars
+    # is a soft floor — Quill compresses, so don't expect 5x).
+    if [ "$NEW_LEN" -gt 4500 ]; then
+      pass "3c. regen output is ${NEW_LEN}B (>4500B — past 4k cutoff zone)"
+    else
+      skip "3c. regen output is ${NEW_LEN}B (≤4500B — could be Quill compressing, not necessarily truncation)"
+    fi
+
+    # Restore.
+    psql "$DATABASE_URL" -c \
+      "UPDATE wikis SET content = \$\$${ORIG_CONTENT}\$\$ WHERE lookup_key = '$WIKI_KEY'" \
+      > /dev/null
+    if [ "$ORIG_REGEN" != "t" ]; then
+      psql "$DATABASE_URL" -c \
+        "UPDATE wikis SET regenerate = false WHERE lookup_key = '$WIKI_KEY'" \
+        > /dev/null
+    fi
+    pass "3z. wiki snapshot restored"
+  fi
+else
+  skip "3a. login failed — skipping live regen"
+fi
+
+# ── 4. §4 — log.yaml double-quote rule ───────────────────────
+# Issue #257 recommends adding a typography rule across wiki-type
+# prompts: convert ASCII double-quotes to single-quotes or italics
+# (so the renderer doesn't fight smart-quote pairing in user content).
+# We grep the canonical type yaml — log.yaml — for a rule mentioning
+# both `quote` and one of (`single`, `italic`).
+LOG_YAML=packages/shared/src/prompts/specs/wiki-types/log.yaml
+if [ -f "$LOG_YAML" ]; then
+  QUOTE_RULE=$(grep -niE 'quote.*(single|italic)|(single|italic).*quote' "$LOG_YAML" || true)
+  if [ -n "$QUOTE_RULE" ]; then
+    pass "4a. log.yaml has a double-quote/single-quote/italics rule"
+    echo "    $QUOTE_RULE"
+  else
+    fail "4a. log.yaml missing the double-quote → single/italic rule (#257 typography)"
+  fi
+else
+  skip "4a. $LOG_YAML missing — yaml moved or renamed"
+fi
+
+# ── Cleanup — already handled inline (§3 restored snapshot) ──
+# No global mutations remain. Cookie jar removed by trap.
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+```
+
+---
+
+## Pass/Fail Summary
+
+| # | Assertion | Source |
+|---|-----------|--------|
+| 0a | Target files exist (`regen.ts`, `caller.ts`, `openrouter-config.ts`) | filesystem |
+| 0b | Login succeeds | `/auth/login` |
+| 1a | `regen.ts` no longer references `agents.wikiClassifier` | `core/src/lib/regen.ts:393-396` |
+| 1b | `regen.ts` references a writer-class agent (writer/generator/quill/etc) | `core/src/lib/regen.ts` |
+| 2a | A 16k literal (`16000` / `16_000`) appears in `caller.ts` or `agent-factory.ts` | `packages/agent/src/agents/caller.ts:25` |
+| 2b | `maxOutputTokens: <n>` literal extractable from `packages/agent/src` | `packages/agent/src` |
+| 3a | `POST /wikis/:id/regenerate` returns `ok=true` on a content-bloated wiki | `core/src/routes/wikis.ts:548` |
+| 3b | Regen output's last char is punctuation/quote/bracket — not mid-word | `wikis.content` post-regen |
+| 3c | Regen output length > 4500B (past historical 4k truncation zone) | `wikis.content` length |
+| 3z | Wiki content + `regenerate` flag restored to pre-§3 snapshot | `psql UPDATE` |
+| 4a | `log.yaml` has a `quote` + (`single` OR `italic`) rule | `packages/shared/src/prompts/specs/wiki-types/log.yaml` |
+| Cleanup | None beyond §3z (in-line) | n/a |
+
+---
+
+## Notes
+
+- **§1, §2, §3, §4 all expected to FAIL on current `main`.** That's
+  the design — §0a-0b are the control signals.
+- **§1b is a SKIP-on-no-match, not FAIL.** The fix may rename the agent
+  (e.g. `quill` instead of `wikiWriter`); we don't want to false-fail
+  on a legit rename. The hard signal is §1a (no longer using
+  `wikiClassifier`).
+- **§2's 16k literal is the cheapest grep.** A more thorough check
+  would parse the actual model setting passed at the writer agent's
+  construction site, but that requires knowing the post-fix shape. The
+  grep catches the common fix shape (constant or per-agent override).
+- **§3 uses `python3` for the filler if available, else `yes | head`.**
+  Pure bash string-multiplication of a 30KB blob is slow on some
+  shells. If the runner has Python and `python3` is on PATH, we use
+  it. Either path produces ~30KB of filler.
+- **§3b's boundary check is heuristic.** A correct LLM output can in
+  rare cases legitimately end on a non-punctuation char (e.g. a code
+  block ending with an identifier). False-positive rate is low because
+  Quill's prompts target prose. The complement signal is §3c
+  (length-based).
+- **§3 has a snapshot-and-restore inline rather than at the end.**
+  This minimises the residue window if the script is interrupted
+  mid-§3. The snapshot is a single in-process variable; if the script
+  dies between mutate and restore, manual cleanup is one psql line.
+- **§4's literal rule wording is loose.** The issue body says "convert
+  double quotes to single quotes or italics" but the actual yaml
+  phrasing is up to the author. We accept any match where `quote` and
+  one of `single`/`italic` co-occur in any order. If the author uses
+  totally different wording (e.g. `“ ”` to `‘ ’`), §4a will
+  false-fail — operator should re-check by hand.
+- **Live confirmation on `main` at the plan-write commit:** §1a
+  matches `agents.wikiClassifier` at `regen.ts:394`. §2a finds zero
+  `16000` occurrences in `caller.ts` (only `maxRetries: 2` ships).
+  §4a finds zero `quote` + `single`/`italic` in `log.yaml`. All three
+  expected to FAIL pre-fix.

--- a/.uat/plans/99-endpoint-sweep.md
+++ b/.uat/plans/99-endpoint-sweep.md
@@ -218,6 +218,82 @@ sweep_binary "5b." "/favicon.ico" "image/x-icon"
 # image branch had nothing to load.
 sweep_binary "5c." "/images/transformer-architecture.svg" "image/svg+xml" "$WIKI_URL"
 
+# ── 5d. Branding — favicon + public page logo wrap ───────────
+# Covers #252 (partial). The favicon route is already handled by 5b
+# above (covers #156), but #252 also calls out the public-wiki header
+# at wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx:42 which
+# renders bare "Robin Wiki" text — no logo SVG, no link to
+# withrobin.ai/knowledge. Two checks:
+#   5d-1 favicon byte signature looks non-default (size > 1024B is a
+#         cheap proxy for "not the empty Lovable/Vercel placeholder";
+#         the repo-checked-in core/assets/favicon.ico is ~15KB).
+#   5d-2 a published wiki page rendered at /p/<nanoid> on $WIKI_URL
+#         contains BOTH (a) a link to withrobin.ai/knowledge and (b) a
+#         logo element (svg or img) inside the <header>. Bare text
+#         fails this. We need a published wiki to hit /p/<slug>; if
+#         none is seeded we publish one transiently and unpublish in
+#         cleanup so downstream plans see no residue.
+
+# 5d-1. favicon size sanity. Default empty ICOs are ≤1024B.
+FAVICON_BYTES=$(curl -s -o /tmp/uat-99-favicon.ico -w "%{size_download}" "$SERVER_URL/favicon.ico")
+if [ "${FAVICON_BYTES:-0}" -gt 1024 ]; then
+  pass "5d-1. favicon is ${FAVICON_BYTES}B (>1024B — likely Robin-branded, not default placeholder)"
+else
+  fail "5d-1. favicon is ${FAVICON_BYTES}B (≤1024B — looks like default placeholder)"
+fi
+
+# 5d-2. public page header has a logo + withrobin.ai/knowledge link.
+# Reach for a published wiki; fall back to publishing one transiently.
+PUB_SLUG=$(psql "$DATABASE_URL" -tA -c \
+  "SELECT published_slug FROM wikis WHERE published = true AND published_slug IS NOT NULL LIMIT 1" 2>/dev/null)
+PUB_TRANSIENT_KEY=""
+if [ -z "$PUB_SLUG" ]; then
+  # Publish the first available wiki so /p/<slug> exists. We'll
+  # unpublish it in cleanup. The publish endpoint is POST /wikis/:id/publish.
+  CAND_KEY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/wikis?limit=1" | jq -r '.wikis[0].id // empty')
+  if [ -n "$CAND_KEY" ]; then
+    PUB_RES=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      -X POST "$SERVER_URL/wikis/$CAND_KEY/publish")
+    PUB_SLUG=$(echo "$PUB_RES" | jq -r '.publishedSlug // empty')
+    if [ -n "$PUB_SLUG" ]; then
+      PUB_TRANSIENT_KEY="$CAND_KEY"
+    fi
+  fi
+fi
+
+if [ -z "$PUB_SLUG" ]; then
+  skip "5d-2. no published wiki and could not publish one — skip header logo check"
+else
+  PAGE_HTML=$(curl -s "$WIKI_URL/p/$PUB_SLUG")
+  HAS_WITHROBIN_LINK=$(echo "$PAGE_HTML" | grep -c 'withrobin\.ai/knowledge' || true)
+  HAS_LOGO_ELEM=$(echo "$PAGE_HTML" | grep -cE '<header[^>]*>.*(<svg|<img)' || true)
+  # The header may span multiple lines after Next.js' RSC render — fall
+  # back to a presence-anywhere-on-page check that flags missing logo
+  # specifically inside any element labelled header/branding.
+  if [ "${HAS_LOGO_ELEM:-0}" -eq 0 ]; then
+    HAS_LOGO_ELEM=$(echo "$PAGE_HTML" | tr -d '\n' | grep -cE '<header[^>]*>[^<]*(<svg|<img)' || true)
+  fi
+  if [ "${HAS_WITHROBIN_LINK:-0}" -ge 1 ]; then
+    pass "5d-2a. /p/$PUB_SLUG contains withrobin.ai/knowledge link"
+  else
+    fail "5d-2a. /p/$PUB_SLUG missing withrobin.ai/knowledge link (#252 logo wrap)"
+  fi
+  if [ "${HAS_LOGO_ELEM:-0}" -ge 1 ]; then
+    pass "5d-2b. /p/$PUB_SLUG header contains a logo element (svg/img)"
+  else
+    fail "5d-2b. /p/$PUB_SLUG header has no <svg>/<img> logo — bare text only (#252)"
+  fi
+
+  # Cleanup: only unpublish if WE published this wiki. Don't touch
+  # pre-published ones; downstream plans may depend on them.
+  if [ -n "$PUB_TRANSIENT_KEY" ]; then
+    curl -s -o /dev/null -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+      -X POST "$SERVER_URL/wikis/$PUB_TRANSIENT_KEY/unpublish"
+  fi
+fi
+rm -f /tmp/uat-99-favicon.ico
+
 # ── 6. Cross-kind: every response referenced by the sidecar parses ───
 # Walks the wiki detail's `refs` map — every person/fragment/wiki/entry
 # reference must resolve to a live detail endpoint. Catches "seed created
@@ -284,6 +360,9 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 3 | `/graph` returns valid nodes + edges; every node has a schema-known type | #153 regression guard |
 | 4 | `/search` returns results shape | search endpoint |
 | 5 | `/system/status` returns 200 + `.status`; `/favicon.ico` (5b) returns 200 + `image/x-icon` on `$SERVER_URL`; `/images/transformer-architecture.svg` (5c) returns 200 + `image/svg+xml` on `$WIKI_URL` | system endpoint; #156 (favicon); #160 (SVG asset) |
+| 5d-1 | `/favicon.ico` byte size > 1024B (Robin-branded, not default placeholder) | #252 |
+| 5d-2a | `/p/<slug>` page contains a `withrobin.ai/knowledge` link | #252 (`PublishedWikiArticle.tsx:42`) |
+| 5d-2b | `/p/<slug>` `<header>` contains an `<svg>` or `<img>` logo element | #252 (`PublishedWikiArticle.tsx:42`) |
 | 6 | Every ref in the wiki sidecar resolves to a live detail endpoint | cross-kind integrity |
 | 7 | The wiki sidecar's `infobox.image.url`, when present, resolves 200 on `$WIKI_URL` (cross-asset linkage) | #160 |
 


### PR DESCRIPTION
## Summary

Adds **10 UAT plan amendments / new plans** providing regression coverage for the 12 confirmed bugs in the stability-window backlog. Each assertion is designed to **fail today (bug present) and pass after the fix lands** — the plans are the contracts each future fix-PR must satisfy.

Built via 12 parallel exploration-and-write subagents (intentional duplication; best version selected per plan at synthesis).

## Plans by bug

| Plan | Bug(s) covered | Live result on current main |
|---|---|---|
| `08-wiki-crud.md` §10 | #236 ghost wikis + zombie edges | 22 P / 3 F (3 fails = bug repro) |
| `21-wiki-sidecar-rendering.md` §15 | #251 hero + infobox layout | 2 P / 5 F (5 fails = bug repro) |
| `24-mcp-description-and-dedup.md` §1d | #223 partial dedup index unused | 0 P / 1 F |
| `27-wiki-settings-and-history.md` §9 | #241 Tiptap save bakes sidebar chrome | 9 P / 1 F |
| `28-password-change-and-public-wiki.md` §9.5 | #253 public page literal HTML render | 9 P / 6 F |
| `29-collections-and-similarity.md` §5g/§6/§8g | #227 + #228 + #229 worker-path RELATED edges + DELETE | 46 P / 18 F |
| `31-test-suite-fidelity.md` (new) | #222 regen.test silent swallow | 5 P / 5 F / 16 SKIP |
| `32-search-recall.md` (new) | #249 BM25 + tags + trigger | 12 P / 8 F |
| `33-quill-writer.md` (new) | #257 Quill on Sonnet 4.6 + 16k | 7 P / 3 F / 3 SKIP |
| `99-endpoint-sweep.md` §5d | #252 branding (favicon + public page logo) | partial fail |

## What this PR does NOT do

- It does NOT fix any bugs — that's future per-bug PRs.
- It does NOT close the bug issues — they close when the fix-PRs land and these assertions go green.

## What this PR DOES do

Locks in the contract for each fix:
- #222 — vitest run produces zero `TypeError` lines + mock chain exposes `.limit()`
- #223 — `EXPLAIN` of the dedup hot-path query is `Index Scan using fragments_dedup_hash_idx` (with `enable_seqscan=off` for determinism on small tables)
- #227 + #229 — every `FRAGMENT_RELATED_TO_FRAGMENT` edge has `attrs.method='cosine-regen'` AND audit-log row count == 2× edge count (both worker + regen.ts paths)
- #228 — `DELETE /fragments/:lookupKey` returns 204 + cascades soft-delete across all edge types referencing the fragment
- #236 — every edge with a soft-deleted wiki endpoint has `deleted_at IS NOT NULL`; `/wikis`, `/graph`, `/search` all hide ghost wikis
- #241 — `wikis.content` after Tiptap save contains zero chrome substrings (`Member Fragments`, `Mentioned People`, `wedit`, `data-slot="wiki-citation"`)
- #249 — BM25 OR-join surfaces partial-match results; tags woven into `search_vector`; trigger fires on content/tags edits across fragments+wikis+people
- #251 — wiki home renders no auth-user hero; rich infobox renders above body at full content width when sidecar has it
- #252 — public published-wiki page header contains a logo element + link to `withrobin.ai/knowledge`
- #253 — anon GET `/p/<nanoid>` renders HTML body as DOM, not literal escaped text
- #257 — `regen.ts` regen path uses `wikiWriter` (not `wikiClassifier`); `maxOutputTokens` ≥ 16000 for the writer; type yamls include double-quote handling rule

## Cross-cutting findings worth filing as new issues

The exploration surfaced patterns beyond the assigned scope:
1. **Transitive ghost bug**: 78 RELATED_TO edges connect live fragments → fragments-in-deleted-wikis. Same class as #236 but distinct codepath.
2. **PUT /fragments/:id content path**: `core/src/routes/fragments.ts:222` writes `dedupHash` but never `content`. Real product bug.
3. **5 sibling `deletedAt`-forgotten instances**: `fragments.ts:77`, `graph.ts:123`, `users.ts:101`, `relationships.ts:82`, `published.ts:25`. Same bug class as #236/#199/#223.
4. **15 `catch + log.warn` swallow patterns** in `core/src/`. Each is a candidate for the same false-green class as #222.

I'll file these as separate issues post-merge.

## Already closed during synthesis

- #199 (verified fixed by PR #226)
- #230 (already correct on current main)
- #231 (description first-class already shipped)