### PR TITLE
fix(stability): test discipline — regen mock, dedup index, swallow triage

### DIFF
--- a/.uat/plans/31-test-suite-fidelity.md
+++ b/.uat/plans/31-test-suite-fidelity.md
@@ -239,20 +239,37 @@ else
   fail "2b. regen.test.ts has zero references to the classify pre-step — fix may have patched the mock without staging responses for the new codepath"
 fi
 
-# ── 3. §3 — warn-and-continue surface (SKIP-with-log only) ───
+# ── 3. §3 — warn-and-continue surface (FAIL on masking instances) ───
 # Codebase-wide hunt for `} catch (...) { log.warn(...) }` blocks in
 # core/src/. Each is a candidate for the same false-green class as
 # #222: an exception is swallowed, a warn is logged, the test (if any)
 # sees green even though the codepath is broken.
 #
-# We DO NOT fail on count — every one of these may be intentional
-# best-effort behavior (audit emit, cleanup-on-error, etc.). The point
-# is to surface the surface for future hardening and to make any new
-# warn-and-continue addition grep-able later.
+# Issue #265 triaged each site into INTENTIONAL (best-effort by design;
+# failure is observable elsewhere) vs MASKING (failure is silent, no
+# downstream surface, and a passing test of the surrounding code does
+# NOT prove the swallowed branch works). The MASKING list FAILS this
+# plan. The INTENTIONAL list is logged as SKIP — surfaced for future
+# hardening but not load-bearing.
+#
+# When adding a new catch+log.warn, classify it explicitly here. If you
+# add a new MASKING site, the plan will go red; either re-classify with
+# justification or fix the underlying false-green vector.
+
+# Sites known MASKING (issue #265). file:approx-line — pattern grep is line-tolerant;
+# we match the warn-message substring so cosmetic line drift (imports added etc.)
+# doesn't false-fail this section.
+declare -A MASKING_SITES=(
+  ["routes/fragments.ts:enqueue regen after fragment acceptance"]="failed to enqueue regen after fragment acceptance"
+  ["routes/fragments.ts:enqueue regen after fragment rejection"]="failed to enqueue regen after fragment rejection"
+  ["queue/regen-worker.ts:batch regen enqueue"]="batch regen: failed to enqueue regen job"
+  ["lib/regen.ts:RELATED_TO edges"]="failed to create RELATED_TO edges"
+)
 
 echo ""
 echo "  ── §3 surface scan: catch + log.warn blocks in core/src/ ──"
 SURFACE_COUNT=0
+declare -A SITE_PRESENT=()
 while IFS= read -r line; do
   SURFACE_COUNT=$((SURFACE_COUNT+1))
   # Each line is "<file>-<lineno>-  } catch (<var>) {" — strip to file:line.
@@ -262,16 +279,29 @@ done < <(grep -rn -B2 'log\.warn' core/src/ --include='*.ts' 2>/dev/null | grep 
 
 echo "  ▸ surfaced $SURFACE_COUNT catch+log.warn block(s) in core/src/"
 
-# Of those, the regen.ts:381 swallow specifically — call it out by name
-# because it's the one #222 names and the one that masks the
-# classifyUnfiledFragments throw. If/when the test suite asserts on the
-# warn (or the swallow is replaced with a re-throw), this entry can move
-# from SKIP to PASS.
+# MASKING gate: each named-masking site must STILL EXIST (so we know
+# the named surface didn't quietly move) AND must be paired with an
+# observable contract elsewhere (test, retry, audit). Today none of
+# the four MASKING sites have such a contract — they FAIL this plan
+# and are tracked by per-site issues filed during #265 triage.
+echo ""
+echo "  ── §3 MASKING gate (issue #265 triage) ──"
+for label in "${!MASKING_SITES[@]}"; do
+  pat="${MASKING_SITES[$label]}"
+  HITS=$(grep -rn "$pat" core/src/ --include='*.ts' 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [ "${HITS:-0}" -ge 1 ]; then
+    fail "    masking-still-present: $label — $pat (file an issue against this site)"
+  else
+    pass "    masking-cleared: $label — warn-message no longer present (site fixed or rephrased)"
+  fi
+done
+
+# regen.ts:381 historical site — kept for delta-tracking with #222.
 REGEN_SWALLOW_PRESENT=$(grep -n 'unfiled fragment classification failed' core/src/lib/regen.ts | head -1 | cut -d: -f1)
 if [ -n "$REGEN_SWALLOW_PRESENT" ]; then
-  skip "  §3-named: core/src/lib/regen.ts:$REGEN_SWALLOW_PRESENT — the #222 swallow itself; consider re-throwing or asserting on the warn in tests"
+  fail "  §3-named: core/src/lib/regen.ts:$REGEN_SWALLOW_PRESENT — the #222 swallow itself is back; re-throw or assert on the warn in tests"
 else
-  pass "  §3-named: core/src/lib/regen.ts swallow log removed (re-throw or warn-asserted)"
+  pass "  §3-named: core/src/lib/regen.ts swallow log removed (#222 fix held)"
 fi
 
 # ── Cleanup — none required ──────────────────────────────────
@@ -296,7 +326,7 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
 | 1e | vitest summary reports tests passed (suite stays green under the fix) | vitest summary line |
 | 2a | `selectChain.where()` return in test file exposes a `.limit` key (mock realistic) | `core/src/lib/regen.test.ts:79-101` |
 | 2b | Test file references the classify pre-step (`classifyUnfiledFragments`, `unfiled`, etc.) — proves awareness, not just mechanical mock patch | `core/src/lib/regen.test.ts` |
-| 3 | Each `} catch { log.warn() }` block in `core/src/` is surfaced as a SKIP entry; the `regen.ts:381` swallow is named explicitly | `grep -rn -B2 'log\.warn' core/src/` |
+| 3 | Each `} catch { log.warn() }` block in `core/src/` is surfaced as a SKIP entry; the four MASKING sites named by issue #265 triage FAIL until each is fixed or its observable-contract issue closed; the `regen.ts:381` swallow is named explicitly | `grep -rn -B2 'log\.warn' core/src/`, issue #265 triage |
 | Cleanup | None — read-only plan | n/a |
 
 ---
@@ -322,14 +352,19 @@ echo "$PASS passed, $FAIL failed, $SKIP skipped"
   test file is restructured (e.g. extracted into a helper), §2a may
   false-fail; the operator should re-check by hand and update the awk
   block.
-- **§3 is intentionally a SKIP list, not a pass/fail.** Most catch +
-  log.warn blocks in `core/src/` are intentional best-effort handlers
-  (audit emit at `db/audit.ts:31-33`, regen-on-accept enqueue at
-  `routes/fragments.ts:298-300`, embedding-retry at
-  `queue/embedding-retry-worker.ts:40`, etc.). Failing the plan on
-  these would punish correct code. The artifact value is the list
-  itself — when adding a new test that asserts on a codepath behind
-  one of these handlers, check this list first.
+- **§3 — INTENTIONAL list is SKIP, MASKING list is FAIL.** Issue #265
+  triaged each catch+log.warn block in `core/src/`. Most are
+  intentional best-effort handlers (audit emit at `db/audit.ts:31-33`,
+  embedding-retry config-skip at `queue/embedding-retry-worker.ts:40`,
+  bootstrap pgvector at `bootstrap/ensure-pgvector.ts:30`, etc.) — the
+  failure is either observable elsewhere or the documented contract.
+  Four sites are MASKING and FAIL this plan: regen-enqueue on accept
+  (`routes/fragments.ts:298`), regen-enqueue on reject
+  (`routes/fragments.ts:359`), batch regen enqueue
+  (`queue/regen-worker.ts:134`), and RELATED_TO edge creation
+  (`lib/regen.ts:325`). Each has a tracking issue from #265 — when
+  the underlying false-green vector is closed (re-throw, retry queue,
+  or test asserting on the warn), the MASKING line flips to PASS.
 - **Why not just run all of `pnpm -C core test`?** Two reasons. First,
   `regen.test.ts` is the file #222 names — focusing on it keeps the
   signal strong and the run fast (~1s vs ~30s for the full suite).

--- a/core/src/db/dedup.ts
+++ b/core/src/db/dedup.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { eq, or, sql } from 'drizzle-orm'
+import { and, eq, isNull, or, sql } from 'drizzle-orm'
 import { processedJobs, entries, fragments } from './schema.js'
 import type { DB } from './client.js'
 
@@ -38,12 +38,19 @@ export async function findDuplicateEntry(db: DB, dedupHash: string) {
  * @summary Check if a fragment with identical content already exists.
  *
  * @returns The existing fragment row if duplicate, or null if content is new.
+ *
+ * @remarks
+ * The `deleted_at IS NULL` predicate is required for the planner to use the
+ * partial index `fragments_dedup_hash_idx` (defined `WHERE deleted_at IS NULL`
+ * in `schema.ts`). Without it the hot-path falls back to a Seq Scan even when
+ * the index exists. Soft-deleted fragments are not eligible duplicates anyway,
+ * so the predicate also matches the intended semantics.
  */
 export async function findDuplicateFragment(db: DB, dedupHash: string) {
   const [existing] = await db
     .select()
     .from(fragments)
-    .where(eq(fragments.dedupHash, dedupHash))
+    .where(and(eq(fragments.dedupHash, dedupHash), isNull(fragments.deletedAt)))
     .limit(1)
   return existing ?? null
 }

--- a/core/src/lib/regen.test.ts
+++ b/core/src/lib/regen.test.ts
@@ -77,7 +77,11 @@ vi.mock('../db/client.js', () => {
     return {
       from: () => ({
         where: (..._args: unknown[]) => {
-          // .where() is thenable — await it or chain .orderBy()/.groupBy()
+          // .where() is thenable — await it or chain .orderBy()/.groupBy()/.limit().
+          // The terminal `.limit()` is the hot path used by classifyUnfiledFragments
+          // (regen.ts:201-211 wiki lookup) and other fixed-row reads. Without it,
+          // every classify call throws TypeError and the regen.ts catch (issue #222)
+          // silently swallowed it, hiding a real test-fidelity bug.
           let deferred: Promise<unknown[]> | null = null
           const ensureDeferred = () => {
             if (!deferred) deferred = Promise.resolve(popResponse())
@@ -88,6 +92,7 @@ vi.mock('../db/client.js', () => {
             // biome-ignore lint/suspicious/noThenProperty: Drizzle thenable mock
             then: (onFulfilled: (v: unknown[]) => unknown, onRejected?: (r: unknown) => unknown) =>
               ensureDeferred().then(onFulfilled, onRejected),
+            limit: async () => popResponse(),
             orderBy: () => ({
               limit: async () => popResponse(),
             }),
@@ -203,14 +208,20 @@ function baseWiki(overrides: Record<string, unknown> = {}) {
 
 // Query order consumed by regenerateWiki when fragmentKeys=[], no [[slug]] refs
 // in wiki.content, no wiki.prompt override:
-//   1. wikis select (by lookupKey)
-//   2. edges select (FRAGMENT_IN_WIKI dst=wikiKey)  → empty → fragmentKeys=[]
+//   1. wikis select (top-level, by lookupKey) — outer regen wiki lookup
+//   2. classifyUnfiledFragments pre-step (regen.ts:201-211)
+//      → wikis select .where().limit(1) — pop returns [] so the
+//        classify path bails at the `if (!wiki) return ...` guard.
+//        This stage is REQUIRED (#222): if you under-stage by skipping it,
+//        the next consumer pops the wrong response and the test will fail
+//        with a meaningless mismatch.
+//   3. edges select (FRAGMENT_IN_WIKI dst=wikiKey)  → empty → fragmentKeys=[]
 //      [fragments select is SKIPPED because fragmentKeys.length === 0]
-//   3. edits select (orderBy+limit)
+//   4. edits select (orderBy+limit)
 //      [shared-fragment edges SKIPPED because fragmentKeys.length === 0]
 //      [slug-ref wikis SKIPPED because content has no [[slug]] matches]
 //      [linked wikis SKIPPED because cappedKeys.length === 0]
-//   4. wikiTypes select (only when wiki.prompt is falsy/whitespace)
+//   5. wikiTypes select (only when wiki.prompt is falsy/whitespace)
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
@@ -231,10 +242,11 @@ describe('regenerateWiki — override hierarchy integration', () => {
 
   it('uses disk default when wiki.prompt is empty and no userModified wiki_type row exists', async () => {
     stageDbResponses([
-      [baseWiki()], // 1. wikis select
-      [],           // 2. fragment edges → empty
-      [],           // 3. user edits → empty
-      [],           // 4. wikiTypes select → no userModified row
+      [baseWiki()], // 1. wikis select (outer)
+      [],           // 2. classifyUnfiledFragments wiki lookup → empty (early-returns)
+      [],           // 3. fragment edges → empty
+      [],           // 4. user edits → empty
+      [],           // 5. wikiTypes select → no userModified row
     ])
 
     const result = await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -251,9 +263,10 @@ describe('regenerateWiki — override hierarchy integration', () => {
 
   it('short-circuits type-level lookup and APPENDS wiki.prompt to system_message', async () => {
     stageDbResponses([
-      [baseWiki({ prompt: 'You are a pirate poet, yarrr.' })], // 1. wikis select
-      [],                                                        // 2. fragment edges
-      [],                                                        // 3. user edits
+      [baseWiki({ prompt: 'You are a pirate poet, yarrr.' })], // 1. wikis select (outer)
+      [],                                                        // 2. classifyUnfiledFragments wiki lookup
+      [],                                                        // 3. fragment edges
+      [],                                                        // 4. user edits
       // wikiTypes select is NEVER reached because wiki.prompt short-circuits.
     ])
 
@@ -298,10 +311,11 @@ input_variables:
 `
 
     stageDbResponses([
-      [baseWiki()],              // 1. wikis select
-      [],                        // 2. fragment edges
-      [],                        // 3. user edits
-      [{ prompt: customYaml }],  // 4. wikiTypes select → userModified row
+      [baseWiki()],              // 1. wikis select (outer)
+      [],                        // 2. classifyUnfiledFragments wiki lookup
+      [],                        // 3. fragment edges
+      [],                        // 4. user edits
+      [{ prompt: customYaml }],  // 5. wikiTypes select → userModified row
     ])
 
     await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -320,10 +334,11 @@ input_variables:
     const corrupt = 'not: : : valid yaml ][['
 
     stageDbResponses([
-      [baseWiki()],           // 1. wikis select
-      [],                     // 2. fragment edges
-      [],                     // 3. user edits
-      [{ prompt: corrupt }],  // 4. wikiTypes select → corrupt blob
+      [baseWiki()],           // 1. wikis select (outer)
+      [],                     // 2. classifyUnfiledFragments wiki lookup
+      [],                     // 3. fragment edges
+      [],                     // 4. user edits
+      [{ prompt: corrupt }],  // 5. wikiTypes select → corrupt blob
     ])
 
     await expect(
@@ -348,10 +363,11 @@ temperature: 0.3
 `
 
     stageDbResponses([
-      [baseWiki()],
-      [],
-      [],
-      [{ prompt: schemaInvalid }],
+      [baseWiki()],                // 1. wikis select (outer)
+      [],                          // 2. classifyUnfiledFragments wiki lookup
+      [],                          // 3. fragment edges
+      [],                          // 4. user edits
+      [{ prompt: schemaInvalid }], // 5. wikiTypes select → schema-invalid row
     ])
 
     await expect(
@@ -364,9 +380,11 @@ temperature: 0.3
 
   it('trims surrounding whitespace from wiki.prompt before appending to system_message', async () => {
     stageDbResponses([
-      [baseWiki({ prompt: 'pirate voice\n\n' })],
-      [],
-      [],
+      [baseWiki({ prompt: 'pirate voice\n\n' })], // 1. wikis select (outer)
+      [],                                          // 2. classifyUnfiledFragments wiki lookup
+      [],                                          // 3. fragment edges
+      [],                                          // 4. user edits
+      // wikiTypes select is NEVER reached because wiki.prompt short-circuits.
     ])
 
     await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -381,10 +399,11 @@ temperature: 0.3
     // wiki.prompt is non-empty string but .trim() is empty — the regen.ts guard
     // must treat this as "no override" and consult wikiTypes instead.
     stageDbResponses([
-      [baseWiki({ prompt: '   \n\t  ' })],
-      [],
-      [],
-      [], // wikiTypes select reached because whitespace-only prompt was ignored
+      [baseWiki({ prompt: '   \n\t  ' })], // 1. wikis select (outer)
+      [],                                   // 2. classifyUnfiledFragments wiki lookup
+      [],                                   // 3. fragment edges
+      [],                                   // 4. user edits
+      [], // 5. wikiTypes select reached because whitespace-only prompt was ignored
     ])
 
     await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -429,10 +448,11 @@ describe('regenerateWiki — sidecar persistence', () => {
     }
 
     stageDbResponses([
-      [baseWiki()], // 1. wikis select
-      [],           // 2. fragment edges → empty
-      [],           // 3. user edits → empty
-      [],           // 4. wikiTypes select → no userModified row
+      [baseWiki()], // 1. wikis select (outer)
+      [],           // 2. classifyUnfiledFragments wiki lookup
+      [],           // 3. fragment edges → empty
+      [],           // 4. user edits → empty
+      [],           // 5. wikiTypes select → no userModified row
     ])
 
     const result = await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -458,10 +478,11 @@ describe('regenerateWiki — sidecar persistence', () => {
     }
 
     stageDbResponses([
-      [baseWiki()], // 1. wikis select
-      [],           // 2. fragment edges
-      [],           // 3. user edits
-      [],           // 4. wikiTypes select
+      [baseWiki()], // 1. wikis select (outer)
+      [],           // 2. classifyUnfiledFragments wiki lookup
+      [],           // 3. fragment edges
+      [],           // 4. user edits
+      [],           // 5. wikiTypes select
     ])
 
     await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
@@ -489,10 +510,11 @@ describe('regenerateWiki — sidecar persistence', () => {
     })
 
     stageDbResponses([
-      [wikiWithExtras],
-      [],
-      [],
-      [],
+      [wikiWithExtras], // 1. wikis select (outer)
+      [],               // 2. classifyUnfiledFragments wiki lookup
+      [],               // 3. fragment edges
+      [],               // 4. user edits
+      [],               // 5. wikiTypes select
     ])
 
     await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -373,14 +373,14 @@ export async function regenerateWiki(
     return { content: '', fragmentCount: 0, hasEmbedding: false, timing: { classify: 0, gatherFragments: 0, llmCall: 0, embed: 0, total: 0 } }
   }
 
-  // Classify unfiled fragments into this wiki before gathering (mechanism 1)
+  // Classify unfiled fragments into this wiki before gathering (mechanism 1).
+  // Errors here are surfaced — the previous catch+log.warn at this site (issue
+  // #222) silently masked a structural test-mock bug for months. If classify
+  // legitimately needs to be best-effort, raise it as a separate decision and
+  // assert on the warn in tests; do not reintroduce the swallow.
   const tClassify0 = performance.now()
-  try {
-    const classifyResult = await classifyUnfiledFragments(database, wikiKey)
-    log.info({ wikiKey, linked: classifyResult.linked }, 'unfiled fragment classification completed')
-  } catch (err) {
-    log.warn({ wikiKey, err }, 'unfiled fragment classification failed — continuing with existing fragments')
-  }
+  const classifyResult = await classifyUnfiledFragments(database, wikiKey)
+  log.info({ wikiKey, linked: classifyResult.linked }, 'unfiled fragment classification completed')
   const classifyMs = performance.now() - tClassify0
 
   const previousContent = wiki.content


### PR DESCRIPTION
## Summary

Closes the test-discipline cluster.

- **#222** — \`regen.test.ts\` mock chain was missing \`.limit()\`, so \`classifyUnfiledFragments\` silently failed in tests via a \`catch + log.warn\` swallow at \`regen.ts:381\`. Repaired the mock chain to expose \`.limit()\`. **Removed** the swallow at \`regen.ts:381\` so future failures bubble.
- **#223** — \`findDuplicateFragment\` query was missing \`isNull(fragments.deletedAt)\` predicate; the partial dedup index (predicated on \`deleted_at IS NULL\`) was unused. Added the predicate; \`EXPLAIN\` now reports \`Index Scan using fragments_dedup_hash_idx\`.
- **#265** — Codebase-wide audit of 15 \`catch + log.warn\` swallow patterns. **Triage only** in this PR — bulk fixes deferred to avoid scope explosion. Plan 31 §3 amended from SKIP-list to FAIL-on-masking-instances. Per-site classification below.

## UAT contract

| Issue | Plan / sections | Pre-fix | Post-fix |
|-------|-----------------|---------|----------|
| #222  | \`.uat/plans/31\` §1+§2 | F (TypeError + 0 classify references) | P (10/10 vitest, 12 references) |
| #223  | \`.uat/plans/24\` §1d | F (Seq Scan, predicate missing) | P (Index Scan) |
| #265  | \`.uat/plans/31\` §3 (rewritten) | n/a (was SKIP) | 4 masking sites surfaced |

## #265 — 15-site triage

INTENTIONAL (11): \`routes/wikis.ts:202\`, \`routes/wiki-types.ts:140\`, \`mcp/handlers.ts:281\`, \`db/audit.ts:31\`, \`queue/embedding-retry-worker.ts:40\`, \`queue/worker.ts:450\`, \`lib/regen.ts:336\`, \`lib/regen.ts:586\`, \`bootstrap/ensure-pgvector.ts:30\`, \`bootstrap/seed-wiki-types.ts:80\`. Plus \`lib/regen.ts:381\` — **REMOVED** in this PR (#222).

MASKING (4) — orchestrator will file follow-up issues:
1. \`routes/fragments.ts:298\` — regen-enqueue failure after fragment acceptance silently swallowed
2. \`routes/fragments.ts:359\` — regen-enqueue failure after fragment rejection silently swallowed
3. \`queue/regen-worker.ts:134\` — batch regen swallows per-wiki enqueue failures, no surface or retry path
4. \`lib/regen.ts:325\` — RELATED_TO edge creation failures during classify silently swallowed

## Files

- \`core/src/lib/regen.ts\` — removed swallow at :381
- \`core/src/lib/regen.test.ts\` — mock chain repair
- \`core/src/db/dedup.ts\` — added \`isNull(fragments.deletedAt)\`
- \`.uat/plans/31-test-suite-fidelity.md\` — §3 rewritten

LOC: +137 / −73

## Open follow-up

\`regen.ts:381\` swallow removal: callers (route handler + worker) now need to handle the bubbled error. The worker already wraps the call in its own try/catch and the route handler returns 500 on throw — but a downstream-plan re-run that exercises malformed \`wikis\` rows could surface a behavior delta. Worth a follow-up scan if any plan goes red post-merge.

Closes #222
Closes #223
Closes #265