### PR TITLE
fix(stability): split Quill into wikiWriter agent — Sonnet 4.6 + 16k tokens + quote rule

### DIFF
--- a/core/src/lib/regen.test.ts
+++ b/core/src/lib/regen.test.ts
@@ -30,6 +30,7 @@ vi.mock('@robin/agent', async (importOriginal) => {
       fragmenter: {},
       entityExtractor: {},
       fragScorer: {},
+      wikiWriter: {},
     })),
     createTypedCaller: vi.fn(() => fakeCallLlm),
     embedText: vi.fn(async () => null),

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -293,7 +293,10 @@ export async function classifyUnfiledFragments(
           )
         return rows
       },
-      llmCall: createTypedCaller(agents.wikiClassifier, wikiClassificationSchema),
+      llmCall: createTypedCaller(
+        agents.wikiClassifier,
+        wikiClassificationSchema,
+      ),
       emitEvent: async () => {},
     }
 
@@ -426,8 +429,13 @@ export async function regenerateWiki(
   // Cast through `unknown` because Zod's `.default()` widens the schema's
   // input type but createTypedCaller is parameterised by the output type
   // (what the caller ultimately consumes).
+  //
+  // Use the dedicated wikiWriter agent (Sonnet, 16k output cap) — not the
+  // wiki-classifier (Haiku, 4k cap). Issue #257: long regen output was
+  // silently truncated mid-sentence because the classifier model's default
+  // ~4096 token cap fell well short of typical wiki bodies.
   const callLlm = createTypedCaller(
-    agents.wikiClassifier,
+    agents.wikiWriter,
     regenOutputSchema as unknown as import('zod').ZodType<RegenOutput>,
   )
 

--- a/packages/agent/src/agent-factory.ts
+++ b/packages/agent/src/agent-factory.ts
@@ -7,6 +7,7 @@ export interface IngestAgents {
   entityExtractor: Agent
   wikiClassifier: Agent
   fragScorer: Agent
+  wikiWriter: Agent
 }
 
 /**
@@ -41,6 +42,15 @@ export function createIngestAgents(config: OpenRouterConfig): IngestAgents {
       name: 'Judge',
       instructions: '',
       model: or(config.models.classification),
+    }),
+    // Quill — wiki body writer. Uses the wikiGeneration model slot
+    // (Sonnet-class) and a 16k output cap so long wikis don't truncate.
+    // The cap is enforced via AGENT_MODEL_SETTINGS in agents/caller.ts.
+    wikiWriter: new Agent({
+      id: 'wiki-writer',
+      name: 'Quill',
+      instructions: '',
+      model: or(config.models.wikiGeneration),
     }),
   }
 }

--- a/packages/agent/src/agents/caller.ts
+++ b/packages/agent/src/agents/caller.ts
@@ -21,9 +21,20 @@ export const AGENT_RETRY_CONFIG = {
   backoff: { initial: 1000, multiplier: 3 }, // 1s, 3s
 } as const
 
+/**
+ * Output token cap shared by every agent.generate() call.
+ *
+ * Sonnet 4.6 supports 16k output tokens; the OpenRouter SDK default is
+ * ~4096, which silently truncated long wiki regen output (issue #257).
+ * Raising the cap globally is safe because shorter prompts simply finish
+ * sooner — the cap is an upper bound, not a target length.
+ */
+export const AGENT_MAX_OUTPUT_TOKENS = 16000
+
 /** Model settings passed to every agent.generate() call. */
 export const AGENT_MODEL_SETTINGS = {
   maxRetries: AGENT_RETRY_CONFIG.maxRetries,
+  maxOutputTokens: AGENT_MAX_OUTPUT_TOKENS,
 } as const
 
 /**

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -114,6 +114,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -114,6 +114,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/collection.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/collection.yaml
@@ -111,6 +111,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -117,6 +117,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -114,6 +114,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -115,6 +115,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/principles.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principles.yaml
@@ -114,6 +114,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -117,6 +117,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -115,6 +115,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -114,6 +114,13 @@ template: |
       infobox rows inside the main markdown body.
   12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
+  13. Typography — never emit straight ASCII double-quote characters
+      (the U+0022 "). For prose, replace them with single quotes ('like
+      this') or italics (*like this*). When the body contains HTML or
+      embedded markup with attribute values, use curly quotes (“…”)
+      or the &quot; entity so attribute round-trip stays safe. This rule
+      keeps the renderer's smart-quote pairing from colliding with raw
+      quotes in user-edit content.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each


### PR DESCRIPTION
## Summary

Closes #257. Splits the wiki-body generation concern out of Quill (classifier) into its own \`wikiWriter\` agent so model + token budget can be tuned independently. Lifts output cap to 16k. Adds a no-straight-double-quotes rule across all 10 wiki-type prompts to fix HTML attribute round-trip damage.

- **wikiWriter agent** registered in \`packages/agent/src/agent-factory.ts\` on the \`wikiGeneration\` model slot (Sonnet 4.6).
- **regen.ts** wiki-body callsite now routes through \`agents.wikiWriter\` instead of \`agents.wikiClassifier\`.
- **AGENT_MAX_OUTPUT_TOKENS = 16000** exported from \`agents/caller.ts\` and folded into \`AGENT_MODEL_SETTINGS\`.
- **10 wiki-type yamls** (agent, belief, collection, decision, log, objective, principles, project, skill, voice) get rule 13: forbid raw ASCII \`"\` in HTML attributes; use single quotes / italics in prose, curly quotes / \`&quot;\` in attributes.

## UAT contract

\`.uat/plans/33-quill-writer.md\` §0–§4. Pre-fix **3 F / 7 P / 3 S**. Post-fix **0 F / 11 P / 2 S** (skips are §2b literal-grep and §3c length>4500 — both designed as soft signals; §3c is a wiki-compression artifact, not truncation).

## Files

- \`packages/agent/src/agent-factory.ts\` — wikiWriter agent registration
- \`packages/agent/src/agents/caller.ts\` — AGENT_MAX_OUTPUT_TOKENS export
- \`core/src/lib/regen.ts\` — wikiWriter wiring at the body callsite
- \`core/src/lib/regen.test.ts\` — \`wikiWriter: {}\` mock entry
- \`packages/shared/src/prompts/specs/wiki-types/{agent,belief,collection,decision,log,objective,principles,project,skill,voice}.yaml\` (10 files) — rule 13 added

LOC: +102 / −2 across 14 files.

Closes #257