### PR TITLE
fix(stability): editor save scope + public HTML render + PUT /fragments content

### DIFF
--- a/.uat/plans/09-fragment-crud.md
+++ b/.uat/plans/09-fragment-crud.md
@@ -97,6 +97,30 @@ DEDUP=$(curl -s -w "\n%{http_code}" -X POST -b "$COOKIE_JAR" \
 DEDUP_HTTP=$(echo "$DEDUP" | tail -1)
 [ "$DEDUP_HTTP" = "200" ] && pass "dedup returns 200 (not 201)" || fail "dedup returned $DEDUP_HTTP (expected 200)"
 
+# 6. Content round-trip (#263) — PUT new content, GET, assert returned content matches.
+# Bug present: PUT /fragments/:id writes dedupHash but never updates the
+# `content` column, so the new body silently disappears. Frontend save
+# loops round-trip the same broken endpoint.
+# This step runs AFTER dedup (#5) because mutating content rotates the
+# fragment's dedupHash and would invalidate the dedup probe.
+NEW_FRAG_CONTENT="UAT-09 §6 new content body [$RUN_SUFFIX]"
+PUT_CONTENT_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X PUT -b "$COOKIE_JAR" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:3000" \
+  -d "$(jq -n --arg c "$NEW_FRAG_CONTENT" '{content:$c}')" \
+  "$SERVER_URL/fragments/$FRAG_ID")
+[ "$PUT_CONTENT_HTTP" = "200" ] && pass "PUT /fragments/:id with {content} → 200" \
+                                || fail "PUT content → HTTP $PUT_CONTENT_HTTP"
+
+ROUNDTRIP_CONTENT=$(curl -s -b "$COOKIE_JAR" -H "Origin: http://localhost:3000" \
+  "$SERVER_URL/fragments/$FRAG_ID" | jq -r '.content')
+if [ "$ROUNDTRIP_CONTENT" = "$NEW_FRAG_CONTENT" ]; then
+  pass "6. content round-trip — PUT then GET returns the new content"
+else
+  fail "6. content round-trip — got '${ROUNDTRIP_CONTENT:0:60}', want '${NEW_FRAG_CONTENT:0:60}' (#263 — PUT writes dedupHash, never content)"
+fi
+
 echo ""
 echo "$PASS passed, $FAIL failed"
 ```

--- a/.uat/plans/28-password-change-and-public-wiki.md
+++ b/.uat/plans/28-password-change-and-public-wiki.md
@@ -501,20 +501,23 @@ if [ -n "${UAT9B_KEY:-}" ] && [ "$UAT9B_KEY" != "null" ]; then
     fi
 
     # 9b-vii. NEGATIVE: escaped HTML tags ('&lt;p&gt;', '&lt;strong&gt;',
-    # '&lt;ul&gt;') must NOT appear in the page body. ReactMarkdown
-    # escapes raw HTML — finding any of these is a deterministic positive
-    # for #253. We restrict the search to the article body region by
-    # scoping to lines containing the marker substring chunks, then sweep
-    # the whole response as a coarse fallback.
+    # '&lt;ul&gt;') must NOT appear in the rendered article body. The page
+    # also serializes `wiki.content` into `<meta name="description">` and
+    # `og:description` (where HTML attribute encoding legitimately escapes
+    # `<` to `&lt;`); we scope the grep to the `<article>` block so meta
+    # encoding never hides a real bug or fakes one. ReactMarkdown escapes
+    # raw HTML — finding any of these inside the article is a deterministic
+    # positive for #253.
+    ARTICLE_BODY=$(grep -oE '<article[^>]*>.*</article>' /tmp/uat-28-9b-page.html | head -1)
     ESCAPED_LEAKS=0
     for tag in "&lt;p&gt;" "&lt;strong&gt;" "&lt;ul&gt;" "&lt;li&gt;"; do
-      if grep -qF "$tag" /tmp/uat-28-9b-page.html; then
+      if echo "$ARTICLE_BODY" | grep -qF "$tag"; then
         ESCAPED_LEAKS=$((ESCAPED_LEAKS+1))
-        fail "9b-vii. Escaped HTML tag found in public page: '$tag' — #253 still present (MarkdownContent rendered HTML body as literal text)"
+        fail "9b-vii. Escaped HTML tag found in <article>: '$tag' — #253 still present (MarkdownContent rendered HTML body as literal text)"
       fi
     done
     if [ "$ESCAPED_LEAKS" = "0" ]; then
-      pass "9b-vii. No escaped HTML tags ('&lt;p&gt;' etc.) in the public page — HTML body branch fired"
+      pass "9b-vii. No escaped HTML tags ('&lt;p&gt;' etc.) in the rendered <article> — HTML body branch fired"
     fi
 
     # 9b-viii. POSITIVE: the rendered DOM should contain real `<strong>`

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -219,7 +219,10 @@ fragmentsRouter.put('/:id', zValidator('json', updateFragmentBodySchema, validat
 
   const updates: Record<string, unknown> = { updatedAt: new Date() }
   if (body.title != null) updates.title = body.title
-  if (body.content != null) updates.dedupHash = computeContentHash(body.content)
+  if (body.content != null) {
+    updates.content = body.content
+    updates.dedupHash = computeContentHash(body.content)
+  }
   if (body.tags != null) updates.tags = body.tags
 
   const [fragment] = await db

--- a/wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx
+++ b/wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx
@@ -29,6 +29,15 @@ export function PublishedWikiArticle({ wiki }: { wiki: PublishedWikiData }) {
     { year: "numeric", month: "long", day: "numeric" },
   );
 
+  // Tiptap-saved bodies are HTML strings (start with `<`); markdown bodies
+  // are LLM-emitted prose. ReactMarkdown escapes raw HTML, so an HTML body
+  // routed through `<MarkdownContent>` renders as literal `&lt;p&gt;` text.
+  // Mirror the shell page's `isHtmlBody` branch: HTML body short-circuits to
+  // `dangerouslySetInnerHTML` (#253). The body is server-side authored and
+  // already trusted (Tiptap save endpoint or AI generation).
+  const isHtmlBody =
+    typeof wiki.content === "string" && wiki.content.trim().startsWith("<");
+
   return (
     <div className="published-page">
       <header className="published-header">
@@ -81,11 +90,19 @@ export function PublishedWikiArticle({ wiki }: { wiki: PublishedWikiData }) {
           />
         )}
 
-        <MarkdownContent
-          content={wiki.content}
-          refs={wiki.refs}
-          style={bodyStyle}
-        />
+        {isHtmlBody ? (
+          <div
+            className="wiki-richtext-rendered"
+            style={bodyStyle}
+            dangerouslySetInnerHTML={{ __html: wiki.content }}
+          />
+        ) : (
+          <MarkdownContent
+            content={wiki.content}
+            refs={wiki.refs}
+            style={bodyStyle}
+          />
+        )}
       </article>
 
       <footer className="published-footer">

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -442,11 +442,13 @@ export default function WikiDetailPage() {
           // rather than injected per-section (MVP option b in the
           // phase spec).
           <>
-            <HtmlWikiBody
-              html={wiki.wikiContent}
-              refs={refs}
-              style={bodyStyle}
-            />
+            <div data-wiki-body>
+              <HtmlWikiBody
+                html={wiki.wikiContent}
+                refs={refs}
+                style={bodyStyle}
+              />
+            </div>
             {sidecarSections.length > 0 && (
               <div
                 style={{
@@ -487,16 +489,18 @@ export default function WikiDetailPage() {
           // syntax and fenced blocks don't survive cleanly. Q9 default
           // option (b): hide the affordance on HTML-saved bodies. The
           // user is told to regenerate to re-enable it.
-          <SectionedMarkdownBody
-            content={wiki.wikiContent}
-            refs={refs}
-            sections={sidecarSections}
-            style={bodyStyle}
-            onEditSection={(sectionId) => {
-              setSectionSaveError(null);
-              setEditingSectionId(sectionId);
-            }}
-          />
+          <div data-wiki-body>
+            <SectionedMarkdownBody
+              content={wiki.wikiContent}
+              refs={refs}
+              sections={sidecarSections}
+              style={bodyStyle}
+              onEditSection={(sectionId) => {
+                setSectionSaveError(null);
+                setEditingSectionId(sectionId);
+              }}
+            />
+          </div>
         )
       )}
       <SectionEditor

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -666,15 +666,38 @@ export function WikiEntityArticle({
                               : "wiki-article-tab"
                           }
                           onClick={() => {
+                            // Scope the read-mode HTML capture to the `[data-wiki-body]`
+                            // subtree so sidebar chrome (Member Fragments,
+                            // Mentioned People, citations, etc.) never leaks
+                            // into the Tiptap draft and gets baked into
+                            // `wikis.content` on save (#241). Fall back to the
+                            // wrapper innerHTML for callers that haven't opted
+                            // in yet (e.g. the People page).
+                            //
+                            // Within the body, strip `[data-slot]` affordances
+                            // (the inline `[edit]` link rendered by
+                            // `WikiEditLink`, citation superscripts, etc.) —
+                            // they are interactive UI, not author content, and
+                            // round-tripping them turns live affordances into
+                            // inert markup permanently baked into the body.
+                            let bodyHtml = "";
+                            const bodyEl = readContentRef.current?.querySelector("[data-wiki-body]");
+                            if (bodyEl) {
+                              const clone = bodyEl.cloneNode(true) as HTMLElement;
+                              clone.querySelectorAll("[data-slot]").forEach((n) => n.remove());
+                              bodyHtml = clone.innerHTML;
+                            } else {
+                              bodyHtml = readContentRef.current?.innerHTML ?? "";
+                            }
                             if (tab === "Edit") {
                               enterEditMode({
-                                currentHtml: readContentRef.current?.innerHTML ?? "",
+                                currentHtml: bodyHtml,
                                 currentTitle: displayTitle,
                                 currentChipLabel: displayChipLabel,
                               });
                             } else if (tab === "View history") {
                               openHistory({
-                                currentHtml: readContentRef.current?.innerHTML ?? "",
+                                currentHtml: bodyHtml,
                                 currentTitle: displayTitle,
                                 currentChipLabel: displayChipLabel,
                               });


### PR DESCRIPTION
## Summary

Closes the editor + public-render integrity cluster — three save-loop bugs.

- **#241** — Tiptap save baked sidebar chrome into \`wikis.content\` because \`readContentRef\` captured the whole editor pane. Now scoped to \`[data-wiki-body]\` and clones-then-strips \`[data-slot]\` affordances before reading \`innerHTML\`.
- **#253** — Public published-wiki page rendered HTML-saved bodies as literal text via MarkdownContent. Now leading-\`<\` short-circuits to \`dangerouslySetInnerHTML\` (mirroring the shell page). Bodies are server-authored and trusted.
- **#263** — \`PUT /fragments/:id\` wrote \`dedupHash\` but never updated \`content\`. Round-trip broken. Fixed by writing \`updates.content = body.content\` alongside the dedupHash recompute.

## UAT contract

| Issue | Plan / sections | Pre-fix | Post-fix |
|-------|-----------------|---------|----------|
| #241 | \`.uat/plans/27\` §9 | 5 P / 1 F (\`wedit\` chrome leaked) | 6 P / 0 F |
| #253 | \`.uat/plans/28\` §9b (scope tightened to \`<article>\`) | 6 P / 4 F (escaped HTML in body) | 7 P / 0 F |
| #263 | \`.uat/plans/09\` §6 (NEW round-trip; reordered after dedup) | 10 P / 1 F (returned old content) | 11 P / 0 F |

## Files

- \`core/src/routes/fragments.ts\` — PUT content path
- \`wiki/src/app/(shell)/wiki/[id]/page.tsx\` — wrap body in \`<div data-wiki-body>\` on both HTML + markdown branches
- \`wiki/src/components/wiki/WikiEntityArticle.tsx\` — capture from \`[data-wiki-body]\`, clone-and-strip \`[data-slot]\`
- \`wiki/src/app/(public)/p/[nanoid]/PublishedWikiArticle.tsx\` — leading-\`<\` HTML branch
- \`.uat/plans/09\`, \`27\`, \`28\` amendments

LOC: +105 / −31

## Open follow-ups

- §9b-vii UAT narrows grep to \`<article>\`. If the page layout later moves the body outside \`<article>\`, the assertion will silently pass on a regressed page. A more durable selector (\`data-published-body\`) would future-proof — out of scope for stability.
- \`[data-slot]\` strip on enterEditMode prevents \`[edit]\` affordances from being baked. If new affordances are added inside the body without \`data-slot\`, they'll leak. Worth a lint rule or Storybook snapshot to enforce the convention — out of scope.

Closes #241
Closes #253
Closes #263