### PR TITLE
fix(stability): forgotten deletedAt sweep — ghost wikis, zombie edges, transitive reachability

### DIFF
--- a/.uat/plans/08-wiki-crud.md
+++ b/.uat/plans/08-wiki-crud.md
@@ -423,6 +423,240 @@ else
   psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE name LIKE 'UAT08 Ghost Wiki %'" >/dev/null 2>&1 || true
   pass "10 cleanup: hard-deleted ghost wiki + edges + test entry chain"
 
+  # ── 11. Forgotten `deletedAt IS NULL` predicates (regression #264) ────
+  # Five sibling drizzle queries label-resolve or count rows from
+  # core tables (wikis, fragments, people) without filtering soft-
+  # deleted rows out of the result. Each sub-section seeds a row,
+  # soft-deletes it, calls the affected route, and asserts the
+  # deleted row is absent from the response.
+  echo ""
+  echo "── 11. Forgotten deletedAt predicates (#264) ──"
+
+  # Helper: hard-delete a row by lookup_key (cleanup is idempotent).
+  uat11_hard_del_wiki() { psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$1' OR dst_id='$1'" >/dev/null 2>&1 || true; psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE lookup_key='$1'" >/dev/null 2>&1 || true; }
+  uat11_hard_del_frag() { psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$1' OR dst_id='$1'" >/dev/null 2>&1 || true; psql "$DATABASE_URL" -c "DELETE FROM fragments WHERE lookup_key='$1'" >/dev/null 2>&1 || true; }
+  uat11_hard_del_person() { psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$1' OR dst_id='$1'" >/dev/null 2>&1 || true; psql "$DATABASE_URL" -c "DELETE FROM people WHERE lookup_key='$1'" >/dev/null 2>&1 || true; }
+
+  # ── 11.1 routes/fragments.ts — backlinks resolve wiki labels with
+  # `inArray(wikis.lookupKey, ids)` only (no isNull(deletedAt)). A live
+  # fragment with a FRAGMENT_IN_WIKI edge to a soft-deleted wiki gets
+  # the deleted wiki name back as a backlink.
+  GH11_WIKI="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT11_1 Backlink Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  GH11_FRAG="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/fragments?limit=10" | jq -r '.fragments[0].lookupKey // empty')"
+  if [ -n "$GH11_WIKI" ] && [ -n "$GH11_FRAG" ]; then
+    psql "$DATABASE_URL" -c "INSERT INTO edges (id,src_type,src_id,dst_type,dst_id,edge_type) VALUES (gen_random_uuid(),'fragment','$GH11_FRAG','wiki','$GH11_WIKI','FRAGMENT_IN_WIKI') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+    # Soft-delete the wiki directly (bypass the DELETE handler so we
+    # isolate the bug — handler-cascade is a separate fix in #236).
+    psql "$DATABASE_URL" -c "UPDATE wikis SET deleted_at=now() WHERE lookup_key='$GH11_WIKI'" >/dev/null 2>&1
+    BL_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/fragments/$GH11_FRAG")
+    BL_HIT=$(echo "$BL_BODY" | jq --arg k "$GH11_WIKI" '[.backlinks[]? | select(.id == $k)] | length' 2>/dev/null)
+    [ "${BL_HIT:-1}" = "0" ] && pass "11.1 fragments backlinks exclude soft-deleted wiki" \
+      || fail "11.1 fragments backlinks include soft-deleted wiki $GH11_WIKI (#264 — routes/fragments.ts wikis lookup missing isNull(deletedAt))"
+    uat11_hard_del_wiki "$GH11_WIKI"
+  else
+    skip "11.1 setup failed (wiki=$GH11_WIKI, frag=$GH11_FRAG)"
+  fi
+
+  # ── 11.2 routes/graph.ts — label-resolution lookups (entries,
+  # fragments, wikis, people) all use `inArray(...lookupKey, ids)`
+  # without isNull(deletedAt). Even after the #236 edge-cascade fix,
+  # an in-flight zombie edge (or a not-yet-cascaded edge from another
+  # path) means the soft-deleted entity may still surface as a node
+  # label. Force the case: insert a live edge pointing at a soft-
+  # deleted fragment and verify /graph does NOT label it.
+  GH11_GHOST_FRAG="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/fragments?limit=20" | jq -r '.fragments[1].lookupKey // empty')"
+  GH11_LIVE_WIKI="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT11_2 Live Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  if [ -n "$GH11_GHOST_FRAG" ] && [ -n "$GH11_LIVE_WIKI" ]; then
+    GH11_GHOST_TITLE="UAT11_2 ghost-frag-title-$RUN_ID"
+    # Snapshot original title so we can restore on cleanup (don't
+    # corrupt real fixture data).
+    GH11_ORIG_TITLE=$(psql "$DATABASE_URL" -t -A -c "SELECT title FROM fragments WHERE lookup_key='$GH11_GHOST_FRAG'" 2>/dev/null)
+    psql "$DATABASE_URL" -c "UPDATE fragments SET title='$GH11_GHOST_TITLE', deleted_at=now() WHERE lookup_key='$GH11_GHOST_FRAG'" >/dev/null 2>&1
+    psql "$DATABASE_URL" -c "INSERT INTO edges (id,src_type,src_id,dst_type,dst_id,edge_type) VALUES (gen_random_uuid(),'fragment','$GH11_GHOST_FRAG','wiki','$GH11_LIVE_WIKI','FRAGMENT_IN_WIKI') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+    GRAPH_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/graph")
+    # Bug surface: /graph builds a node for the soft-deleted fragment
+    # AND labels it with its title (proving the lookup ran without
+    # deletedAt filter). Strict assertion: the label is NOT the
+    # ghost title (i.e. either no node, or label fell through to id).
+    GRAPH_LABEL=$(echo "$GRAPH_BODY" | jq --arg k "$GH11_GHOST_FRAG" '[.nodes[]? | select(.id == $k) | .label][0] // empty' 2>/dev/null | tr -d '"')
+    if [ "$GRAPH_LABEL" = "$GH11_GHOST_TITLE" ]; then
+      fail "11.2 /graph resolves label for soft-deleted fragment (#264 — routes/graph.ts label lookups missing isNull(deletedAt))"
+    else
+      pass "11.2 /graph does not resolve label for soft-deleted fragment"
+    fi
+    # Cleanup: restore title, hard-delete wiki+edge.
+    if [ -n "$GH11_ORIG_TITLE" ]; then
+      psql "$DATABASE_URL" -c "UPDATE fragments SET title=\$\$${GH11_ORIG_TITLE}\$\$, deleted_at=NULL WHERE lookup_key='$GH11_GHOST_FRAG'" >/dev/null 2>&1
+    fi
+    uat11_hard_del_wiki "$GH11_LIVE_WIKI"
+  else
+    skip "11.2 setup failed"
+  fi
+
+  # ── 11.3 routes/users.ts /users/stats — count(*) over fragments,
+  # wikis, people without isNull(deletedAt). Insert a live extra row
+  # of each and verify the count goes UP by exactly one — then soft-
+  # delete and verify the count goes DOWN by one. The bug is that
+  # post-soft-delete the count stays inflated.
+  STATS_BEFORE=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/stats")
+  N_NOTES_B=$(echo "$STATS_BEFORE" | jq -r '.totalNotes // 0')
+  N_THREADS_B=$(echo "$STATS_BEFORE" | jq -r '.totalThreads // 0')
+  N_PEOPLE_B=$(echo "$STATS_BEFORE" | jq -r '.peopleCount // 0')
+
+  GH11_W2="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT11_3 Stats Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  # Seed a live fragment + person directly (no MCP needed).
+  GH11_F2="frag$(date +%s)$$_$RUN_ID"
+  psql "$DATABASE_URL" -c "INSERT INTO fragments (lookup_key, slug, title, content) VALUES ('$GH11_F2','uat11-3-$RUN_ID','UAT11_3 Stats Frag','x') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+  GH11_P2="person$(date +%s)$$_$RUN_ID"
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name) VALUES ('$GH11_P2','uat11-3-person-$RUN_ID','UAT11_3 Stats Person') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+
+  # Soft-delete all three.
+  psql "$DATABASE_URL" -c "UPDATE wikis SET deleted_at=now() WHERE lookup_key='$GH11_W2'" >/dev/null 2>&1
+  psql "$DATABASE_URL" -c "UPDATE fragments SET deleted_at=now() WHERE lookup_key='$GH11_F2'" >/dev/null 2>&1
+  psql "$DATABASE_URL" -c "UPDATE people SET deleted_at=now() WHERE lookup_key='$GH11_P2'" >/dev/null 2>&1
+
+  STATS_AFTER=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/users/stats")
+  N_NOTES_A=$(echo "$STATS_AFTER" | jq -r '.totalNotes // 0')
+  N_THREADS_A=$(echo "$STATS_AFTER" | jq -r '.totalThreads // 0')
+  N_PEOPLE_A=$(echo "$STATS_AFTER" | jq -r '.peopleCount // 0')
+
+  # After soft-delete, counts must equal the pre-seed baseline (i.e.
+  # the seeded-then-deleted rows must NOT be counted). With the bug,
+  # they're inflated by exactly one each.
+  if [ "$N_NOTES_A" = "$N_NOTES_B" ] && [ "$N_THREADS_A" = "$N_THREADS_B" ] && [ "$N_PEOPLE_A" = "$N_PEOPLE_B" ]; then
+    pass "11.3 /users/stats excludes soft-deleted rows (notes=$N_NOTES_A threads=$N_THREADS_A people=$N_PEOPLE_A)"
+  else
+    fail "11.3 /users/stats counts soft-deleted rows: notes $N_NOTES_B→$N_NOTES_A threads $N_THREADS_B→$N_THREADS_A people $N_PEOPLE_B→$N_PEOPLE_A (#264 — routes/users.ts:102-104 missing isNull(deletedAt))"
+  fi
+
+  uat11_hard_del_wiki "$GH11_W2"
+  uat11_hard_del_frag "$GH11_F2"
+  uat11_hard_del_person "$GH11_P2"
+
+  # ── 11.4 routes/relationships.ts — same pattern as graph: label-
+  # resolution batches don't filter deletedAt, so a relationship to a
+  # soft-deleted wiki/fragment still resolves to its label. Seed a
+  # live edge from a fragment to a soft-deleted wiki; GET
+  # /relationships/fragment/:id must NOT include the deleted wiki.
+  GH11_FREL=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    "$SERVER_URL/fragments?limit=10" | jq -r '.fragments[0].lookupKey // empty')
+  GH11_WREL="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT11_4 Rel Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  if [ -n "$GH11_FREL" ] && [ -n "$GH11_WREL" ]; then
+    GH11_REL_EDGE_ID=$(psql "$DATABASE_URL" -t -A -c "SELECT gen_random_uuid()" 2>/dev/null | tr -d '[:space:]')
+    psql "$DATABASE_URL" -c "INSERT INTO edges (id,src_type,src_id,dst_type,dst_id,edge_type) VALUES ('$GH11_REL_EDGE_ID','fragment','$GH11_FREL','wiki','$GH11_WREL','FRAGMENT_IN_WIKI') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+    psql "$DATABASE_URL" -c "UPDATE wikis SET deleted_at=now() WHERE lookup_key='$GH11_WREL'" >/dev/null 2>&1
+    REL_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/relationships/fragment/$GH11_FREL")
+    # Bug surface: when the lookup batch ignores deletedAt, the soft-
+    # deleted wiki still appears in the response at all (with type=wiki).
+    # Fix: filter the lookup batch on isNull(deletedAt) AND drop the
+    # other-side from `others[]` when its label resolution returned no
+    # row (i.e. don't ship the bare id as a phantom relationship).
+    REL_HIT=$(echo "$REL_BODY" | jq --arg k "$GH11_WREL" '[.relationships | to_entries[].value[] | select(.id == $k)] | length' 2>/dev/null)
+    if [ "${REL_HIT:-1}" = "0" ]; then
+      pass "11.4 relationships exclude soft-deleted wiki entirely"
+    else
+      fail "11.4 relationships still surface soft-deleted wiki $GH11_WREL (count=$REL_HIT) (#264 — routes/relationships.ts batch lookups missing isNull(deletedAt))"
+    fi
+    uat11_hard_del_wiki "$GH11_WREL"
+  else
+    skip "11.4 setup failed"
+  fi
+
+  # ── 11.5 routes/published.ts — GET /wiki/:nanoid resolves a public
+  # wiki by `publishedSlug AND published=true` only — no isNull(deletedAt).
+  # Workflow: publish a wiki, capture its publishedSlug, soft-delete
+  # it, then hit /wiki/:slug. Bug: returns 200 with content. Fix:
+  # returns 404.
+  GH11_PUB="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT11_5 Pub Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  if [ -n "$GH11_PUB" ]; then
+    # Force-publish via direct UPDATE — the publish API path varies.
+    GH11_PUB_SLUG="uat11-5-$RUN_ID-$(date +%N | head -c 6)"
+    psql "$DATABASE_URL" -c "UPDATE wikis SET published=true, published_slug='$GH11_PUB_SLUG', published_at=now(), content='UAT11_5 published content $RUN_ID' WHERE lookup_key='$GH11_PUB'" >/dev/null 2>&1
+    # Sanity: pre-delete it returns 200.
+    PUB_PRE=$(curl -s -o /dev/null -w "%{http_code}" "$SERVER_URL/published/wiki/$GH11_PUB_SLUG")
+    if [ "$PUB_PRE" != "200" ]; then
+      skip "11.5 pre-delete /published/wiki/$GH11_PUB_SLUG → $PUB_PRE (expected 200) — published-route assertion skipped"
+    else
+      psql "$DATABASE_URL" -c "UPDATE wikis SET deleted_at=now() WHERE lookup_key='$GH11_PUB'" >/dev/null 2>&1
+      PUB_POST=$(curl -s -o /dev/null -w "%{http_code}" "$SERVER_URL/published/wiki/$GH11_PUB_SLUG")
+      [ "$PUB_POST" = "404" ] && pass "11.5 /published/wiki returns 404 after soft-delete" \
+        || fail "11.5 /published/wiki still readable after soft-delete (HTTP $PUB_POST, expected 404) — #264 routes/published.ts missing isNull(deletedAt)"
+    fi
+    uat11_hard_del_wiki "$GH11_PUB"
+  else
+    skip "11.5 setup failed"
+  fi
+
+  # ── 12. Transitive ghost reachability (#262) ──────────────────────
+  # Even with #264 fixes, /fragments/:id resolves relatedFragments via
+  # a join that filters on the related fragment's own deletedAt — but
+  # not on the related fragment's *terminal wiki*. If fragment fA
+  # (live) has a FRAGMENT_RELATED_TO_FRAGMENT edge to fB (live), and
+  # fB's only FRAGMENT_IN_WIKI is to a soft-deleted wiki, fB still
+  # appears in fA.relatedFragments — the user can navigate from a
+  # live fragment to one whose only home is a deleted wiki.
+  echo ""
+  echo "── 12. Transitive ghost reachability (#262) ──"
+
+  # Setup: two wikis (W_LIVE kept alive for fA, W_GHOST will be
+  # soft-deleted) + two fragments.
+  GH12_W_LIVE="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT12 Live Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  GH12_W_GHOST="$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+    -H "Content-Type: application/json" -X POST \
+    -d "$(jq -n --arg n "UAT12 Ghost Wiki $RUN_ID" '{name:$n,type:"log",prompt:"x"}')" \
+    "$SERVER_URL/wikis" | jq -r '.lookupKey // .id // empty')"
+  GH12_FA="frag-uat12-a-$RUN_ID"
+  GH12_FB="frag-uat12-b-$RUN_ID"
+  psql "$DATABASE_URL" -c "INSERT INTO fragments (lookup_key, slug, title, content) VALUES ('$GH12_FA','uat12-a-$RUN_ID','UAT12 Live Frag A','x'),('$GH12_FB','uat12-b-$RUN_ID','UAT12 Ghost-Bound Frag B','y') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+  # Edges: fA in W_LIVE; fB in W_GHOST; fA<->fB RELATED_TO.
+  psql "$DATABASE_URL" -c "INSERT INTO edges (id,src_type,src_id,dst_type,dst_id,edge_type) VALUES (gen_random_uuid(),'fragment','$GH12_FA','wiki','$GH12_W_LIVE','FRAGMENT_IN_WIKI'),(gen_random_uuid(),'fragment','$GH12_FB','wiki','$GH12_W_GHOST','FRAGMENT_IN_WIKI'),(gen_random_uuid(),'fragment','$GH12_FA','fragment','$GH12_FB','FRAGMENT_RELATED_TO_FRAGMENT') ON CONFLICT DO NOTHING" >/dev/null 2>&1
+  # Soft-delete W_GHOST. fB itself stays live.
+  psql "$DATABASE_URL" -c "UPDATE wikis SET deleted_at=now() WHERE lookup_key='$GH12_W_GHOST'" >/dev/null 2>&1
+
+  # Assertion: GET /fragments/$GH12_FA must NOT include $GH12_FB in
+  # relatedFragments — fB is reachable only through a deleted wiki.
+  REL_BODY=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" "$SERVER_URL/fragments/$GH12_FA")
+  REL_HIT=$(echo "$REL_BODY" | jq --arg k "$GH12_FB" '[.relatedFragments[]? | select(.id == $k)] | length' 2>/dev/null)
+  if [ "${REL_HIT:-1}" = "0" ]; then
+    pass "12 relatedFragments excludes fragment whose only wiki is soft-deleted"
+  else
+    fail "12 relatedFragments includes ghost-bound fragment $GH12_FB (#262 — transitive ghost reachability via RELATED_TO edges)"
+  fi
+
+  # Cleanup
+  uat11_hard_del_frag "$GH12_FA"
+  uat11_hard_del_frag "$GH12_FB"
+  uat11_hard_del_wiki "$GH12_W_LIVE"
+  uat11_hard_del_wiki "$GH12_W_GHOST"
+
+  # UAT11/12 sweep — clear stragglers from any failed prior run.
+  psql "$DATABASE_URL" -c "
+    DELETE FROM edges WHERE src_id IN (SELECT lookup_key FROM wikis WHERE name LIKE 'UAT1_% Wiki %' OR name LIKE 'UAT12 %')
+                          OR dst_id IN (SELECT lookup_key FROM wikis WHERE name LIKE 'UAT1_% Wiki %' OR name LIKE 'UAT12 %')" >/dev/null 2>&1 || true
+  psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE name LIKE 'UAT11_% %' OR name LIKE 'UAT12 %'" >/dev/null 2>&1 || true
+  psql "$DATABASE_URL" -c "DELETE FROM fragments WHERE title LIKE 'UAT11_3 %' OR title LIKE 'UAT12 %'" >/dev/null 2>&1 || true
+  psql "$DATABASE_URL" -c "DELETE FROM people WHERE name LIKE 'UAT11_3 %'" >/dev/null 2>&1 || true
+
 fi
 
 echo ""

--- a/core/drizzle/migrations/0010_backfill_zombie_edges.sql
+++ b/core/drizzle/migrations/0010_backfill_zombie_edges.sql
@@ -1,0 +1,11 @@
+-- One-time backfill for #236. Edges that referenced wikis soft-deleted
+-- before the DELETE-handler cascade landed are still live (deleted_at
+-- IS NULL while their wiki has deleted_at IS NOT NULL). Triage observed
+-- 45+ such rows. Sweep them now and let the new handler keep the
+-- invariant.
+UPDATE edges
+SET deleted_at = now()
+FROM wikis
+WHERE edges.deleted_at IS NULL
+  AND wikis.deleted_at IS NOT NULL
+  AND (edges.src_id = wikis.lookup_key OR edges.dst_id = wikis.lookup_key);

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778025600000,
       "tag": "0009_search_recall_tags_and_triggers",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778112000000,
+      "tag": "0010_backfill_zombie_edges",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -207,7 +207,7 @@ export async function classifyUnfiledFragments(
       description: wikis.description,
     })
     .from(wikis)
-    .where(eq(wikis.lookupKey, wikiKey))
+    .where(and(eq(wikis.lookupKey, wikiKey), isNull(wikis.deletedAt)))
     .limit(1)
 
   if (!wiki) return { linked: 0, autoFiled: 0, llmFiled: 0, llmRejected: 0 }
@@ -273,10 +273,13 @@ export async function classifyUnfiledFragments(
           })
           .from(wikis)
           .where(
-            sql`${wikis.lookupKey} = ANY(ARRAY[${sql.join(
-              wikiKeys.map((k) => sql`${k}`),
-              sql`, `
-            )}])`
+            and(
+              isNull(wikis.deletedAt),
+              sql`${wikis.lookupKey} = ANY(ARRAY[${sql.join(
+                wikiKeys.map((k) => sql`${k}`),
+                sql`, `
+              )}])`,
+            ),
           )
         return rows
       },
@@ -302,6 +305,20 @@ export async function classifyUnfiledFragments(
 
         if (result.data.wikiEdges.length > 0) {
           for (const edge of result.data.wikiEdges) {
+            // Re-check the destination wiki right before the insert.
+            // The LLM call is slow; the wiki may have been soft-
+            // deleted while we were waiting. Without this, we close
+            // a TOCTOU window that the regen-entry deletedAt check
+            // can't (10c surfaced ~1 of these per UAT run).
+            const [stillLive] = await database
+              .select({ key: wikis.lookupKey })
+              .from(wikis)
+              .where(and(eq(wikis.lookupKey, edge.wikiKey), isNull(wikis.deletedAt)))
+              .limit(1)
+            if (!stillLive) {
+              log.warn({ fragmentKey: frag.lookupKey, wikiKey: edge.wikiKey }, 'skipping FRAGMENT_IN_WIKI insert: wiki was soft-deleted during LLM call')
+              continue
+            }
             await database
               .insert(edges)
               .values({
@@ -360,6 +377,15 @@ export async function regenerateWiki(
   const t0 = performance.now()
   const [wiki] = await database.select().from(wikis).where(eq(wikis.lookupKey, wikiKey))
   if (!wiki) throw new Error(`Wiki not found: ${wikiKey}`)
+  // #236 — a regen job may still be in the queue when the wiki is
+  // soft-deleted (DELETE handler doesn't drain BullMQ). Bail out
+  // here so the LLM classifier doesn't insert FRAGMENT_IN_WIKI
+  // edges into a tombstone, which is exactly the zombie-edge
+  // production path 10c was catching.
+  if (wiki.deletedAt) {
+    log.warn({ wikiKey }, 'regen target is soft-deleted; skipping')
+    return { content: '', fragmentCount: 0, hasEmbedding: false, timing: { classify: 0, gatherFragments: 0, llmCall: 0, embed: 0, total: 0 } }
+  }
 
   // Optimistic lock: transition to LINKING to prevent concurrent regen runs.
   // If the wiki is already LINKING, another worker owns it — bail out.

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -36,7 +36,7 @@ import {
   wikiClassificationSchema,
   fragmentRelevanceSchema,
 } from '@robin/shared'
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import {
   fragments,
@@ -78,6 +78,21 @@ function emitEvent(event: {
 }
 
 async function insertEdgeRow(edge: Record<string, unknown>): Promise<void> {
+  // TOCTOU guard for FRAGMENT_IN_WIKI edges: the LLM classifier may
+  // have decided to file a fragment into a wiki that got soft-
+  // deleted while it was thinking. Re-check the dst wiki right
+  // before the insert and drop the row if it's a tombstone.
+  if (edge.edgeType === 'FRAGMENT_IN_WIKI' && typeof edge.dstId === 'string') {
+    const [stillLive] = await db
+      .select({ key: wikis.lookupKey })
+      .from(wikis)
+      .where(and(eq(wikis.lookupKey, edge.dstId), isNull(wikis.deletedAt)))
+      .limit(1)
+    if (!stillLive) {
+      log.warn({ wikiKey: edge.dstId, srcId: edge.srcId }, 'skipping FRAGMENT_IN_WIKI insert: target wiki was soft-deleted')
+      return
+    }
+  }
   await db
     .insert(edges)
     .values({
@@ -379,6 +394,7 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
         const rows = await db
           .select({ lookupKey: wikis.lookupKey })
           .from(wikis)
+          .where(isNull(wikis.deletedAt))
           .limit(limit)
         return rows.map((r) => ({ wikiKey: r.lookupKey, score: 0 }))
       },
@@ -394,10 +410,13 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
           })
           .from(wikis)
           .where(
-            sql`${wikis.lookupKey} = ANY(ARRAY[${sql.join(
-              wikiKeys.map((k) => sql`${k}`),
-              sql`, `
-            )}])`
+            and(
+              isNull(wikis.deletedAt),
+              sql`${wikis.lookupKey} = ANY(ARRAY[${sql.join(
+                wikiKeys.map((k) => sql`${k}`),
+                sql`, `
+              )}])`,
+            ),
           )
         return rows
       },

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -78,21 +78,21 @@ fragmentsRouter.get('/:id', async (c) => {
     const rows = await db
       .select({ key: wikis.lookupKey, name: wikis.name, bouncerMode: wikis.bouncerMode })
       .from(wikis)
-      .where(inArray(wikis.lookupKey, dstByType.wiki))
+      .where(and(inArray(wikis.lookupKey, dstByType.wiki), isNull(wikis.deletedAt)))
     for (const r of rows) backlinks.push({ id: r.key, name: r.name, type: 'wiki', bouncerMode: r.bouncerMode })
   }
   if (dstByType.person?.length) {
     const rows = await db
       .select({ key: people.lookupKey, name: people.name })
       .from(people)
-      .where(inArray(people.lookupKey, dstByType.person))
+      .where(and(inArray(people.lookupKey, dstByType.person), isNull(people.deletedAt)))
     for (const r of rows) backlinks.push({ id: r.key, name: r.name, type: 'person' })
   }
   if (dstByType.fragment?.length) {
     const rows = await db
       .select({ key: fragments.lookupKey, title: fragments.title })
       .from(fragments)
-      .where(inArray(fragments.lookupKey, dstByType.fragment))
+      .where(and(inArray(fragments.lookupKey, dstByType.fragment), isNull(fragments.deletedAt)))
     for (const r of rows) backlinks.push({ id: r.key, name: r.title, type: 'fragment' })
   }
 

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -121,11 +121,33 @@ fragmentsRouter.get('/:id', async (c) => {
 
   const relatedFragments: { id: string; slug: string; title: string; similarity: number }[] = []
   if (relatedKeySet.size > 0) {
+    const relatedKeys = [...relatedKeySet]
     const relatedRows = await db
       .select({ lookupKey: fragments.lookupKey, slug: fragments.slug, title: fragments.title })
       .from(fragments)
-      .where(and(inArray(fragments.lookupKey, [...relatedKeySet]), isNull(fragments.deletedAt)))
+      .where(and(inArray(fragments.lookupKey, relatedKeys), isNull(fragments.deletedAt)))
+
+    // #262 — terminal-wiki check. A related fragment may itself be live
+    // but only sit inside a soft-deleted wiki; surfacing it lets the
+    // user navigate from a live fragment into ghost content. Keep
+    // only fragments with at least one live FRAGMENT_IN_WIKI edge
+    // pointing at a live (non-soft-deleted) wiki.
+    const liveTerminalRows = await db
+      .select({ srcId: edges.srcId })
+      .from(edges)
+      .innerJoin(wikis, eq(wikis.lookupKey, edges.dstId))
+      .where(
+        and(
+          eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+          isNull(edges.deletedAt),
+          isNull(wikis.deletedAt),
+          inArray(edges.srcId, relatedKeys),
+        ),
+      )
+    const liveTerminal = new Set(liveTerminalRows.map((r) => r.srcId))
+
     for (const r of relatedRows) {
+      if (!liveTerminal.has(r.lookupKey)) continue
       relatedFragments.push({
         id: r.lookupKey,
         slug: r.slug,

--- a/core/src/routes/graph.ts
+++ b/core/src/routes/graph.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { isNull, inArray } from 'drizzle-orm'
+import { and, isNull, inArray } from 'drizzle-orm'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
 import { edges, entries, fragments, wikis, people } from '../db/schema.js'
@@ -87,7 +87,7 @@ graphRouter.get('/', async (c) => {
         content: entries.content,
       })
       .from(entries)
-      .where(inArray(entries.lookupKey, idsByType.entry))
+      .where(and(inArray(entries.lookupKey, idsByType.entry), isNull(entries.deletedAt)))
     for (const r of rows)
       labelMap[`entry:${r.key}`] = {
         label: r.title || 'Untitled Entry',
@@ -102,7 +102,7 @@ graphRouter.get('/', async (c) => {
         content: fragments.content,
       })
       .from(fragments)
-      .where(inArray(fragments.lookupKey, idsByType.fragment))
+      .where(and(inArray(fragments.lookupKey, idsByType.fragment), isNull(fragments.deletedAt)))
     for (const r of rows)
       labelMap[`fragment:${r.key}`] = {
         label: r.title || 'Untitled Fragment',
@@ -113,7 +113,7 @@ graphRouter.get('/', async (c) => {
     const rows = await db
       .select({ key: wikis.lookupKey, name: wikis.name, content: wikis.content })
       .from(wikis)
-      .where(inArray(wikis.lookupKey, idsByType.thread))
+      .where(and(inArray(wikis.lookupKey, idsByType.thread), isNull(wikis.deletedAt)))
     for (const r of rows)
       labelMap[`thread:${r.key}`] = {
         label: r.name,
@@ -124,7 +124,7 @@ graphRouter.get('/', async (c) => {
     const rows = await db
       .select({ key: wikis.lookupKey, name: wikis.name, content: wikis.content })
       .from(wikis)
-      .where(inArray(wikis.lookupKey, idsByType.wiki))
+      .where(and(inArray(wikis.lookupKey, idsByType.wiki), isNull(wikis.deletedAt)))
     for (const r of rows)
       labelMap[`wiki:${r.key}`] = {
         label: r.name,
@@ -135,7 +135,7 @@ graphRouter.get('/', async (c) => {
     const rows = await db
       .select({ key: people.lookupKey, name: people.name, content: people.content })
       .from(people)
-      .where(inArray(people.lookupKey, idsByType.person))
+      .where(and(inArray(people.lookupKey, idsByType.person), isNull(people.deletedAt)))
     for (const r of rows)
       labelMap[`person:${r.key}`] = {
         label: r.name,

--- a/core/src/routes/published.ts
+++ b/core/src/routes/published.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import { wikis } from '../db/schema.js'
 import { publicWikiResponseSchema } from '../schemas/wikis.schema.js'
@@ -23,7 +23,13 @@ publishedRoutes.get('/wiki/:nanoid', async (c) => {
       citationDeclarations: wikis.citationDeclarations,
     })
     .from(wikis)
-    .where(and(eq(wikis.publishedSlug, nanoid), eq(wikis.published, true)))
+    .where(
+      and(
+        eq(wikis.publishedSlug, nanoid),
+        eq(wikis.published, true),
+        isNull(wikis.deletedAt),
+      ),
+    )
     .limit(1)
 
   if (!wiki || !wiki.content) {

--- a/core/src/routes/relationships.ts
+++ b/core/src/routes/relationships.ts
@@ -65,7 +65,7 @@ relationshipsRouter.get('/:type/:id', async (c) => {
     const rows = await db
       .select({ key: entries.lookupKey, title: entries.title })
       .from(entries)
-      .where(inArray(entries.lookupKey, ids))
+      .where(and(inArray(entries.lookupKey, ids), isNull(entries.deletedAt)))
     for (const r of rows) labelMap[`entry:${r.key}`] = r.title || 'Untitled Entry'
   }
   if (idsByType.fragment?.size) {
@@ -73,33 +73,37 @@ relationshipsRouter.get('/:type/:id', async (c) => {
     const rows = await db
       .select({ key: fragments.lookupKey, title: fragments.title })
       .from(fragments)
-      .where(inArray(fragments.lookupKey, ids))
+      .where(and(inArray(fragments.lookupKey, ids), isNull(fragments.deletedAt)))
     for (const r of rows) labelMap[`fragment:${r.key}`] = r.title || 'Untitled Fragment'
   }
-  if (idsByType.thread?.size) {
-    const ids = [...idsByType.thread]
+  if (idsByType.wiki?.size) {
+    const ids = [...idsByType.wiki]
     const rows = await db
       .select({ key: wikis.lookupKey, name: wikis.name })
       .from(wikis)
-      .where(inArray(wikis.lookupKey, ids))
-    for (const r of rows) labelMap[`thread:${r.key}`] = r.name
+      .where(and(inArray(wikis.lookupKey, ids), isNull(wikis.deletedAt)))
+    for (const r of rows) labelMap[`wiki:${r.key}`] = r.name
   }
   if (idsByType.person?.size) {
     const ids = [...idsByType.person]
     const rows = await db
       .select({ key: people.lookupKey, name: people.name })
       .from(people)
-      .where(inArray(people.lookupKey, ids))
+      .where(and(inArray(people.lookupKey, ids), isNull(people.deletedAt)))
     for (const r of rows) labelMap[`person:${r.key}`] = r.name
   }
 
-  // Group by edgeType
+  // Group by edgeType. Drop entries whose label resolution returned
+  // nothing — those rows point at a soft-deleted (or otherwise
+  // missing) entity and shouldn't ship as phantom relationships
+  // with bare-id labels.
   const grouped: Record<
     string,
     Array<{ id: string; type: string; label: string; edgeType: string }>
   > = {}
   for (const o of others) {
-    const label = labelMap[`${o.type}:${o.id}`] ?? o.id
+    const label = labelMap[`${o.type}:${o.id}`]
+    if (!label) continue
     if (!grouped[o.edgeType]) grouped[o.edgeType] = []
     grouped[o.edgeType].push({
       id: o.id,

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -99,18 +99,30 @@ usersRouter.get('/keypair', async (c) => {
 // GET /users/stats
 usersRouter.get('/stats', async (c) => {
   const [[noteCount], [wikiCount], [personCount], [unwikiedCountResult]] = await Promise.all([
-    db.select({ count: sql<number>`count(*)` }).from(fragments),
-    db.select({ count: sql<number>`count(*)` }).from(wikis),
-    db.select({ count: sql<number>`count(*)` }).from(people),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(fragments)
+      .where(isNull(fragments.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(wikis)
+      .where(isNull(wikis.deletedAt)),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(people)
+      .where(isNull(people.deletedAt)),
     db
       .select({ count: sql<number>`count(*)` })
       .from(fragments)
       .where(
-        sql`${fragments.lookupKey} NOT IN (
-          SELECT src_id FROM edges
-          WHERE edge_type = 'FRAGMENT_IN_WIKI'
-          AND deleted_at IS NULL
-        )`
+        and(
+          isNull(fragments.deletedAt),
+          sql`${fragments.lookupKey} NOT IN (
+            SELECT src_id FROM edges
+            WHERE edge_type = 'FRAGMENT_IN_WIKI'
+            AND deleted_at IS NULL
+          )`
+        )
       ),
   ])
 

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -718,10 +718,26 @@ wikisRouter.delete('/:id', async (c) => {
   const [wiki] = await db.select().from(wikis).where(and(eq(wikis.lookupKey, id), isNull(wikis.deletedAt)))
   if (!wiki) return c.json({ error: 'Not found' }, 404)
 
+  const now = new Date()
   await db
     .update(wikis)
-    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .set({ deletedAt: now, updatedAt: now })
     .where(eq(wikis.lookupKey, id))
+
+  // Cascade: soft-delete every edge that references this wiki on
+  // either side. Without this the graph keeps zombie nodes alive
+  // and the classifier can route fresh fragments through stale
+  // FRAGMENT_IN_WIKI edges. Mirrors the read-side soft-delete
+  // contract used everywhere else in the codebase.
+  await db
+    .update(edges)
+    .set({ deletedAt: now })
+    .where(
+      and(
+        isNull(edges.deletedAt),
+        sql`(${edges.srcId} = ${id} OR ${edges.dstId} = ${id})`,
+      ),
+    )
 
   // Hard-delete group memberships — soft-delete doesn't trigger FK CASCADE
   await db.delete(groupWikis).where(eq(groupWikis.wikiId, id))


### PR DESCRIPTION
## Summary

Closes the deletedAt-predicate-forgotten cluster — three related bugs around soft-deleted wikis bleeding into live behavior.

- **#236** — Fragments routed to soft-deleted ghost wikis; wiki delete leaves zombie edges. Three-part fix: edge cascade in wiki DELETE handler + classifier candidate filter + regen bail-on-soft-deleted-target.
- **#264** — Five sibling drizzle queries missing `isNull(deletedAt)`: `core/src/routes/{fragments,graph,users,relationships,published}.ts` (corrected from handover's `core/src/lib/...` paths — actual sites were under `routes/`).
- **#262** — Transitive ghost reachability: RELATED_TO traversal in `/fragments/:id` returned related fragments living in deleted wikis. Now drops them at terminal-wiki check.

## UAT contract

`.uat/plans/08-wiki-crud.md` extended with §11.1–§11.5 (one per #264 site) and §12 (transitive reachability for #262). All assertions FAIL on \`4ecfdcf\` and PASS on this branch. Final post-fix: **31 P / 0 F / 0 SKIP.**

| Issue | Sections | Pre-fix | Post-fix |
|-------|----------|---------|----------|
| #236  | §10b, §10c, §10d.4 | F | P |
| #264  | §11.1–§11.5 | F | P |
| #262  | §12 | F | P |

## Backfill migration

`core/drizzle/migrations/0009_backfill_zombie_edges.sql` deletes pre-existing zombie edges that the new cascade prevents going forward. Migration is idempotent.

> Note: clusters 1 + 3 both wrote `0009_*.sql` on parallel branches. The PR merged second renames its migration to 0010 — orchestrator will handle at merge time.

## Files

- routes: `wikis.ts`, `fragments.ts`, `graph.ts`, `users.ts`, `relationships.ts`, `published.ts`
- queue: `worker.ts`
- lib: `regen.ts`
- migration: `0009_backfill_zombie_edges.sql` + journal

LOC: +397 / −40

## Plan-strengthening note

The original plan 08 §10a (classifier check) was non-deterministic — the LLM may not pick the ghost wiki on a small test corpus. The new §10c global-zombie-sweep is the deterministic catch for #236 bug 1.

Closes #236
Closes #264
Closes #262