### PR TITLE
fix(stability): search recall — BM25 OR-join, tag-weighted vector, ?tags= filter

### DIFF
--- a/.uat/plans/11-search.md
+++ b/.uat/plans/11-search.md
@@ -1,0 +1,261 @@
+# 11 — Search (advanced filters: ?tables= and ?tags=)
+
+## What it proves
+
+Issue #46 — advanced search filters at the REST surface.
+
+**(§1) `?tables=` already does what `?type=` asked for.** Existing schema
+already accepts `tables=fragment,wiki,person` as a union over the row
+discriminator. We assert the basics still hold: omitting `tables=`
+returns a mixed result set; restricting to a single table returns only
+that type.
+
+**(§2) `?tags=` filter (NEW — added in #46).** The new
+`?tags=foo,bar` parameter restricts BM25 results to fragments whose
+`tags` jsonb array intersects (UNION semantics — *any* of the listed
+tags qualifies). Wikis and people have no `tags` column, so the filter
+is a no-op for those tables. Semantics chosen to mirror `?tables=`,
+which already means "any of these tables" — picking AND would be
+asymmetric and surprising.
+
+The new assertion has TWO sides:
+- **Positive:** a fragment tagged with `["foo"]` surfaces when we
+  search with `?tags=foo`.
+- **Negative:** an untagged fragment with the same body text does NOT
+  surface when we search with `?tags=foo`.
+
+Without the negative, a missing-filter regression (e.g. param parsed
+but never applied) would silently pass.
+
+## Pre-fix expectations
+
+- §1a / §1b (existing `?tables=` behaviour): pass on both pre- and
+  post-#46.
+- §2a (positive: tagged fragment surfaces with `?tags=foo`): **fails**
+  pre-#46 (the param is unknown to the schema → 400, or ignored → both
+  fragments returned and the test still fails on the negative side).
+- §2b (negative: untagged fragment hidden with `?tags=foo`): **fails**
+  pre-#46 — without filter implementation, both fragments come back.
+
+## Prerequisites
+
+- Core running on `SERVER_URL`.
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` set in `core/.env`.
+- `jq` and `curl` installed.
+
+## Fixture identity this plan references
+
+- Per-run salt `RUN_ID="$(date +%s)-$$"`.
+- Per-run UAT raw_source: `uat11-search-<RUN_ID>`.
+- Per-run UAT fragments:
+  - `Tagged Probe <RUN_ID>` (tags=`["uat11-foo"]`) — §2 positive.
+  - `Untagged Probe <RUN_ID>` (tags=`[]`) — §2 negative. Body text
+    intentionally shares the salt so a no-filter search would match
+    both.
+
+## Restoring downstream-plan state
+
+Cleanup deletes every per-RUN_ID row + the parent raw_source. No
+shared-corpus drift.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:${PORT:-3000}}"
+COOKIE_JAR=$(mktemp /tmp/uat-cookies-11-XXXXXX.txt)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+RUN_ID="$(date +%s)-$$"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "11 — Search (advanced filters: ?tables= and ?tags=)"
+echo ""
+
+# ── 0. Sign in ──────────────────────────────────────────────
+curl -s -o /dev/null -c "$COOKIE_JAR" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+
+if [ -s "$COOKIE_JAR" ]; then
+  pass "0a. sign-in established a session cookie"
+else
+  fail "0a. sign-in failed"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+# Parent entry.
+ENTRY_RESP=$(curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+  -H "Content-Type: application/json" \
+  -X POST -d "$(jq -n --arg c "uat11-search-$RUN_ID" '{content:$c}')" \
+  "$SERVER_URL/entries")
+ENTRY_ID=$(echo "$ENTRY_RESP" | jq -r '.lookupKey // .id // empty')
+if [ -n "$ENTRY_ID" ] && [ "$ENTRY_ID" != "null" ]; then
+  pass "0b. created parent entry ($ENTRY_ID)"
+else
+  fail "0b. could not create parent entry: $ENTRY_RESP"
+  echo ""
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"
+  exit 1
+fi
+
+mk_fragment() {
+  local title="$1" content="$2" tags_json="$3"
+  curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+    -H "Content-Type: application/json" \
+    -X POST -d "$(jq -n \
+      --arg t "$title" --arg c "$content" --arg e "$ENTRY_ID" \
+      --argjson tg "$tags_json" \
+      '{title:$t, content:$c, entryId:$e, tags:$tg}')" \
+    "$SERVER_URL/fragments"
+}
+
+bm25_search() {
+  local q="$1" extra="$2"
+  curl -s -b "$COOKIE_JAR" -H "Origin: $SERVER_URL" \
+    --get \
+    --data-urlencode "q=$q" \
+    --data-urlencode "mode=bm25" \
+    $extra \
+    "$SERVER_URL/search"
+}
+
+# ── §1. ?tables= as the single source of type-filtering ──────
+# Existing behaviour; must keep passing.
+
+F_TABLE_RESP=$(mk_fragment \
+  "Tables Probe $RUN_ID" \
+  "Distinctive uat11tables $RUN_ID body content." \
+  '[]')
+F_TABLE_KEY=$(echo "$F_TABLE_RESP" | jq -r '.lookupKey // empty')
+if [ -n "$F_TABLE_KEY" ]; then
+  pass "§1a-i. created §1 control fragment '$F_TABLE_KEY'"
+else
+  fail "§1a-i. could not create §1 fragment: $F_TABLE_RESP"
+fi
+
+# tables=fragment must include our fragment.
+T_HITS=$(bm25_search "uat11tables $RUN_ID" "--data-urlencode tables=fragment" \
+  | jq --arg k "$F_TABLE_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${T_HITS:-0}" -ge 1 ]; then
+  pass "§1a-ii. tables=fragment returns the §1 fragment"
+else
+  fail "§1a-ii. tables=fragment did not return §1 fragment"
+fi
+
+# tables=wiki must NOT include the fragment.
+W_HITS=$(bm25_search "uat11tables $RUN_ID" "--data-urlencode tables=wiki" \
+  | jq --arg k "$F_TABLE_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${W_HITS:-0}" -eq 0 ]; then
+  pass "§1b. tables=wiki excludes the fragment (table-discriminator works)"
+else
+  fail "§1b. tables=wiki returned the fragment — type-discriminator broken"
+fi
+
+# ── §2. ?tags= filter — new in #46 ──────────────────────────
+# Two fragments share the same distinctive body salt so a no-filter
+# search would match both. Tags differentiate them. With ?tags=uat11-foo:
+#   POSITIVE — Tagged Probe must surface (its tags array contains foo).
+#   NEGATIVE — Untagged Probe must NOT surface (empty tags array).
+
+F_TAG_RESP=$(mk_fragment \
+  "Tagged Probe $RUN_ID" \
+  "Distinctive uat11tagsalt $RUN_ID body — tagged variant." \
+  '["uat11-foo"]')
+F_TAG_KEY=$(echo "$F_TAG_RESP" | jq -r '.lookupKey // empty')
+
+F_NOTAG_RESP=$(mk_fragment \
+  "Untagged Probe $RUN_ID" \
+  "Distinctive uat11tagsalt $RUN_ID body — untagged variant." \
+  '[]')
+F_NOTAG_KEY=$(echo "$F_NOTAG_RESP" | jq -r '.lookupKey // empty')
+
+if [ -n "$F_TAG_KEY" ] && [ -n "$F_NOTAG_KEY" ]; then
+  pass "§2-setup. created tagged ($F_TAG_KEY) + untagged ($F_NOTAG_KEY) fragments"
+else
+  fail "§2-setup. could not create §2 fragments"
+fi
+
+# Sanity — no filter, both surface.
+NOFILTER=$(bm25_search "uat11tagsalt $RUN_ID" "")
+SANITY_TAG=$(echo "$NOFILTER"   | jq --arg k "$F_TAG_KEY"   '[.results[] | select(.id==$k)] | length')
+SANITY_NOTAG=$(echo "$NOFILTER" | jq --arg k "$F_NOTAG_KEY" '[.results[] | select(.id==$k)] | length')
+if [ "${SANITY_TAG:-0}" -ge 1 ] && [ "${SANITY_NOTAG:-0}" -ge 1 ]; then
+  pass "§2-sanity. no-filter search surfaces both probes (control)"
+else
+  fail "§2-sanity. no-filter search missed a probe — recall broken upstream"
+fi
+
+# Apply ?tags=uat11-foo.
+TAG_RESP=$(bm25_search "uat11tagsalt $RUN_ID" "--data-urlencode tags=uat11-foo")
+
+POS_HITS=$(echo "$TAG_RESP" | jq --arg k "$F_TAG_KEY"   '[.results[] | select(.id==$k)] | length')
+NEG_HITS=$(echo "$TAG_RESP" | jq --arg k "$F_NOTAG_KEY" '[.results[] | select(.id==$k)] | length')
+
+# Positive: tagged fragment surfaces.
+if [ "${POS_HITS:-0}" -ge 1 ]; then
+  pass "§2a (POSITIVE). tags=uat11-foo surfaces tagged fragment"
+else
+  fail "§2a (POSITIVE). tags=uat11-foo did NOT surface tagged fragment (CURRENTLY FAILS pre-#46)"
+fi
+
+# Negative: untagged fragment excluded.
+if [ "${NEG_HITS:-0}" -eq 0 ]; then
+  pass "§2b (NEGATIVE). tags=uat11-foo excludes untagged fragment"
+else
+  fail "§2b (NEGATIVE). tags=uat11-foo did NOT exclude untagged fragment — filter ignored (CURRENTLY FAILS pre-#46)"
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────
+if [ -n "${DATABASE_URL:-}" ]; then
+  for k in "$F_TABLE_KEY" "$F_TAG_KEY" "$F_NOTAG_KEY"; do
+    [ -n "$k" ] && psql "$DATABASE_URL" -q -c \
+      "DELETE FROM fragments WHERE lookup_key='$k'" >/dev/null 2>&1
+  done
+  if [ -n "${ENTRY_ID:-}" ]; then
+    psql "$DATABASE_URL" -q -c "DELETE FROM pipeline_events WHERE entry_id='$ENTRY_ID'" >/dev/null 2>&1
+    psql "$DATABASE_URL" -q -c "DELETE FROM processed_jobs WHERE job_id='$ENTRY_ID'" >/dev/null 2>&1
+    psql "$DATABASE_URL" -q -c "DELETE FROM raw_sources WHERE lookup_key='$ENTRY_ID'" >/dev/null 2>&1
+  fi
+  pass "cleanup. per-RUN_ID rows deleted"
+else
+  skip "cleanup. DATABASE_URL unset — per-RUN_ID rows left in place"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```
+
+## Expected outcome (pre-#46 vs post-#46)
+
+| Section | Pre-#46 | Post-#46 |
+| --- | --- | --- |
+| §1a-i / §1a-ii / §1b (`?tables=`) | pass | pass |
+| §2-setup / §2-sanity | pass | pass |
+| §2a (POSITIVE: tagged fragment surfaces) | **fail** | pass |
+| §2b (NEGATIVE: untagged excluded) | **fail** | pass |
+| cleanup | pass | pass |
+
+## Tag-filter semantics — UNION (any-of)
+
+`?tags=a,b` returns rows whose tag array intersects `{a, b}`. Picked
+to mirror `?tables=`, which is also union over the discriminator. AND
+(intersect-all) was rejected because no consumer asked for it and
+asymmetric semantics across two filter parameters is the kind of
+papercut that bites integrators six months later.

--- a/core/drizzle/migrations/0009_search_recall_tags_and_triggers.sql
+++ b/core/drizzle/migrations/0009_search_recall_tags_and_triggers.sql
@@ -1,0 +1,87 @@
+-- Search-recall fixes (issue #249).
+--
+-- 1. Weave fragment tags into fragments.search_vector (weight C). Tags
+--    were previously absent from the vector — tag-only queries hit 0
+--    rows even when the row's tags array clearly matched.
+--
+-- 2. Expand each trigger's UPDATE-OF column list so the vector rebuilds
+--    on every column it depends on. The shipped triggers fired only on
+--    a partial subset (e.g. fragments fired on title only, missing
+--    content + tags) so live edits silently drifted the index.
+--
+-- 3. Backfill — every existing row needs its vector rebuilt once so
+--    deployed data benefits from the wider source set.
+--
+-- All statements are idempotent (CREATE OR REPLACE / DROP TRIGGER IF
+-- EXISTS) so re-running the migration is safe.
+
+-- ─── fragments: title (A) + content (B) + tags (C) ───
+CREATE OR REPLACE FUNCTION fragments_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'B') ||
+    setweight(
+      to_tsvector(
+        'english',
+        coalesce(
+          (SELECT string_agg(replace(value, '-', ' '), ' ')
+             FROM jsonb_array_elements_text(NEW.tags)),
+          ''
+        )
+      ),
+      'C'
+    );
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS fragments_search_vector_trigger ON "fragments";--> statement-breakpoint
+CREATE TRIGGER fragments_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF title, content, tags ON "fragments"
+  FOR EACH ROW EXECUTE FUNCTION fragments_search_vector_update();--> statement-breakpoint
+
+-- ─── wikis: name (A) + prompt + description (B) + content (C) ───
+-- description was never in the vector either — adding it here so a
+-- single trigger expansion covers every text source.
+CREATE OR REPLACE FUNCTION wikis_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.prompt, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'C');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS wikis_search_vector_trigger ON "wikis";--> statement-breakpoint
+CREATE TRIGGER wikis_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF name, prompt, description, content ON "wikis"
+  FOR EACH ROW EXECUTE FUNCTION wikis_search_vector_update();--> statement-breakpoint
+
+-- ─── people: name + aliases (A) + slug + relationship (B) + content (C) ───
+CREATE OR REPLACE FUNCTION people_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(array_to_string(NEW.aliases, ' '), '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.slug, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.relationship, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'C');
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS people_search_vector_trigger ON "people";--> statement-breakpoint
+CREATE TRIGGER people_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF name, aliases, slug, relationship, content ON "people"
+  FOR EACH ROW EXECUTE FUNCTION people_search_vector_update();--> statement-breakpoint
+
+-- ─── Backfill — rebuild every existing search_vector once ───
+-- Touching a vector-source column forces the BEFORE trigger to fire
+-- and recompute the vector with the new column set. We pick a column
+-- that's always non-null so the no-op self-assign is safe.
+UPDATE "fragments" SET title = title;--> statement-breakpoint
+UPDATE "wikis"     SET name  = name;--> statement-breakpoint
+UPDATE "people"    SET name  = name;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777939200000,
       "tag": "0008_fragments_dedup_hash_partial_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778025600000,
+      "tag": "0009_search_recall_tags_and_triggers",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/lib/search.test.ts
+++ b/core/src/lib/search.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildOrTsQuery } from './search.js'
+
+// Sanitiser unit tests — guard against the class of bug where raw user
+// input reaches `to_tsquery` with an unescaped operator and crashes the
+// query parser. Every dangerous character must round-trip to whitespace
+// or be dropped before it can reach postgres.
+
+describe('buildOrTsQuery', () => {
+  it('OR-joins simple multi-word queries', () => {
+    expect(buildOrTsQuery('divya europe travel')).toBe('divya | europe | travel')
+  })
+
+  it('lowercases tokens', () => {
+    expect(buildOrTsQuery('Divya EUROPE')).toBe('divya | europe')
+  })
+
+  it('dedupes repeated tokens while preserving order', () => {
+    expect(buildOrTsQuery('alpha bravo alpha charlie bravo')).toBe(
+      'alpha | bravo | charlie'
+    )
+  })
+
+  it('strips tsquery reserved chars (& | ! ( ) : * < @)', () => {
+    // & | ! ( ) : * < @ all become whitespace, splitting tokens cleanly.
+    expect(buildOrTsQuery('foo & bar | baz')).toBe('foo | bar | baz')
+    expect(buildOrTsQuery('a:* | (b!c)')).toBe('a | b | c')
+    expect(buildOrTsQuery("don't @mention")).toBe('don | t | mention')
+  })
+
+  it('strips quotes and backslashes (also tsquery-fatal)', () => {
+    expect(buildOrTsQuery('"quoted phrase" plain')).toBe(
+      'quoted | phrase | plain'
+    )
+    expect(buildOrTsQuery('back\\slash here')).toBe('back | slash | here')
+  })
+
+  it('returns null for empty / whitespace / pure-punctuation input', () => {
+    expect(buildOrTsQuery('')).toBeNull()
+    expect(buildOrTsQuery('   ')).toBeNull()
+    expect(buildOrTsQuery('& | ! @')).toBeNull()
+  })
+
+  it('splits hyphenated tokens so tag slugs match indexed stems', () => {
+    // to_tsquery treats `machine-learning` as a phrase query (<->) on
+    // the english parser, so we explicitly OR the parts to keep recall.
+    expect(buildOrTsQuery('machine-learning')).toBe('machine | learning')
+  })
+
+  it('handles unicode-ish junk gracefully (non-alphanum splits)', () => {
+    // The regex passes [A-Za-z0-9_-] only; non-ASCII letters get split.
+    // We assert the call does not throw and returns a usable string.
+    const out = buildOrTsQuery('café münchen 東京')
+    expect(out).not.toBeNull()
+    // At minimum the ASCII fragments survive:
+    expect(out).toContain('caf')
+  })
+})

--- a/core/src/lib/search.ts
+++ b/core/src/lib/search.ts
@@ -13,6 +13,48 @@ export interface SearchResult {
 
 type SearchTable = 'fragment' | 'wiki' | 'person'
 
+// to_tsquery operators we have to neutralise before splitting raw user
+// input — postgres throws "syntax error in tsquery" if any of these
+// reach the parser unescaped.
+const TSQUERY_RESERVED = /[&|!():*<@'"\\]/g
+
+/**
+ * Convert raw user input into a safe `to_tsquery` OR-string.
+ *
+ * - Strips reserved tsquery operators (`& | ! ( ) : * < @ ' " \`).
+ * - Splits on whitespace + any remaining non-alphanumeric junk.
+ * - Lowercases and dedupes tokens.
+ * - Joins with ` | ` for OR semantics. ts_rank still scores
+ *   all-terms-matched docs higher than partial matches, so recall
+ *   improves without flattening the ranking signal.
+ *
+ * Returns `null` when no usable tokens remain — callers should treat
+ * that as "match nothing" and skip the BM25 query entirely.
+ */
+export function buildOrTsQuery(raw: string): string | null {
+  const cleaned = raw.replace(TSQUERY_RESERVED, ' ')
+  // Split on whitespace AND hyphens — `to_tsquery('machine-learning')`
+  // becomes a phrase query (`<->` operator) on the english parser, so a
+  // doc containing only the standalone stems wouldn't match. Splitting
+  // on `-` lets us OR the parts and trade phrase-precision for recall.
+  const tokens = cleaned
+    .split(/[^A-Za-z0-9_]+/)
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > 0)
+  if (tokens.length === 0) return null
+  // Dedupe while preserving order so the query string stays stable
+  // for caching and easier debugging.
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const t of tokens) {
+    if (!seen.has(t)) {
+      seen.add(t)
+      unique.push(t)
+    }
+  }
+  return unique.join(' | ')
+}
+
 // Reciprocal Rank Fusion: score = sum(1 / (k + rank)) across all lists
 function rrfFuse(lists: SearchResult[][], k = 60): SearchResult[] {
   const scores = new Map<string, { result: SearchResult; score: number }>()
@@ -76,10 +118,35 @@ async function bm25SearchTable(
   database: DB,
   query: string,
   tableType: SearchTable,
-  limit: number
+  limit: number,
+  tagsFilter?: string[]
 ): Promise<SearchResult[]> {
   const meta = tableMeta[tableType]
-  const tsQuery = sql`plainto_tsquery('english', ${query})`
+  const orQuery = buildOrTsQuery(query)
+  if (orQuery === null) return []
+  const tsQuery = sql`to_tsquery('english', ${orQuery})`
+
+  // Tag filter (issue #46) only applies to fragments — wikis and
+  // people have no tags column. UNION semantics: `tags=a,b` matches
+  // any fragment whose tags array intersects {a,b}. Mirrors `tables=`,
+  // which is also union over the row discriminator. Wikis/people
+  // return no rows when a tag filter is set (none could ever satisfy).
+  const tags =
+    tagsFilter && tagsFilter.length > 0 ? tagsFilter : null
+  if (tags && tableType !== 'fragment') return []
+
+  // Build the tags filter clause separately because postgres-js does
+  // not serialise JS arrays into a `text[]` parameter cleanly. We
+  // pass each tag as its own parameter and bind them inside an
+  // EXISTS over jsonb_array_elements_text — equivalent to
+  // `tags ?| array[...]` (UNION) but bind-safe.
+  const whereClause =
+    tags && tableType === 'fragment'
+      ? sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery} AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${fragments.tags}) AS t(elem) WHERE t.elem IN (${sql.join(
+          tags.map((tag) => sql`${tag}`),
+          sql`, `
+        )}))`
+      : sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery}`
 
   const rows = await database
     .select({
@@ -89,9 +156,7 @@ async function bm25SearchTable(
       score: sql<number>`ts_rank(${meta.searchVectorCol}, ${tsQuery})`,
     })
     .from(meta.table)
-    .where(
-      sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery}`
-    )
+    .where(whereClause)
     .orderBy(sql`ts_rank(${meta.searchVectorCol}, ${tsQuery}) DESC`)
     .limit(limit)
 
@@ -107,13 +172,13 @@ async function bm25SearchTable(
 async function bm25Search(
   database: DB,
   query: string,
-  opts: { limit?: number; tables?: SearchTable[] } = {}
+  opts: { limit?: number; tables?: SearchTable[]; tags?: string[] } = {}
 ): Promise<SearchResult[]> {
   const limit = opts.limit ?? 20
   const tables = opts.tables ?? ['fragment', 'wiki', 'person']
 
   const results = await Promise.all(
-    tables.map((t) => bm25SearchTable(database, query, t, limit))
+    tables.map((t) => bm25SearchTable(database, query, t, limit, opts.tags))
   )
 
   return results
@@ -126,10 +191,24 @@ async function vectorSearchTable(
   database: DB,
   queryEmbedding: number[],
   tableType: SearchTable,
-  limit: number
+  limit: number,
+  tagsFilter?: string[]
 ): Promise<SearchResult[]> {
   const meta = tableMeta[tableType]
   const vecLiteral = JSON.stringify(queryEmbedding)
+
+  // Same tag-filter rules as bm25SearchTable: fragments only.
+  const tags =
+    tagsFilter && tagsFilter.length > 0 ? tagsFilter : null
+  if (tags && tableType !== 'fragment') return []
+
+  const whereClause =
+    tags && tableType === 'fragment'
+      ? sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${fragments.tags}) AS t(elem) WHERE t.elem IN (${sql.join(
+          tags.map((tag) => sql`${tag}`),
+          sql`, `
+        )}))`
+      : sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL`
 
   const rows = await database
     .select({
@@ -139,9 +218,7 @@ async function vectorSearchTable(
       distance: sql<number>`${meta.embeddingCol} <=> ${vecLiteral}::vector`,
     })
     .from(meta.table)
-    .where(
-      sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL`
-    )
+    .where(whereClause)
     .orderBy(sql`${meta.embeddingCol} <=> ${vecLiteral}::vector`)
     .limit(limit)
 
@@ -157,13 +234,15 @@ async function vectorSearchTable(
 async function vectorSearch(
   database: DB,
   queryEmbedding: number[],
-  opts: { limit?: number; tables?: SearchTable[] } = {}
+  opts: { limit?: number; tables?: SearchTable[]; tags?: string[] } = {}
 ): Promise<SearchResult[]> {
   const limit = opts.limit ?? 20
   const tables = opts.tables ?? ['fragment', 'wiki', 'person']
 
   const results = await Promise.all(
-    tables.map((t) => vectorSearchTable(database, queryEmbedding, t, limit))
+    tables.map((t) =>
+      vectorSearchTable(database, queryEmbedding, t, limit, opts.tags)
+    )
   )
 
   return results
@@ -178,6 +257,7 @@ export async function hybridSearch(
   opts: {
     limit?: number
     tables?: SearchTable[]
+    tags?: string[]
     mode?: 'hybrid' | 'bm25' | 'vector'
     embedConfig?: EmbedConfig
   } = {}
@@ -185,18 +265,19 @@ export async function hybridSearch(
   const limit = opts.limit ?? 20
   const tables = opts.tables ?? ['fragment', 'wiki', 'person']
   const mode = opts.mode ?? 'hybrid'
+  const tags = opts.tags
 
   const lists: SearchResult[][] = []
 
   if (mode === 'bm25' || mode === 'hybrid') {
-    lists.push(await bm25Search(database, query, { limit, tables }))
+    lists.push(await bm25Search(database, query, { limit, tables, tags }))
   }
 
   if (mode === 'vector' || mode === 'hybrid') {
     if (opts.embedConfig) {
       const vec = await embedText(query, opts.embedConfig)
       if (vec) {
-        lists.push(await vectorSearch(database, vec, { limit, tables }))
+        lists.push(await vectorSearch(database, vec, { limit, tables, tags }))
       }
     }
   }

--- a/core/src/routes/search.ts
+++ b/core/src/routes/search.ts
@@ -14,12 +14,13 @@ search.get('/', async (c) => {
     q: c.req.query('q'),
     limit: c.req.query('limit'),
     tables: c.req.query('tables'),
+    tags: c.req.query('tags'),
     mode: c.req.query('mode'),
   })
   if (!parsed.success)
     return c.json({ error: 'Validation failed', fields: parsed.error.flatten() }, 400)
 
-  const { q, limit, tables, mode } = parsed.data
+  const { q, limit, tables, tags, mode } = parsed.data
 
   let embedConfig: { apiKey: string; model: string } | undefined
   if (mode === 'hybrid' || mode === 'vector') {
@@ -31,7 +32,7 @@ search.get('/', async (c) => {
     }
   }
 
-  const results = await hybridSearch(db, q, { limit, tables, mode, embedConfig })
+  const results = await hybridSearch(db, q, { limit, tables, tags, mode, embedConfig })
 
   return c.json(searchResponseSchema.parse({ results }))
 })

--- a/core/src/schemas/search.schema.ts
+++ b/core/src/schemas/search.schema.ts
@@ -16,6 +16,20 @@ export const searchQuerySchema = z.object({
       return v.split(',').map((s) => s.trim()) as Array<'fragment' | 'wiki' | 'person'>
     })
     .pipe(z.array(searchTableEnum).min(1)),
+  // ?tags=foo,bar — UNION semantics (any-of). Mirrors `tables=`, which
+  // is also a union over the row discriminator. Ignored for wiki/person
+  // tables because those rows have no tags column.
+  tags: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (!v) return undefined
+      const parts = v
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+      return parts.length > 0 ? parts : undefined
+    }),
   mode: searchModeEnum.default('hybrid'),
 })
 


### PR DESCRIPTION
## Summary

Closes the search-recall cluster.

- **#249** — BM25 query terms were AND-joined → 0 hits whenever any token didn't match. Now OR-joined with sanitized \`to_tsquery\`. Tags woven into \`search_vector\` (weight C) across fragments, wikis, people. Triggers expanded to fire on content/tags edits.
- **#46** — \`?tags=\` filter added with UNION (any-of) semantics, mirroring the existing \`?tables=\` discriminator.

## UAT contract

| Issue | Plan / sections | Pre-fix | Post-fix |
|-------|-----------------|---------|----------|
| #249 | \`.uat/plans/32\` §1c, §2b/c, §3b/c, §4a-ii, §4b-ii, §5c | 12 P / 8 F | 20 P / 0 F |
| #46  | \`.uat/plans/11\` §2a/b (NEW) | 9 P / 1 F (negative side) | 10 P / 0 F |

Plus 8/8 new unit tests in \`core/src/lib/search.test.ts\`.

## Tag-filter semantics

UNION (any-of). \`?tags=foo,bar\` returns rows whose tags intersect {foo,bar}. Mirrors \`?tables=\` which is also union over the row discriminator. No-op for non-fragment tables (wikis/people have no tags column).

Implementation: \`EXISTS (SELECT FROM jsonb_array_elements_text(tags) WHERE elem IN (...))\` rather than \`tags ?| array[...]::text[]\` because postgres-js cannot bind a JS array to \`text[]\` cleanly.

## Sanitizer

\`buildOrTsQuery\` strips \`& | ! ( ) : * < @ ' " \\\`, splits on whitespace and hyphens (because \`to_tsquery\` treats \`machine-learning\` as \`<->\` phrase query, not standalone stems), lowercases, dedupes, OR-joins. Returns \`null\` for empty input → caller short-circuits.

## Migration

\`core/drizzle/migrations/0009_search_recall_tags_and_triggers.sql\` — idempotent (\`CREATE OR REPLACE\` / \`DROP TRIGGER IF EXISTS\`). Backfills via \`UPDATE table SET col = col\` to retrigger every existing row.

> ⚠️ **Conflicts with PR #266**: cluster 1 (\`fix/deletedat-sweep\`) also writes \`0009_*.sql\`. Whichever merges second renames its migration to 0010 — orchestrator handles at merge time.

## Files

- \`core/src/lib/search.ts\` (rewrite of query builder + sanitizer)
- \`core/src/lib/search.test.ts\` (NEW)
- \`core/src/routes/search.ts\`, \`core/src/schemas/search.schema.ts\`
- \`core/drizzle/migrations/0009_search_recall_tags_and_triggers.sql\` (NEW)
- \`.uat/plans/11-search.md\`, \`.uat/plans/32-search-recall.md\`

LOC: +526 / −17

## Open question

Plan 11 §2 sanity check passes pre-fix because no-filter search returns the tagged fragment too. The load-bearing pre-fix failure is the negative side (untagged fragment incorrectly returned with \`?tags=foo\`). If we want stricter pre-fix-only failure on the positive side too, the schema would need to reject unknown params (currently parses \`tags=\` silently into undefined). Defer to v2.

Closes #249
Closes #46