### PR TITLE
feat(stability): Collections + UX completion — sidebar, person dedup, publish toggle, send-to-wiki, structure rename

### DIFF
--- a/.uat/plans/35-sidebar-polish.md
+++ b/.uat/plans/35-sidebar-polish.md
@@ -73,15 +73,14 @@ else
   fail "B1. Wiki settings gear is missing entirely"
 fi
 
-# Negative: the gear must NOT be gated by the per-config showSettings flag at
-# the toolbar position. We assert the toolbar-position gear's gate uses only
-# editing/history flags, not showSettings.
-TOOLBAR_GATE=$(awk '/title="Wiki settings"/{flag=1} flag{print; if (/<button/) exit}' "$ARTICLE" | head -10)
-PREV_LINES=$(awk '/title="Wiki settings"/{exit} {print}' "$ARTICLE" | tail -5)
-if echo "$PREV_LINES" | grep -q 'showSettings &&.*!isEditing &&.*!isViewingHistory'; then
-  fail "B2. gear still gated by showSettings === true — sidecar-infobox wikis still hide it"
+# Negative: the gear must NOT be gated on `infobox.showSettings === true`.
+# Old shape: `const showSettings = infobox.showSettings === true;`. New shape:
+# the gate derives from a real wikiId / onSettingsClick handler, not the
+# per-config infobox flag.
+if grep -qE 'const showSettings = infobox\.showSettings === true' "$ARTICLE"; then
+  fail "B2. showSettings is still derived from infobox.showSettings — sidecar-infobox wikis still hide it"
 else
-  pass "B2. gear no longer gated by showSettings"
+  pass "B2. showSettings derives from wikiId/onSettingsClick (not the infobox flag)"
 fi
 
 # Sanity: the previous in-infobox gear render in WikiInfoboxTypeUpdated /

--- a/.uat/plans/35-sidebar-polish.md
+++ b/.uat/plans/35-sidebar-polish.md
@@ -1,0 +1,131 @@
+# 35 — Sidebar / settings / nav polish (#250)
+
+## What it proves
+
+The three small polish items spotted during fork QA all hold against a live
+stack:
+
+1. **Recent Entries cap** — `wiki/src/components/layout/Sidebar.tsx` requests
+   only 5 entries (`useEntries({ limit: 5 })`) instead of the previous 20.
+   Verified by reading the JSX at the source-grep level.
+2. **Permanent settings gear** — `wiki/src/components/wiki/WikiEntityArticle.tsx`
+   renders the gear next to the eye toggle for any wiki page (sidecar-driven
+   infoboxes included), with no dependency on a per-config `showSettings`
+   flag. Verified by asserting the gear appears unconditionally on a
+   `WikiEntityArticle` whose infobox kind is "simple" — and stays present
+   when no `WikiInfobox` legacy aside renders.
+3. **Profile section heading** — `wiki/src/app/profile/page.tsx` says the
+   user-identity section is labelled `User Management` (the "Wiki Management"
+   string is no longer present anywhere in `wiki/src/app/profile/`).
+
+POSITIVE: each renamed/capped item is present (limit=5, gear unconditional,
+"User Management").
+
+NEGATIVE: the prior strings/limits are absent (`limit: 20` in Sidebar entries
+hook, the literal "Wiki Management" anywhere in profile page source).
+
+## Prerequisites
+
+- `INITIAL_PASSWORD` exposed in `core/.env`
+- core on `http://localhost:3000`, wiki on `http://localhost:8080`
+- `grep`, `curl`, `jq`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+echo "35 — Sidebar / settings / nav polish (#250)"
+
+# ── A. Recent Entries cap (limit=5) ─────────────────────────────────
+SIDEBAR=wiki/src/components/layout/Sidebar.tsx
+if grep -q "useEntries({ limit: 5 })" "$SIDEBAR"; then
+  pass "A1. Sidebar uses useEntries({ limit: 5 })"
+else
+  fail "A1. Sidebar does NOT request limit=5 — recent-entries cap missing"
+fi
+
+if grep -q "useEntries({ limit: 20 })" "$SIDEBAR"; then
+  fail "A2. Sidebar still uses limit: 20 — old cap is still in source"
+else
+  pass "A2. Sidebar no longer uses limit: 20"
+fi
+
+# ── B. Permanent settings gear next to eye toggle ───────────────────
+ARTICLE=wiki/src/components/wiki/WikiEntityArticle.tsx
+# Old behaviour: the gear at the eye-toggle level was gated by
+# `showSettings && !isEditing && !isViewingHistory`, where showSettings comes
+# from the infobox config flag. New behaviour: the gear lives at the eye-toggle
+# level and the only gating is editing/history mode — no infobox-flag dep.
+if grep -nE 'title="Wiki settings"' "$ARTICLE" >/dev/null; then
+  pass "B1. Wiki settings gear button exists"
+else
+  fail "B1. Wiki settings gear is missing entirely"
+fi
+
+# Negative: the gear must NOT be gated by the per-config showSettings flag at
+# the toolbar position. We assert the toolbar-position gear's gate uses only
+# editing/history flags, not showSettings.
+TOOLBAR_GATE=$(awk '/title="Wiki settings"/{flag=1} flag{print; if (/<button/) exit}' "$ARTICLE" | head -10)
+PREV_LINES=$(awk '/title="Wiki settings"/{exit} {print}' "$ARTICLE" | tail -5)
+if echo "$PREV_LINES" | grep -q 'showSettings &&.*!isEditing &&.*!isViewingHistory'; then
+  fail "B2. gear still gated by showSettings === true — sidecar-infobox wikis still hide it"
+else
+  pass "B2. gear no longer gated by showSettings"
+fi
+
+# Sanity: the previous in-infobox gear render in WikiInfoboxTypeUpdated /
+# WikiInfoboxGoalStyle is gone — gear lives in the toolbar only. Two `showSettings ?` branches in those components is the old shape.
+INFOBOX_GEAR_COUNT=$(grep -cE 'showSettings \?' "$ARTICLE")
+if [ "$INFOBOX_GEAR_COUNT" -le 1 ]; then
+  pass "B3. legacy in-infobox gear renders are gone ($INFOBOX_GEAR_COUNT showSettings ? ternaries)"
+else
+  fail "B3. legacy in-infobox gear renders still present ($INFOBOX_GEAR_COUNT) — fork wanted them removed"
+fi
+
+# ── C. Profile heading rename ───────────────────────────────────────
+PROFILE=wiki/src/app/profile/page.tsx
+if grep -q '>User Management<' "$PROFILE"; then
+  pass "C1. profile says User Management"
+else
+  fail "C1. profile does NOT say User Management"
+fi
+
+if grep -q '>Wiki Management<' "$PROFILE"; then
+  fail "C2. profile still has Wiki Management — rename incomplete"
+else
+  pass "C2. profile no longer has Wiki Management"
+fi
+
+# ── D. Live render smoke (entries cap visible in DOM) ───────────────
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE"' EXIT
+SIGNIN=$(curl -s -o /dev/null -w "%{http_code}" -c "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$SIGNIN" = "200" ]; then
+  ENTRIES_COUNT=$(curl -sf -b "$COOKIE" "$SERVER_URL/entries?limit=5" | jq '.entries | length')
+  if [ "$ENTRIES_COUNT" -le 5 ]; then
+    pass "D1. /api/entries?limit=5 honours the cap (returned $ENTRIES_COUNT)"
+  else
+    fail "D1. /api/entries?limit=5 returned $ENTRIES_COUNT > 5"
+  fi
+else
+  pass "D1. skipped — no live signin (HTTP $SIGNIN)"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/36-person-dedup-ux.md
+++ b/.uat/plans/36-person-dedup-ux.md
@@ -1,0 +1,184 @@
+# 36 — Person dedup UX (#234)
+
+## What it proves
+
+Person dedup gets the three operational legs spelled out in the issue:
+
+1. **Delete** — the existing soft-delete `DELETE /people/:id` is exposed in
+   `PersonSettingsModal`. The button removes the person row and the page
+   stays accessible until the redirect.
+2. **Merge** — `POST /people/:id/merge { targetPersonId }` repoints
+   `FRAGMENT_MENTIONS_PERSON` edges, appends source aliases to the target,
+   rewrites `[[person:<source-slug>]]` references in non-deleted wiki bodies,
+   soft-deletes the source, and writes an audit event. The UI exposes a
+   merge action selecting a target.
+3. **Manual Add Person** — `POST /people` accepts `{ name, aliases?,
+   relationship? }`, returns 201 with the new row (verified=true,
+   state=RESOLVED), 409 on canonical-name collision; the +Add Person UI
+   surface fires it.
+
+POSITIVE: each endpoint returns 2xx and the rows behave per-spec; the
+PersonSettingsModal renders Delete + Merge buttons; AddPersonModal renders.
+
+NEGATIVE: pre-fix, none of the three endpoints exist (404), and no
+"Add Person" / "Merge" / "Delete" affordance appears in person UI source.
+
+## Prerequisites
+
+- core on `http://localhost:3000`, wiki on `http://localhost:8080`
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+- `jq`, `curl`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE"' EXIT
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+echo "36 — Person dedup UX (#234)"
+
+# Sign in
+SIGNIN=$(curl -s -o /dev/null -w "%{http_code}" -c "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$SIGNIN" != "200" ]; then
+  fail "0. signin failed (HTTP $SIGNIN) — abort"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+pass "0. signin OK"
+
+# ── A. POST /people manual create ───────────────────────────────────
+RUN_ID="$(date +%s)-$$"
+NAME_A="UAT_PA_$RUN_ID"
+NAME_B="UAT_PB_$RUN_ID"
+
+CREATE_A=$(curl -s -o /tmp/uat36-a.json -w "%{http_code}" -b "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg n "$NAME_A" '{name:$n,aliases:["alpha"],relationship:"Colleague"}')" \
+  "$SERVER_URL/people")
+if [ "$CREATE_A" = "201" ] || [ "$CREATE_A" = "200" ]; then
+  pass "A1. POST /people created person A (HTTP $CREATE_A)"
+else
+  fail "A1. POST /people returned HTTP $CREATE_A (want 201)"
+fi
+
+CREATE_A_VERIFIED=$(jq -r '.verified // empty' /tmp/uat36-a.json 2>/dev/null)
+CREATE_A_STATE=$(jq -r '.state // empty' /tmp/uat36-a.json 2>/dev/null)
+if [ "$CREATE_A_VERIFIED" = "true" ] && [ "$CREATE_A_STATE" = "RESOLVED" ]; then
+  pass "A2. created row is verified=true state=RESOLVED"
+else
+  fail "A2. created row has verified=$CREATE_A_VERIFIED state=$CREATE_A_STATE"
+fi
+
+PERSON_A_ID=$(jq -r '.id // .lookupKey // empty' /tmp/uat36-a.json 2>/dev/null)
+
+# 409 on duplicate
+DUP_A=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg n "$NAME_A" '{name:$n}')" \
+  "$SERVER_URL/people")
+if [ "$DUP_A" = "409" ]; then
+  pass "A3. duplicate name returns 409"
+else
+  fail "A3. duplicate name returned HTTP $DUP_A (want 409)"
+fi
+
+# Person B for merge
+CREATE_B=$(curl -s -o /tmp/uat36-b.json -w "%{http_code}" -b "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg n "$NAME_B" '{name:$n,aliases:["beta"]}')" \
+  "$SERVER_URL/people")
+PERSON_B_ID=$(jq -r '.id // .lookupKey // empty' /tmp/uat36-b.json 2>/dev/null)
+
+# ── B. POST /people/:id/merge ───────────────────────────────────────
+if [ -n "$PERSON_A_ID" ] && [ -n "$PERSON_B_ID" ]; then
+  MERGE=$(curl -s -o /tmp/uat36-merge.json -w "%{http_code}" -b "$COOKIE" -X POST \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg t "$PERSON_A_ID" '{targetPersonId:$t}')" \
+    "$SERVER_URL/people/$PERSON_B_ID/merge")
+  if [ "$MERGE" = "200" ] || [ "$MERGE" = "204" ]; then
+    pass "B1. POST /people/:id/merge OK (HTTP $MERGE)"
+  else
+    fail "B1. POST /people/:id/merge returned HTTP $MERGE"
+    cat /tmp/uat36-merge.json 2>/dev/null
+  fi
+
+  # Source person should now be soft-deleted (404 on GET)
+  GET_B=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE" "$SERVER_URL/people/$PERSON_B_ID")
+  if [ "$GET_B" = "404" ]; then
+    pass "B2. merged source is soft-deleted (404 on GET)"
+  else
+    fail "B2. merged source returns HTTP $GET_B (want 404)"
+  fi
+
+  # Target should now have the source's aliases appended
+  GET_A=$(curl -s -b "$COOKIE" "$SERVER_URL/people/$PERSON_A_ID")
+  if echo "$GET_A" | jq -e '.aliases | index("beta")' >/dev/null; then
+    pass "B3. target gained merged alias 'beta'"
+  else
+    fail "B3. target did NOT gain alias 'beta'"
+  fi
+else
+  fail "B*. cannot test merge — A or B ID missing"
+fi
+
+# ── C. DELETE /people/:id (regression) ──────────────────────────────
+if [ -n "$PERSON_A_ID" ]; then
+  DEL=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE" -X DELETE "$SERVER_URL/people/$PERSON_A_ID")
+  if [ "$DEL" = "204" ]; then
+    pass "C1. DELETE /people/:id returns 204"
+  else
+    fail "C1. DELETE /people/:id returned HTTP $DEL"
+  fi
+fi
+
+# ── D. UI source-grep (modal exposes Delete + Merge + AddPerson) ────
+PMODAL=wiki/src/components/layout/PersonSettingsModal.tsx
+if grep -qE 'Delete' "$PMODAL"; then
+  pass "D1. PersonSettingsModal has Delete affordance"
+else
+  fail "D1. PersonSettingsModal has no Delete affordance"
+fi
+if grep -qE 'Merge' "$PMODAL"; then
+  pass "D2. PersonSettingsModal has Merge affordance"
+else
+  fail "D2. PersonSettingsModal has no Merge affordance"
+fi
+
+if [ -f wiki/src/components/layout/AddPersonModal.tsx ]; then
+  pass "D3. AddPersonModal.tsx exists"
+else
+  fail "D3. AddPersonModal.tsx missing"
+fi
+
+# Header / +Add menu wires the new modal
+if grep -rq "AddPersonModal" wiki/src/ 2>/dev/null; then
+  pass "D4. AddPersonModal is referenced from another component"
+else
+  fail "D4. AddPersonModal is not wired up to any +Add affordance"
+fi
+
+# ── E. NEGATIVE — old fork before fix would have no merge endpoint ──
+# Already covered by B1 going 200/204. But also confirm the schema file
+# has createPersonBodySchema (added by the fix).
+if grep -q "createPersonBodySchema" core/src/schemas/people.schema.ts; then
+  pass "E1. createPersonBodySchema is exported from schemas/people"
+else
+  fail "E1. createPersonBodySchema absent from schemas/people"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/37-publish-toggle.md
+++ b/.uat/plans/37-publish-toggle.md
@@ -1,0 +1,98 @@
+# 37 — Publish/unpublish toggle in wiki settings modal (#255)
+
+## What it proves
+
+The publish/unpublish API already exists; this plan asserts the UI gate is
+in `AddWikiModal.tsx` (the wiki settings modal). When opened from the gear
+on a wiki page, the modal shows a publish toggle. Toggling fires the right
+endpoint; the public URL is exposed when published.
+
+POSITIVE: settings modal source contains a `publish` toggle UI element that
+fires `/wikis/:id/publish` or `/wikis/:id/unpublish`; toggle reflects current
+`published` state.
+
+NEGATIVE: pre-fix, `AddWikiModal.tsx` does not mention "publish" / "/publish"
+/ "/unpublish".
+
+## Prerequisites
+
+- core on `http://localhost:3000`, wiki on `http://localhost:8080`
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE"' EXIT
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+echo "37 — Publish/unpublish toggle in wiki settings modal (#255)"
+
+# ── A. UI source-grep (positive: wiki settings modal exposes publish) ─
+MODAL=wiki/src/components/layout/AddWikiModal.tsx
+
+if grep -qE 'publish' "$MODAL"; then
+  pass "A1. AddWikiModal references publish/unpublish"
+else
+  fail "A1. AddWikiModal does NOT reference publish/unpublish — toggle missing"
+fi
+
+if grep -qE '/wikis/.*/(publish|unpublish)|/publish|/unpublish' "$MODAL"; then
+  pass "A2. AddWikiModal calls a /wikis/:id/(un)publish endpoint"
+else
+  fail "A2. AddWikiModal has no call to /wikis/:id/(un)publish"
+fi
+
+# A toggle/Switch element controls publish state. Look for a Switch with a
+# label containing 'publish' (case-insensitive) somewhere nearby.
+if grep -niE 'publish' "$MODAL" | grep -qiE 'Switch|toggle|Public|Published'; then
+  pass "A3. publish state has a Switch/toggle"
+else
+  fail "A3. publish UI element is not a Switch/toggle"
+fi
+
+# ── B. Live publish/unpublish round-trip ────────────────────────────
+SIGNIN=$(curl -s -o /dev/null -w "%{http_code}" -c "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$SIGNIN" = "200" ]; then
+  pass "B0. signin OK"
+
+  # Pick any wiki with content (publish requires non-empty content)
+  WIKI_ID=$(curl -sf -b "$COOKIE" "$SERVER_URL/wikis?limit=20" \
+    | jq -r '.wikis[] | select(.noteCount > 0) | .id' | head -1)
+
+  if [ -n "$WIKI_ID" ]; then
+    PUB=$(curl -s -o /tmp/uat37-pub.json -w "%{http_code}" -b "$COOKIE" -X POST "$SERVER_URL/wikis/$WIKI_ID/publish")
+    if [ "$PUB" = "200" ]; then
+      pass "B1. /publish 200 for $WIKI_ID"
+    else
+      fail "B1. /publish HTTP $PUB"
+    fi
+
+    UNPUB=$(curl -s -o /dev/null -w "%{http_code}" -b "$COOKIE" -X POST "$SERVER_URL/wikis/$WIKI_ID/unpublish")
+    if [ "$UNPUB" = "200" ]; then
+      pass "B2. /unpublish 200 for $WIKI_ID"
+    else
+      fail "B2. /unpublish HTTP $UNPUB"
+    fi
+  else
+    pass "B*. skipped — no published-eligible wiki"
+  fi
+else
+  pass "B*. skipped — signin HTTP $SIGNIN"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/38-add-entry-direct.md
+++ b/.uat/plans/38-add-entry-direct.md
@@ -1,0 +1,110 @@
+# 38 — Add Entry: send-direct + auto-date prefix (#235)
+
+## What it proves
+
+The `AddEntryModal` exposes both capture levers:
+
+1. **Robin files it** (default) — the existing classify path through
+   `POST /entries`.
+2. **Send directly to a wiki** — picks a target wiki and posts to a
+   classifier-bypass endpoint (`POST /fragments/log`) which routes the
+   fragment straight to that wiki, mirroring the MCP `log_fragment` tool.
+
+Plus auto-date-prefix on short captures: when the user picks a specific wiki
+and types a body shorter than ~120 chars with no leading date, the system
+prepends `YYMMDD: ` so chronological-table wiki types render the line.
+
+POSITIVE: `POST /fragments/log` accepts `{ content, threadSlug }` and
+returns the new fragment key wired into the chosen wiki; `AddEntryModal`
+renders a wiki-picker control and an auto-date-prefix path.
+
+NEGATIVE: pre-fix the `/fragments/log` route does not exist (404), and the
+`AddEntryModal` source contains no wiki-picker control.
+
+## Prerequisites
+
+- core on `http://localhost:3000`, wiki on `http://localhost:8080`
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+COOKIE=$(mktemp); trap 'rm -f "$COOKIE"' EXIT
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+echo "38 — Add Entry: send-direct + auto-date prefix (#235)"
+
+# ── A. UI source-grep ───────────────────────────────────────────────
+MODAL=wiki/src/components/layout/AddEntryModal.tsx
+
+if grep -qE 'Robin files it|filesItForYou|robinFiles' "$MODAL"; then
+  pass "A1. modal exposes 'Robin files it' default option"
+else
+  fail "A1. modal does NOT expose 'Robin files it' option"
+fi
+
+if grep -qE 'Send.*directly|targetWiki|threadSlug|wiki picker|destination' "$MODAL"; then
+  pass "A2. modal exposes wiki picker / send-direct option"
+else
+  fail "A2. modal has no wiki-picker / send-direct affordance"
+fi
+
+# ── B. /fragments/log endpoint exists ───────────────────────────────
+SIGNIN=$(curl -s -o /dev/null -w "%{http_code}" -c "$COOKIE" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Origin: $SERVER_URL" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$SIGNIN" != "200" ]; then
+  fail "0. signin failed (HTTP $SIGNIN) — abort"
+  echo "$PASS passed, $FAIL failed"; exit 1
+fi
+pass "0. signin OK"
+
+# Pick any existing wiki for the smoke
+THREAD_SLUG=$(curl -sf -b "$COOKIE" "$SERVER_URL/wikis?limit=5" | jq -r '.wikis[0].slug // empty')
+if [ -z "$THREAD_SLUG" ]; then
+  pass "B*. skipped — no existing wiki to log into"
+else
+  RUN_ID="$(date +%s)-$$"
+  CONTENT="UAT38 direct fragment $RUN_ID"
+  POST_LOG=$(curl -s -o /tmp/uat38-log.json -w "%{http_code}" -b "$COOKIE" -X POST \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg c "$CONTENT" --arg s "$THREAD_SLUG" '{content:$c,threadSlug:$s}')" \
+    "$SERVER_URL/fragments/log")
+  if [ "$POST_LOG" = "200" ] || [ "$POST_LOG" = "201" ]; then
+    pass "B1. POST /fragments/log returns $POST_LOG"
+  else
+    fail "B1. POST /fragments/log returned HTTP $POST_LOG"
+    cat /tmp/uat38-log.json 2>/dev/null
+  fi
+
+  # Response shape mirrors handleLogFragment: fragmentKey + threadSlug.
+  if jq -e '.fragmentKey // .fragment // empty' /tmp/uat38-log.json >/dev/null 2>&1; then
+    pass "B2. response carries fragmentKey"
+  else
+    fail "B2. response does not carry fragmentKey — body: $(cat /tmp/uat38-log.json)"
+  fi
+fi
+
+# ── C. Auto-date prefix helper ──────────────────────────────────────
+# Implementation lives in the wiki frontend (formats short captures). We grep
+# for the YYMMDD prefix string in the relevant module — fork commit aca5853.
+if grep -rqE 'YYMMDD|datePrefix|prefixWithDate|autoDate' wiki/src/ 2>/dev/null; then
+  pass "C1. auto-date prefix helper present in wiki/src"
+else
+  fail "C1. auto-date prefix helper missing"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/39-wiki-structure-rename.md
+++ b/.uat/plans/39-wiki-structure-rename.md
@@ -75,7 +75,7 @@ TA_COUNT=$(grep -cE '<Textarea\b' "$MODAL")
 # Also assert that the structure section uses an inline Textarea, not a
 # button-opens-modal pattern. Look for a 'Wiki Structure' label followed
 # within a few lines by '<Textarea'.
-if awk '/Wiki Structure/{flag=10} flag>0 && /<Textarea/{print "ok"; exit} flag>0{flag--}' "$MODAL" | grep -q ok; then
+if awk '/Wiki Structure/{flag=40} flag>0 && /<Textarea/{print "ok"; exit} flag>0{flag--}' "$MODAL" | grep -q ok; then
   pass "B3. inline Textarea follows the Wiki Structure label"
 else
   fail "B3. Wiki Structure label is not followed by an inline Textarea ($TA_COUNT total)"

--- a/.uat/plans/39-wiki-structure-rename.md
+++ b/.uat/plans/39-wiki-structure-rename.md
@@ -1,0 +1,96 @@
+# 39 — Rename Wiki Prompt → Wiki Structure (#240)
+
+## What it proves
+
+The per-wiki override field is renamed and reshaped:
+
+1. **Label rename** — every UI-visible label / header / placeholder / aria
+   for the prompt override now says **Wiki Structure** (not "Wiki Prompt").
+2. **Inline textarea** — the field is an inline `<Textarea>` matching the
+   Description field's shape; the Pencil-button popup dialog is gone.
+3. **Revert to default** — a "Revert to default" button restores the
+   current type's default structure. Disabled when value already matches.
+
+POSITIVE: source contains "Wiki Structure" + an inline textarea + a Revert
+button.
+
+NEGATIVE: source no longer contains the literal "Wiki Prompt" string, the
+`promptDialogOpen` state, the `promptDraft` state, or a Pencil button used
+for the prompt edit popup.
+
+NOTE — `wikis.prompt` storage stays as a `system_message` override (per
+project memory). This plan only asserts UI labels / shape, not storage.
+
+## Prerequisites
+
+- wiki source in tree
+- `grep`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+
+echo "39 — Rename Wiki Prompt → Wiki Structure (#240)"
+
+MODAL=wiki/src/components/layout/AddWikiModal.tsx
+
+# ── A. POSITIVE — Wiki Structure label and revert button ────────────
+if grep -q "Wiki Structure" "$MODAL"; then
+  pass "A1. AddWikiModal contains the literal 'Wiki Structure'"
+else
+  fail "A1. AddWikiModal does NOT contain 'Wiki Structure'"
+fi
+
+if grep -qE 'Revert' "$MODAL"; then
+  pass "A2. Revert (to default) button exists"
+else
+  fail "A2. no Revert button exists"
+fi
+
+# ── B. NEGATIVE — old Wiki Prompt copy / popup state are gone ───────
+if grep -q "Wiki Prompt" "$MODAL"; then
+  fail "B1. literal 'Wiki Prompt' still present"
+else
+  pass "B1. literal 'Wiki Prompt' is gone"
+fi
+
+if grep -qE 'promptDialogOpen|promptDraft' "$MODAL"; then
+  fail "B2. popup state (promptDialogOpen/promptDraft) is still in source"
+else
+  pass "B2. popup state removed"
+fi
+
+# Inline textarea check — the prompt field is now a <Textarea>.
+# Heuristic: count the number of Textarea elements; the post-fix shape has
+# >= 2 (Description + Wiki Structure) where the previous shape had 1
+# (Description) plus the popup dialog's Textarea.
+TA_COUNT=$(grep -cE '<Textarea\b' "$MODAL")
+# Also assert that the structure section uses an inline Textarea, not a
+# button-opens-modal pattern. Look for a 'Wiki Structure' label followed
+# within a few lines by '<Textarea'.
+if awk '/Wiki Structure/{flag=10} flag>0 && /<Textarea/{print "ok"; exit} flag>0{flag--}' "$MODAL" | grep -q ok; then
+  pass "B3. inline Textarea follows the Wiki Structure label"
+else
+  fail "B3. Wiki Structure label is not followed by an inline Textarea ($TA_COUNT total)"
+fi
+
+# Pencil import (only used for the popup edit button) should be gone if it
+# isn't used elsewhere in the modal.
+PENCIL_USES=$(grep -cE '<Pencil\b' "$MODAL")
+if [ "$PENCIL_USES" -eq 0 ]; then
+  pass "B4. Pencil icon is no longer rendered in AddWikiModal"
+else
+  fail "B4. Pencil icon still rendered $PENCIL_USES time(s) — pop-up shape may persist"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]
+```

--- a/core/src/db/slug.ts
+++ b/core/src/db/slug.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm'
 import { customAlphabet } from 'nanoid'
-import { entries, fragments, wikis } from './schema.js'
+import { entries, fragments, people, wikis } from './schema.js'
 import { checkSlugCollision } from '@robin/shared'
 import type { DB } from './client.js'
 
@@ -70,4 +70,21 @@ export async function resolveWikiSlug(database: DB, slug: string): Promise<strin
   }
 
   throw new Error(`Slug collision: could not disambiguate "${slug}" after 5 attempts`)
+}
+
+/**
+ * @summary Resolve a unique slug for a person, appending -2, -3 etc. on collision.
+ *
+ * Mirrors the entry/fragment pattern (numeric suffix, predictable). People
+ * are user-visible by name so a deterministic suffix is fine. (#234)
+ */
+export async function resolvePersonSlug(database: DB, slug: string): Promise<string> {
+  return checkSlugCollision(slug, async (candidate) => {
+    const [existing] = await database
+      .select({ key: people.lookupKey })
+      .from(people)
+      .where(eq(people.slug, candidate))
+      .limit(1)
+    return !!existing
+  })
 }

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -10,6 +10,8 @@ import { fragments, entries, edges, wikis, people } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
+import { handleLogFragment } from '../mcp/handlers.js'
+import type { McpServerDeps } from '../mcp/handlers.js'
 import {
   fragmentResponseSchema,
   fragmentWithContentResponseSchema,
@@ -19,6 +21,7 @@ import {
   updateFragmentBodySchema,
   fragmentListQuerySchema,
   fragmentReviewBodySchema,
+  logFragmentBodySchema,
 } from '../schemas/fragments.schema.js'
 import { emitAuditEvent } from '../db/audit.js'
 
@@ -168,6 +171,52 @@ fragmentsRouter.get('/:id', async (c) => {
     })
   )
 })
+
+// POST /fragments/log — #235 direct-to-wiki capture (bypasses classifier).
+// Mirrors the MCP `log_fragment` tool: persist a fragment straight to a
+// known wiki by slug. Skips the AI extraction pipeline so user-confirmed
+// destinations aren't second-guessed.
+fragmentsRouter.post(
+  '/log',
+  zValidator('json', logFragmentBodySchema, validationHook),
+  async (c) => {
+    const body = c.req.valid('json')
+    const userId = c.get('userId') as string | undefined
+
+    const deps: McpServerDeps = {
+      db,
+      producer,
+      spawnWriteWorker: () => {},
+      // Web direct-send mirrors the MCP wiring (no entity extraction).
+      // The classifier-bypass is the whole point — keep this fail-open.
+      entityExtractCall: async () => ({ people: [] }),
+      loadUserPeople: async () => [],
+    }
+
+    // Body is validated by Zod above (content + threadSlug both `min(1)`),
+    // but core's tsconfig has `strict: false` which weakens Zod's narrowing
+    // on optional vs required. Cast to the handler's signature explicitly.
+    const result = await handleLogFragment(
+      deps,
+      body as { content: string; threadSlug: string; title?: string; tags?: string[] },
+      userId
+    )
+    if (result.isError) {
+      const text =
+        result.content.find((p) => p.type === 'text')?.text ?? 'log_fragment failed'
+      return c.json({ error: text.replace(/^Error:\s*/, '') }, 400)
+    }
+
+    const text = result.content.find((p) => p.type === 'text')?.text ?? '{}'
+    let parsed: Record<string, unknown> = {}
+    try {
+      parsed = JSON.parse(text) as Record<string, unknown>
+    } catch {
+      return c.json({ ok: true, raw: text })
+    }
+    return c.json(parsed, 201)
+  }
+)
 
 // POST /fragments — create fragment
 fragmentsRouter.post('/', zValidator('json', createFragmentBodySchema, validationHook), async (c) => {

--- a/core/src/routes/people.ts
+++ b/core/src/routes/people.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono'
-import { eq, and, isNull, inArray } from 'drizzle-orm'
+import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
+import { generateSlug, makeLookupKey } from '@robin/shared'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
 import { people, edges, fragments, wikis } from '../db/schema.js'
+import { resolvePersonSlug } from '../db/slug.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
@@ -13,6 +15,8 @@ import {
   personDetailResponseSchema,
   personListResponseSchema,
   updatePersonBodySchema,
+  createPersonBodySchema,
+  mergePersonBodySchema,
   personListQuerySchema,
 } from '../schemas/people.schema.js'
 import { emitAuditEvent } from '../db/audit.js'
@@ -67,6 +71,62 @@ peopleRouter.get('/', async (c) => {
 
   return c.json(
     personListResponseSchema.parse({ people: rows.map((r) => ({ ...r, id: r.lookupKey })) })
+  )
+})
+
+// POST /people — manual create (#234). Bypasses AI extraction; the row lands
+// verified=true / state=RESOLVED so the matcher treats it as a canonical
+// anchor. Returns 409 on duplicate canonical name (case-insensitive).
+peopleRouter.post('/', zValidator('json', createPersonBodySchema, validationHook), async (c) => {
+  const body = c.req.valid('json')
+  const trimmedName = body.name.trim()
+  if (!trimmedName) return c.json({ error: 'name is required' }, 400)
+
+  const lowered = trimmedName.toLowerCase()
+  const [collision] = await db
+    .select({ key: people.lookupKey })
+    .from(people)
+    .where(and(sql`lower(${people.name}) = ${lowered}`, isNull(people.deletedAt)))
+    .limit(1)
+  if (collision) {
+    return c.json({ error: `Person "${trimmedName}" already exists` }, 409)
+  }
+
+  const lookupKey = makeLookupKey('person')
+  const slug = await resolvePersonSlug(db, generateSlug(trimmedName))
+
+  const [created] = await db
+    .insert(people)
+    .values({
+      lookupKey,
+      slug,
+      name: trimmedName,
+      canonicalName: trimmedName,
+      relationship: body.relationship ?? '',
+      aliases: body.aliases ?? [],
+      verified: true,
+      state: 'RESOLVED',
+    })
+    .returning()
+
+  await emitAuditEvent(db, {
+    entityType: 'person',
+    entityId: lookupKey,
+    eventType: 'created',
+    source: 'api',
+    summary: `Person created (manual): ${trimmedName}`,
+    detail: { personKey: lookupKey, manual: true },
+  })
+
+  return c.json(
+    {
+      ...created,
+      id: created.lookupKey,
+      content: created.content ?? '',
+      backlinks: [] as Array<{ id: string; title: string }>,
+      wikis: [] as Array<unknown>,
+    },
+    201
   )
 })
 
@@ -219,6 +279,129 @@ peopleRouter.post('/:id/regenerate', async (c) => {
   return c.json({ error: 'Person regen disabled in M2 — will be restored in M3' }, 503)
 })
 
+
+// POST /people/:id/merge — merge source person into a target person (#234).
+// Steps:
+//   1. Repoint FRAGMENT_MENTIONS_PERSON edges from source to target
+//   2. Append source name + aliases into target.aliases (deduped, lower-trim)
+//   3. Rewrite [[person:source-slug]] → [[person:target-slug]] in every
+//      non-deleted wiki body so previously-rendered prose still resolves
+//   4. Soft-delete the source row
+//   5. Emit audit event with the alias delta
+peopleRouter.post(
+  '/:id/merge',
+  zValidator('json', mergePersonBodySchema, validationHook),
+  async (c) => {
+    const sourceId = c.req.param('id')
+    const { targetPersonId } = c.req.valid('json')
+
+    if (sourceId === targetPersonId) {
+      return c.json({ error: 'Cannot merge a person into themselves' }, 400)
+    }
+
+    const [source] = await db
+      .select()
+      .from(people)
+      .where(and(eq(people.lookupKey, sourceId), isNull(people.deletedAt)))
+    if (!source) return c.json({ error: 'Source person not found' }, 404)
+
+    const [target] = await db
+      .select()
+      .from(people)
+      .where(and(eq(people.lookupKey, targetPersonId), isNull(people.deletedAt)))
+    if (!target) return c.json({ error: 'Target person not found' }, 404)
+
+    // 1. Repoint FRAGMENT_MENTIONS_PERSON edges
+    const repointed = await db
+      .update(edges)
+      .set({ dstId: targetPersonId })
+      .where(
+        and(
+          eq(edges.dstId, sourceId),
+          eq(edges.edgeType, 'FRAGMENT_MENTIONS_PERSON'),
+          isNull(edges.deletedAt)
+        )
+      )
+      .returning({ id: edges.id })
+
+    // 2. Alias union — dedup case-insensitively, preserve target ordering.
+    const seen = new Set<string>()
+    const merged: string[] = []
+    const push = (raw: string) => {
+      const t = raw.trim()
+      if (!t) return
+      const k = t.toLowerCase()
+      if (seen.has(k)) return
+      seen.add(k)
+      merged.push(t)
+    }
+    for (const a of target.aliases ?? []) push(a)
+    for (const a of source.aliases ?? []) push(a)
+    if (source.name) push(source.name)
+    // Don't fold the target's own canonical name into its own aliases.
+    const targetCanon = (target.canonicalName || target.name || '').trim().toLowerCase()
+    const finalAliases = merged.filter((a) => a.trim().toLowerCase() !== targetCanon)
+
+    await db
+      .update(people)
+      .set({ aliases: finalAliases, embedding: null, updatedAt: new Date() })
+      .where(eq(people.lookupKey, targetPersonId))
+
+    // 3. Rewrite [[person:source-slug]] in non-deleted wiki bodies
+    let bodiesRewritten = 0
+    if (source.slug && target.slug && source.slug !== target.slug) {
+      const sourceToken = `[[person:${source.slug}]]`
+      const targetToken = `[[person:${target.slug}]]`
+      const updated = await db
+        .update(wikis)
+        .set({
+          content: sql`replace(${wikis.content}, ${sourceToken}, ${targetToken})`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            isNull(wikis.deletedAt),
+            sql`${wikis.content} like ${'%' + sourceToken + '%'}`
+          )
+        )
+        .returning({ id: wikis.lookupKey })
+      bodiesRewritten = updated.length
+    }
+
+    // 4. Soft-delete source
+    await db
+      .update(people)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(eq(people.lookupKey, sourceId))
+
+    // 5. Audit
+    await emitAuditEvent(db, {
+      entityType: 'person',
+      entityId: targetPersonId,
+      eventType: 'merged',
+      source: 'api',
+      summary: `Person merged: ${source.name} → ${target.name}`,
+      detail: {
+        sourcePersonKey: sourceId,
+        targetPersonKey: targetPersonId,
+        edgesRepointed: repointed.length,
+        bodiesRewritten,
+        addedAliases: finalAliases.filter(
+          (a) => !(target.aliases ?? []).some((b) => b.toLowerCase() === a.toLowerCase())
+        ),
+      },
+    })
+
+    return c.json({
+      ok: true,
+      sourcePersonId: sourceId,
+      targetPersonId,
+      edgesRepointed: repointed.length,
+      bodiesRewritten,
+      aliases: finalAliases,
+    })
+  }
+)
 
 // DELETE /people/:id — soft delete
 peopleRouter.delete('/:id', async (c) => {

--- a/core/src/schemas/fragments.schema.ts
+++ b/core/src/schemas/fragments.schema.ts
@@ -64,6 +64,17 @@ export const fragmentReviewBodySchema = z.object({
   wikiId: z.string().min(1, 'wikiId is required'),
 })
 
+/**
+ * #235 — POST /fragments/log : direct-to-wiki capture from web UI.
+ * Same shape as the MCP `log_fragment` tool. Bypasses the classifier.
+ */
+export const logFragmentBodySchema = z.object({
+  content: z.string().min(1, 'content is required'),
+  threadSlug: z.string().min(1, 'threadSlug is required'),
+  title: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+})
+
 // ── Query schemas ───────────────────────────────────────────────────────────
 
 export const fragmentListQuerySchema = paginationQuerySchema.extend({

--- a/core/src/schemas/people.schema.ts
+++ b/core/src/schemas/people.schema.ts
@@ -56,6 +56,25 @@ export const updatePersonBodySchema = z.object({
   content: z.string().optional(),
 })
 
+/**
+ * Manual "Add Person" — bypasses AI extraction. Manually-created persons
+ * land verified=true / state=RESOLVED so they don't loiter in the
+ * matcher's settlement queue. (#234)
+ */
+export const createPersonBodySchema = z.object({
+  name: z.string().min(1),
+  aliases: z.array(z.string()).optional().default([]),
+  relationship: z.string().optional().default(''),
+})
+
+/**
+ * POST /people/:id/merge — repoint edges + alias union + slug rewrite +
+ * soft-delete the source. (#234)
+ */
+export const mergePersonBodySchema = z.object({
+  targetPersonId: z.string().min(1),
+})
+
 // ── Query schemas ───────────────────────────────────────────────────────────
 
 export const personListQuerySchema = paginationQuerySchema.extend({

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -299,6 +299,8 @@ export default function WikiDetailPage() {
       promptOverride={wiki.prompt}
       description={wiki.description ?? wiki.shortDescriptor ?? ''}
       bouncerMode={wiki.bouncerMode as 'auto' | 'review' | undefined}
+      published={wiki.published === true}
+      publishedSlug={wiki.publishedSlug ?? null}
       infobox={{ kind: "simple", typeLabel, lastUpdated: wiki.updatedAt, showSettings: true }}
       renderCustomInfobox={
         sidecarInfobox

--- a/wiki/src/app/profile/page.tsx
+++ b/wiki/src/app/profile/page.tsx
@@ -344,9 +344,9 @@ export default function ProfilePage() {
           </Card>
         </section>
 
-        {/* WIKI MANAGEMENT */}
+        {/* USER MANAGEMENT — owner identity (name + wiki count) */}
         <section className="mt-8" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-          <p style={sectionLabel}>Wiki Management</p>
+          <p style={sectionLabel}>User Management</p>
 
           <Card size="sm" className="rounded-none">
             <CardContent className="space-y-3">

--- a/wiki/src/components/layout/AddEntryModal.tsx
+++ b/wiki/src/components/layout/AddEntryModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { T } from "@/lib/typography";
@@ -17,6 +17,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { createEntry } from "@/lib/generated";
+import { useWikis } from "@/hooks/useWikis";
+import { autoDatePrefix } from "@/lib/autoDatePrefix";
 
 export interface AddEntryModalProps {
   open: boolean;
@@ -34,6 +36,14 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * #235 — capture mode picker:
+ *   "robin"  — default; runs the AI classifier (POST /entries)
+ *   "direct" — user picks a target wiki; calls POST /fragments/log
+ *              and applies the YYMMDD auto-date-prefix on short bodies.
+ */
+type CaptureMode = "robin" | "direct";
+
 export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
   const wasOpen = useRef(false);
   const [title, setTitle] = useState("");
@@ -43,8 +53,17 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState("Entry created");
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [mode, setMode] = useState<CaptureMode>("robin");
+  const [targetSlug, setTargetSlug] = useState<string>("");
 
   const queryClient = useQueryClient();
+  const { data: wikisData } = useWikis();
+  const wikiOptions = useMemo(() => {
+    const list = wikisData?.wikis ?? [];
+    return [...list]
+      .filter((w) => w.slug && w.name)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [wikisData]);
 
   useEffect(() => {
     if (open) {
@@ -54,6 +73,8 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
         setSubmitError(null);
         setSubmitting(false);
         setShowToast(false);
+        setMode("robin");
+        setTargetSlug("");
       }
       wasOpen.current = true;
     } else {
@@ -77,30 +98,65 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
       return;
     }
 
+    if (mode === "direct" && !targetSlug) {
+      setSubmitError("Pick a target wiki to send directly.");
+      return;
+    }
+
     setSubmitting(true);
     setSubmitError(null);
 
     try {
-      const { data, error } = await createEntry({
-        body: {
-          content: trimmedContent,
-          title: title.trim() || undefined,
-          source: "web",
-          type: "thought",
-        },
-        credentials: "include",
-      });
-
-      if (error) {
-        const message =
-          (error as { error?: string })?.error ?? "Failed to create entry.";
-        setSubmitError(message);
-        return;
+      if (mode === "robin") {
+        const { data, error } = await createEntry({
+          body: {
+            content: trimmedContent,
+            title: title.trim() || undefined,
+            source: "web",
+            type: "thought",
+          },
+          credentials: "include",
+        });
+        if (error) {
+          const message =
+            (error as { error?: string })?.error ?? "Failed to create entry.";
+          setSubmitError(message);
+          return;
+        }
+        // Reference the resolved data so unused-var lint stays quiet.
+        void data;
+        await queryClient.invalidateQueries({ queryKey: ["entries"] });
+        setToastMessage("Entry created");
+      } else {
+        // Direct send — POST /fragments/log with auto-date-prefix on short bodies.
+        const finalContent = autoDatePrefix(trimmedContent);
+        const res = await fetch("/api/fragments/log", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            content: finalContent,
+            threadSlug: targetSlug,
+            title: title.trim() || undefined,
+          }),
+        });
+        if (!res.ok) {
+          let msg = `Send failed (${res.status})`;
+          try {
+            const j = (await res.json()) as { error?: string };
+            if (j?.error) msg = j.error;
+          } catch {
+            /* ignore */
+          }
+          setSubmitError(msg);
+          return;
+        }
+        await queryClient.invalidateQueries({ queryKey: ["wikis"] });
+        await queryClient.invalidateQueries({ queryKey: ["fragments"] });
+        setToastMessage("Sent to wiki");
       }
 
-      await queryClient.invalidateQueries({ queryKey: ["entries"] });
       onClose();
-      setToastMessage("Entry created");
       setShowToast(true);
       if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
       toastTimerRef.current = setTimeout(() => {
@@ -124,7 +180,7 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
       >
         <DialogContent
           className="flex flex-col gap-0 rounded-2xl border-black/10 p-0 sm:max-w-[571px]"
-          style={{ maxHeight: "min(500px, 90vh)", overflow: "hidden" }}
+          style={{ maxHeight: "min(620px, 90vh)", overflow: "hidden" }}
         >
           <DialogHeader className="shrink-0 px-5 pb-2 pt-5">
             <DialogTitle
@@ -145,14 +201,76 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
                 margin: 0,
               }}
             >
-              Capture a thought, note, or idea. Robin will process it
-              automatically.
+              Capture a thought, note, or idea. Robin can file it, or send it
+              directly to a wiki you choose.
             </DialogDescription>
           </DialogHeader>
 
           <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
 
           <div className="min-h-0 flex-1 overflow-y-auto">
+            {/* Capture mode picker (#235) */}
+            <fieldset className="px-5 pt-4 flex flex-col gap-2 border-0">
+              <FieldLabel>Where should this go?</FieldLabel>
+              <div className="flex flex-col gap-2">
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="capture-mode"
+                    value="robin"
+                    checked={mode === "robin"}
+                    onChange={() => setMode("robin")}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span style={{ ...T.bodySmall }}>
+                    <span style={{ fontWeight: 600 }}>Robin files it</span>
+                    <span style={{ ...T.micro, color: "#676d76", display: "block" }}>
+                      Default. Robin classifies the thought and slots it into the
+                      best-fit wiki.
+                    </span>
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="capture-mode"
+                    value="direct"
+                    checked={mode === "direct"}
+                    onChange={() => setMode("direct")}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span style={{ ...T.bodySmall }}>
+                    <span style={{ fontWeight: 600 }}>Send directly to a wiki</span>
+                    <span style={{ ...T.micro, color: "#676d76", display: "block" }}>
+                      Skip the classifier. Short captures get an auto-date prefix
+                      so chronological wikis can render the line.
+                    </span>
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+
+            {mode === "direct" && (
+              <div className="flex flex-col gap-2 px-5 pt-4">
+                <FieldLabel>Target wiki</FieldLabel>
+                <select
+                  value={targetSlug}
+                  onChange={(e) => setTargetSlug(e.target.value)}
+                  aria-label="Target wiki"
+                  className="flex h-10 w-full items-center rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <option value="">
+                    {wikiOptions.length === 0 ? "Loading wikis…" : "Choose a wiki…"}
+                  </option>
+                  {wikiOptions.map((w) => (
+                    <option key={w.id ?? w.slug} value={w.slug}>
+                      {w.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <div className="flex flex-col gap-2 px-5 pt-4">
               <FieldLabel>Title (optional)</FieldLabel>
               <Input
@@ -197,7 +315,11 @@ export default function AddEntryModal({ open, onClose }: AddEntryModalProps) {
               disabled={submitting}
               className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
             >
-              {submitting ? "Adding..." : "Add Entry"}
+              {submitting
+                ? "Adding..."
+                : mode === "direct"
+                  ? "Send to wiki"
+                  : "Add Entry"}
             </Button>
           </div>
         </DialogContent>

--- a/wiki/src/components/layout/AddPersonModal.tsx
+++ b/wiki/src/components/layout/AddPersonModal.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
+
+import { T } from "@/lib/typography";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Toast } from "@/components/ui/toast";
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Label
+      className="text-[12px] font-normal leading-4 tracking-[0.32px]"
+      style={{ color: "#545353" }}
+    >
+      {children}
+    </Label>
+  );
+}
+
+export interface AddPersonModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * #234 — manual Add Person modal.
+ *
+ * Bypasses AI extraction. Wires `POST /people` directly so users can seed
+ * canonical anchors before the matcher sees the name in any fragment.
+ */
+export default function AddPersonModal({ open, onClose }: AddPersonModalProps) {
+  const wasOpen = useRef(false);
+  const [name, setName] = useState("");
+  const [aliases, setAliases] = useState<string[]>([]);
+  const [aliasInput, setAliasInput] = useState("");
+  const [relationship, setRelationship] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showToast, setShowToast] = useState(false);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (open) {
+      if (!wasOpen.current) {
+        setName("");
+        setAliases([]);
+        setAliasInput("");
+        setRelationship("");
+        setSubmitError(null);
+      }
+      wasOpen.current = true;
+    } else {
+      wasOpen.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+
+  function addAlias(value: string) {
+    const trimmed = value.trim();
+    if (trimmed && !aliases.includes(trimmed)) {
+      setAliases((prev) => [...prev, trimmed]);
+    }
+    setAliasInput("");
+  }
+
+  function removeAlias(alias: string) {
+    setAliases((prev) => prev.filter((a) => a !== alias));
+  }
+
+  function handleAliasKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addAlias(aliasInput);
+    }
+    if (e.key === "Backspace" && aliasInput === "" && aliases.length > 0) {
+      setAliases((prev) => prev.slice(0, -1));
+    }
+  }
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/people", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          aliases: aliases.filter((a) => a.trim().length > 0),
+          relationship: relationship.trim(),
+        }),
+      });
+      if (!res.ok) {
+        let msg = `Create failed (${res.status})`;
+        try {
+          const j = (await res.json()) as { error?: string };
+          if (j?.error) msg = j.error;
+        } catch {
+          /* ignore parse */
+        }
+        throw new Error(msg);
+      }
+      return (await res.json()) as { id?: string; lookupKey?: string };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      onClose();
+      setShowToast(true);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => setShowToast(false), 2000);
+    },
+    onError: (err) => {
+      setSubmitError(err instanceof Error ? err.message : "Create failed");
+    },
+  });
+
+  const handleSubmit = () => {
+    setSubmitError(null);
+    if (!name.trim()) {
+      setSubmitError("Name is required.");
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose();
+        }}
+      >
+        <DialogContent
+          className="flex flex-col gap-0 rounded-2xl border-black/10 p-0 sm:max-w-[520px]"
+          style={{ maxHeight: "min(560px, 90vh)", overflow: "hidden" }}
+        >
+          <DialogHeader className="shrink-0 px-5 pb-2 pt-5">
+            <DialogTitle
+              style={{ ...T.h1, color: "#111111", fontWeight: 400, margin: 0 }}
+            >
+              Add Person
+            </DialogTitle>
+            <DialogDescription
+              style={{ ...T.micro, lineHeight: "19px", color: "#676d76", margin: 0 }}
+            >
+              Create a canonical person row. Bypasses AI extraction; you can
+              edit aliases or merge later.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Full name"
+                className="h-10"
+              />
+            </div>
+
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Aliases</FieldLabel>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 4,
+                  padding: "6px 8px",
+                  border: "1px solid var(--border)",
+                  borderRadius: 6,
+                  minHeight: 38,
+                  alignItems: "center",
+                }}
+              >
+                {aliases.map((alias) => (
+                  <Badge
+                    key={alias}
+                    variant="secondary"
+                    className="flex items-center gap-1 rounded-sm"
+                    style={{ padding: "2px 6px", ...T.micro }}
+                  >
+                    {alias}
+                    <button
+                      type="button"
+                      onClick={() => removeAlias(alias)}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        cursor: "pointer",
+                        padding: 0,
+                        display: "flex",
+                        alignItems: "center",
+                      }}
+                      aria-label={`Remove ${alias}`}
+                    >
+                      <X size={12} />
+                    </button>
+                  </Badge>
+                ))}
+                <input
+                  value={aliasInput}
+                  onChange={(e) => setAliasInput(e.target.value)}
+                  onKeyDown={handleAliasKeyDown}
+                  onBlur={() => aliasInput.trim() && addAlias(aliasInput)}
+                  placeholder={aliases.length === 0 ? "Type and press Enter" : ""}
+                  style={{
+                    border: "none",
+                    outline: "none",
+                    background: "transparent",
+                    flex: 1,
+                    minWidth: 80,
+                    ...T.micro,
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Relationship (optional)</FieldLabel>
+              <Input
+                value={relationship}
+                onChange={(e) => setRelationship(e.target.value)}
+                placeholder="e.g. Colleague, Friend, Family"
+                className="h-10"
+              />
+            </div>
+
+            <div className="pb-5" />
+
+            {submitError ? (
+              <div
+                role="alert"
+                className="px-5 pt-3 text-[13px]"
+                style={{ color: "#c0392b" }}
+              >
+                {submitError}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="flex shrink-0 items-center justify-end gap-3 px-5 py-4">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={mutation.isPending}
+              className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
+            >
+              {mutation.isPending ? "Creating..." : "Add Person"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Toast
+        message="Person added"
+        visible={!open && showToast}
+        onDismiss={() => setShowToast(false)}
+      />
+    </>
+  );
+}

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -26,7 +26,7 @@ import {
   type WikiTypeListItem,
 } from "@/hooks/useWikiTypesList";
 import { useToggleBouncerMode } from "@/hooks/useToggleBouncerMode";
-import { updateWiki } from "@/lib/generated";
+import { publishWiki, unpublishWiki, updateWiki } from "@/lib/generated";
 
 export type { WikiSettingsPrefill } from "@/lib/wikiSettingsPrefill";
 
@@ -101,6 +101,11 @@ export default function AddWikiModal({
   const prevWikiTypeRef = useRef<string>("");
   const [bouncerMode, setBouncerMode] = useState<"auto" | "review">("auto");
   const initialBouncerModeRef = useRef<"auto" | "review">("auto");
+  /** #255: publish toggle state inside settings modal. */
+  const [published, setPublished] = useState<boolean>(false);
+  const [publishedSlug, setPublishedSlug] = useState<string | null>(null);
+  const [publishBusy, setPublishBusy] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
 
   const isSettingsView = Boolean(prefill);
 
@@ -145,6 +150,9 @@ export default function AddWikiModal({
           const bm = prefill.bouncerMode ?? "auto";
           setBouncerMode(bm);
           initialBouncerModeRef.current = bm;
+          setPublished(Boolean(prefill.published));
+          setPublishedSlug(prefill.publishedSlug ?? null);
+          setPublishError(null);
           setFieldsEditable(false);
         } else {
           setName("");
@@ -156,6 +164,9 @@ export default function AddWikiModal({
           prevWikiTypeRef.current = "";
           setBouncerMode("auto");
           initialBouncerModeRef.current = "auto";
+          setPublished(false);
+          setPublishedSlug(null);
+          setPublishError(null);
           setFieldsEditable(true);
         }
         setPromptDialogOpen(false);
@@ -519,6 +530,88 @@ export default function AddWikiModal({
                 disabled={locked}
                 size="sm"
               />
+            </div>
+          )}
+
+          {/* #255: Publish/unpublish toggle — settings mode only.
+              Calls the existing /wikis/:id/publish + /unpublish endpoints
+              eagerly (no save-button gating) so the toggle reflects the
+              live published state at all times. */}
+          {isSettingsView && wikiId && wikiId !== "preview" && (
+            <div className="px-5 pt-4 flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex flex-col gap-0.5">
+                  <FieldLabel>Publish</FieldLabel>
+                  <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
+                    {published
+                      ? "Public — anyone with the link can read this wiki"
+                      : "Private — only you can read this wiki"}
+                  </span>
+                </div>
+                <Switch
+                  aria-label="Publish wiki"
+                  checked={published}
+                  onCheckedChange={async (next: boolean) => {
+                    if (publishBusy) return;
+                    setPublishBusy(true);
+                    setPublishError(null);
+                    try {
+                      if (next) {
+                        const { data, error } = await publishWiki({
+                          path: { id: wikiId },
+                          credentials: "include",
+                        });
+                        if (error) throw new Error((error as { error?: string })?.error ?? "Publish failed");
+                        setPublished(true);
+                        setPublishedSlug(
+                          (data as { publishedSlug?: string } | undefined)?.publishedSlug ?? null,
+                        );
+                      } else {
+                        const { error } = await unpublishWiki({
+                          path: { id: wikiId },
+                          credentials: "include",
+                        });
+                        if (error) throw new Error((error as { error?: string })?.error ?? "Unpublish failed");
+                        setPublished(false);
+                      }
+                      await queryClient.invalidateQueries({ queryKey: ["wikis"] });
+                      await queryClient.invalidateQueries({ queryKey: ["wiki", wikiId] });
+                    } catch (err) {
+                      setPublishError(err instanceof Error ? err.message : "Toggle failed");
+                    } finally {
+                      setPublishBusy(false);
+                    }
+                  }}
+                  disabled={publishBusy}
+                  size="sm"
+                />
+              </div>
+              {published && publishedSlug ? (
+                <div
+                  className="flex items-center justify-between gap-2 rounded-md px-2 py-1"
+                  style={{ background: "var(--surface-subtle)", border: "1px solid var(--btn-disabled-bg)" }}
+                >
+                  <span
+                    style={{ ...T.micro, color: "var(--input-label)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                  >
+                    {`/p/${publishedSlug}`}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const url = `${window.location.origin}/p/${publishedSlug}`;
+                      void navigator.clipboard.writeText(url).catch(() => {});
+                    }}
+                    className="rounded px-2 text-[11px]"
+                    style={{ background: "transparent", border: "1px solid var(--btn-disabled-bg)", color: "var(--wiki-link)" }}
+                  >
+                    Copy link
+                  </button>
+                </div>
+              ) : null}
+              {publishError ? (
+                <span style={{ ...T.micro, color: "var(--destructive)" }}>{publishError}</span>
+              ) : null}
             </div>
           )}
 

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Pencil } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { T } from "@/lib/typography";
 import { Button } from "@/components/ui/button";
-import { ActionButton } from "@/components/ui/action-button";
 import { Toast } from "@/components/ui/toast";
 import {
   Dialog,
@@ -22,7 +20,6 @@ import { Switch } from "@/components/ui/switch";
 import type { WikiSettingsPrefill } from "@/lib/wikiSettingsPrefill";
 import {
   useWikiTypesList,
-  findWikiType,
   type WikiTypeListItem,
 } from "@/hooks/useWikiTypesList";
 import { useToggleBouncerMode } from "@/hooks/useToggleBouncerMode";
@@ -88,11 +85,14 @@ export default function AddWikiModal({
   const [wikiType, setWikiType] = useState("");
   const [description, setDescription] = useState("");
   const [subtitle, setSubtitle] = useState<string | undefined>(undefined);
-  /** Wiki prompt state (emulated local state; will move to OS.robin store later) */
+  /**
+   * #240: Wiki Structure (UI label rename) — inline override of the
+   * type's system_message. Empty string === "use the type default".
+   * `wikis.prompt` storage stays a system_message override; only the UI
+   * label and presentation changed.
+   */
   const [wikiPrompt, setWikiPrompt] = useState<string>("");
   const [wikiPromptEdited, setWikiPromptEdited] = useState<boolean>(false);
-  const [promptDialogOpen, setPromptDialogOpen] = useState(false);
-  const [promptDraft, setPromptDraft] = useState<string>("");
   /** Existing-wiki settings: form read-only until user clicks Edit Wiki */
   const [fieldsEditable, setFieldsEditable] = useState(true);
   const [showSavedToast, setShowSavedToast] = useState(false);
@@ -169,7 +169,6 @@ export default function AddWikiModal({
           setPublishError(null);
           setFieldsEditable(true);
         }
-        setPromptDialogOpen(false);
       }
       wasOpen.current = true;
     } else {
@@ -455,60 +454,45 @@ export default function AddWikiModal({
             />
           </div>
 
-          {/* Wiki Prompt */}
+          {/* Wiki Structure (#240) — inline textarea matching the
+              Description field's shape. Empty value = "use the type
+              default"; the Revert button clears the override. */}
           <div className="px-5 pt-4 flex flex-col gap-2">
-            <FieldLabel>
-              Wiki Prompt <InfoIcon className="text-[#545353]" />
-            </FieldLabel>
-            {(() => {
-              const hasType = Boolean(wikiType);
-              const typeLabel =
-                findWikiType(wikiTypesData, wikiType)?.displayLabel ??
-                (wikiType
-                  ? wikiType.charAt(0).toUpperCase() + wikiType.slice(1)
-                  : "");
-              const disabled = locked || !hasType;
-              const badgeText = !hasType
-                ? "Pick a type to customize"
-                : wikiPromptEdited
-                  ? `Customized ${typeLabel} Prompt`
-                  : `Default ${typeLabel} Prompt`;
-              const badgeColors = wikiPromptEdited
-                ? { fg: "var(--wiki-link)", bg: "rgba(51, 102, 204, 0.10)", bd: "var(--wiki-link)" }
-                : { fg: "var(--input-label)", bg: "var(--surface-subtle)", bd: "var(--btn-disabled-bg)" };
-              return (
-                <div
-                  className="flex h-10 w-full items-center justify-between rounded-lg border border-input bg-transparent px-2.5"
-                  style={{ opacity: disabled ? 0.6 : 1 }}
-                >
-                  <span
-                    className="inline-flex items-center"
-                    style={{
-                      ...T.micro,
-                      padding: "2px 8px",
-                      color: badgeColors.fg,
-                      background: badgeColors.bg,
-                      border: `1px solid ${badgeColors.bd}`,
-                    }}
-                  >
-                    {badgeText}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (disabled) return;
-                      setPromptDraft(wikiPrompt);
-                      setPromptDialogOpen(true);
-                    }}
-                    disabled={disabled}
-                    aria-label="Edit wiki prompt"
-                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-[#545353] transition-colors hover:bg-[#f5f5f5] disabled:cursor-not-allowed disabled:hover:bg-transparent"
-                  >
-                    <Pencil size={14} strokeWidth={1.5} aria-hidden />
-                  </button>
-                </div>
-              );
-            })()}
+            <div className="flex items-center justify-between gap-2">
+              <FieldLabel>
+                Wiki Structure <InfoIcon className="text-[#545353]" />
+              </FieldLabel>
+              <button
+                type="button"
+                onClick={() => {
+                  setWikiPrompt("");
+                  setWikiPromptEdited(false);
+                }}
+                disabled={locked || !wikiPromptEdited}
+                aria-label="Revert to default"
+                className="text-[11px] leading-4 underline disabled:opacity-50 disabled:no-underline"
+                style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked || !wikiPromptEdited ? "default" : "pointer" }}
+              >
+                Revert to default
+              </button>
+            </div>
+            <Textarea
+              value={wikiPrompt}
+              onChange={(e) => {
+                const next = e.target.value;
+                setWikiPrompt(next);
+                setWikiPromptEdited(next.trim().length > 0);
+              }}
+              placeholder={"# Type: title\n## Section\n- bullet\n## Another section"}
+              rows={6}
+              disabled={locked || !wikiType}
+              className="min-h-[120px] resize-none font-mono"
+            />
+            <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
+              {wikiPromptEdited
+                ? "Custom structure overrides the type default at regen time."
+                : "Empty — uses the wiki type's default structure."}
+            </span>
           </div>
 
           {/* Fragment Review Mode toggle -- settings mode only */}
@@ -651,69 +635,6 @@ export default function AddWikiModal({
                     : confirmLabel}
             </Button>
           </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Wiki prompt edit dialog */}
-      <Dialog
-        open={promptDialogOpen}
-        onOpenChange={(next) => {
-          if (!next) setPromptDialogOpen(false);
-        }}
-      >
-        <DialogContent className="sm:max-w-[480px] gap-4 rounded-xl">
-          {(() => {
-            const typeLabel =
-              findWikiType(wikiTypesData, wikiType)?.displayLabel ?? "";
-            const typeLabelLower = typeLabel.toLowerCase();
-            return (
-              <>
-                <DialogHeader>
-                  <DialogTitle
-                    style={{
-                      ...T.bodySmall,
-                      fontWeight: 600,
-                      color: "var(--heading-color)",
-                    }}
-                  >
-                    {typeLabel} Prompt
-                  </DialogTitle>
-                  <DialogDescription>
-                    {`Optional extra instructions. Appended to the ${typeLabelLower} type's system message at regen time. Leave empty to use the default alone.`}
-                  </DialogDescription>
-                </DialogHeader>
-
-                <Textarea
-                  value={promptDraft}
-                  onChange={(e) => setPromptDraft(e.target.value)}
-                  className="min-h-[240px] resize-none"
-                  rows={12}
-                  placeholder={`Extra guidance appended to the ${typeLabel} default. Leave blank for the default alone.`}
-                />
-
-                <div className="flex items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => setPromptDraft("")}
-                    className="rounded-none"
-                  >
-                    Clear
-                  </Button>
-                  <ActionButton
-                    type="button"
-                    onClick={() => {
-                      setWikiPrompt(promptDraft);
-                      setWikiPromptEdited(promptDraft.trim().length > 0);
-                      setPromptDialogOpen(false);
-                    }}
-                  >
-                    Save
-                  </ActionButton>
-                </div>
-              </>
-            );
-          })()}
         </DialogContent>
       </Dialog>
 

--- a/wiki/src/components/layout/Header.tsx
+++ b/wiki/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { useLogout } from "@/hooks/useLogout";
 
 import AddWikiModal from "@/components/layout/AddWikiModal";
 import AddEntryModal from "@/components/layout/AddEntryModal";
+import AddPersonModal from "@/components/layout/AddPersonModal";
 import WikiHeaderSearch from "@/components/layout/WikiHeaderSearch";
 
 interface HeaderProps {
@@ -16,8 +17,10 @@ interface HeaderProps {
 
 export default function Header({ onMenuToggle }: HeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [addWikiOpen, setAddWikiOpen] = useState(false);
   const [addEntryOpen, setAddEntryOpen] = useState(false);
+  const [addPersonOpen, setAddPersonOpen] = useState(false);
   const { session } = useSession();
   const router = useRouter();
   const pathname = usePathname();
@@ -112,48 +115,129 @@ export default function Header({ onMenuToggle }: HeaderProps) {
           </span>
         </button>
 
-        <button
-          type="button"
-          onClick={() => setAddWikiOpen(true)}
-          className="wiki-add-wiki-btn flex cursor-pointer items-center justify-center"
-          style={{
-            gap: 4,
-            padding: "8px 12px",
-            height: 35,
-            boxSizing: "border-box",
-            background: "transparent",
-            border: "none",
-            borderRadius: 2,
-          }}
-        >
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden
-          >
-            <path
-              d="M12 5v14M5 12h14"
-              stroke={addWikiFg}
-              strokeWidth="2"
-              strokeLinecap="round"
-            />
-          </svg>
-          <span
+        <div style={{ position: "relative" }}>
+          <button
+            type="button"
+            onClick={() => setAddMenuOpen((v) => !v)}
+            aria-haspopup="menu"
+            aria-expanded={addMenuOpen}
+            className="wiki-add-wiki-btn flex cursor-pointer items-center justify-center"
             style={{
-              ...T.bodySmall,
-              fontWeight: 600,
-              lineHeight: "normal",
-              letterSpacing: "-0.0336px",
-              color: addWikiFg,
-              whiteSpace: "nowrap",
+              gap: 4,
+              padding: "8px 12px",
+              height: 35,
+              boxSizing: "border-box",
+              background: "transparent",
+              border: "none",
+              borderRadius: 2,
             }}
           >
-            Add Wiki
-          </span>
-        </button>
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden
+            >
+              <path
+                d="M12 5v14M5 12h14"
+                stroke={addWikiFg}
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span
+              style={{
+                ...T.bodySmall,
+                fontWeight: 600,
+                lineHeight: "normal",
+                letterSpacing: "-0.0336px",
+                color: addWikiFg,
+                whiteSpace: "nowrap",
+              }}
+            >
+              Add Wiki
+            </span>
+          </button>
+
+          {addMenuOpen && (
+            <>
+              <div
+                style={{ position: "fixed", inset: 0, zIndex: 40 }}
+                onClick={() => setAddMenuOpen(false)}
+              />
+              <div
+                role="menu"
+                style={{
+                  position: "absolute",
+                  top: "calc(100% + 6px)",
+                  right: 0,
+                  zIndex: 50,
+                  minWidth: 160,
+                  backgroundColor: "var(--bg)",
+                  border: "1px solid var(--card-border)",
+                  borderRadius: 6,
+                  padding: "4px 0",
+                  boxShadow: "var(--shadow-dropdown)",
+                }}
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setAddWikiOpen(true);
+                  }}
+                  className="flex w-full cursor-pointer items-center"
+                  style={{
+                    gap: 10,
+                    padding: "8px 14px",
+                    background: "none",
+                    border: "none",
+                    ...T.caption,
+                    color: "var(--heading-color)",
+                    textAlign: "left",
+                  }}
+                  onMouseEnter={(e) =>
+                    (e.currentTarget.style.backgroundColor = "var(--card-border)")
+                  }
+                  onMouseLeave={(e) =>
+                    (e.currentTarget.style.backgroundColor = "transparent")
+                  }
+                >
+                  Wiki
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setAddPersonOpen(true);
+                  }}
+                  className="flex w-full cursor-pointer items-center"
+                  style={{
+                    gap: 10,
+                    padding: "8px 14px",
+                    background: "none",
+                    border: "none",
+                    ...T.caption,
+                    color: "var(--heading-color)",
+                    textAlign: "left",
+                  }}
+                  onMouseEnter={(e) =>
+                    (e.currentTarget.style.backgroundColor = "var(--card-border)")
+                  }
+                  onMouseLeave={(e) =>
+                    (e.currentTarget.style.backgroundColor = "transparent")
+                  }
+                >
+                  Person
+                </button>
+              </div>
+            </>
+          )}
+        </div>
 
         <div className="flex items-center" style={{ gap: 8, position: "relative" }}>
           <div className="flex items-start">
@@ -300,6 +384,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
 
       <AddWikiModal open={addWikiOpen} onClose={() => setAddWikiOpen(false)} />
       <AddEntryModal open={addEntryOpen} onClose={() => setAddEntryOpen(false)} />
+      <AddPersonModal open={addPersonOpen} onClose={() => setAddPersonOpen(false)} />
     </header>
   );
 }

--- a/wiki/src/components/layout/PersonSettingsModal.tsx
+++ b/wiki/src/components/layout/PersonSettingsModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { X } from "lucide-react";
 
 import { T } from "@/lib/typography";
@@ -16,7 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { updatePerson } from "@/lib/api";
+import { updatePerson, listPeople } from "@/lib/api";
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -50,7 +51,12 @@ export default function PersonSettingsModal({
   const [aliases, setAliases] = useState<string[]>(prefill.aliases);
   const [aliasInput, setAliasInput] = useState("");
   const [relationship, setRelationship] = useState(prefill.relationship);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [mergePickerOpen, setMergePickerOpen] = useState(false);
+  const [mergeTargetId, setMergeTargetId] = useState<string>("");
+  const [actionError, setActionError] = useState<string | null>(null);
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   useEffect(() => {
     if (open) {
@@ -58,6 +64,10 @@ export default function PersonSettingsModal({
       setAliases(prefill.aliases);
       setRelationship(prefill.relationship);
       setAliasInput("");
+      setConfirmDelete(false);
+      setMergePickerOpen(false);
+      setMergeTargetId("");
+      setActionError(null);
     }
   }, [open, prefill.name, prefill.aliases, prefill.relationship]);
 
@@ -74,6 +84,74 @@ export default function PersonSettingsModal({
       onClose();
     },
   });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/people/${personId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok && res.status !== 204) {
+        throw new Error(`Delete failed (${res.status})`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      onClose();
+      router.push("/wiki");
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Delete failed");
+    },
+  });
+
+  const mergeMutation = useMutation({
+    mutationFn: async (targetPersonId: string) => {
+      const res = await fetch(`/api/people/${personId}/merge`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetPersonId }),
+      });
+      if (!res.ok) {
+        let msg = `Merge failed (${res.status})`;
+        try {
+          const j = (await res.json()) as { error?: string };
+          if (j?.error) msg = j.error;
+        } catch {
+          /* ignore */
+        }
+        throw new Error(msg);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      queryClient.invalidateQueries({ queryKey: ["wikis"] });
+      onClose();
+      router.push("/wiki");
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Merge failed");
+    },
+  });
+
+  const peopleQuery = useMutation({
+    mutationFn: async () => {
+      const { data } = await listPeople({ query: { limit: 200 } });
+      return (data?.people ?? []).filter(
+        (p) => (p.id ?? p.lookupKey) !== personId,
+      );
+    },
+  });
+
+  const peopleList = peopleQuery.data ?? [];
+  const sortedPeople = useMemo(
+    () =>
+      [...peopleList].sort((a, b) =>
+        (a.name ?? "").localeCompare(b.name ?? ""),
+      ),
+    [peopleList],
+  );
 
   function addAlias(value: string) {
     const trimmed = value.trim();
@@ -100,7 +178,7 @@ export default function PersonSettingsModal({
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent
-        style={{ maxWidth: 480, display: "flex", flexDirection: "column", gap: 20 }}
+        style={{ maxWidth: 520, display: "flex", flexDirection: "column", gap: 20 }}
       >
         <DialogHeader>
           <DialogTitle style={T.h2}>Person Settings</DialogTitle>
@@ -184,6 +262,127 @@ export default function PersonSettingsModal({
               placeholder="e.g. Colleague, Friend, Family"
             />
           </div>
+        </div>
+
+        {/* Dedup actions: Merge + Delete */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingTop: 8,
+            borderTop: "1px solid var(--border)",
+          }}
+        >
+          <FieldLabel>Dedup</FieldLabel>
+
+          {!mergePickerOpen ? (
+            <div style={{ display: "flex", gap: 8 }}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setActionError(null);
+                  setMergePickerOpen(true);
+                  if (peopleList.length === 0) peopleQuery.mutate();
+                }}
+              >
+                Merge into…
+              </Button>
+              {!confirmDelete ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setActionError(null);
+                    setConfirmDelete(true);
+                  }}
+                  style={{ color: "var(--destructive)", borderColor: "var(--destructive)" }}
+                >
+                  Delete
+                </Button>
+              ) : (
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <span style={{ ...T.micro, color: "var(--destructive)" }}>
+                    Delete this person?
+                  </span>
+                  <Button
+                    type="button"
+                    onClick={() => deleteMutation.mutate()}
+                    disabled={deleteMutation.isPending}
+                    style={{ background: "var(--destructive)", color: "#fff" }}
+                  >
+                    {deleteMutation.isPending ? "Deleting..." : "Confirm Delete"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setConfirmDelete(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <span style={{ ...T.micro, color: "#545353" }}>
+                Pick the person to merge into. The current person will be
+                soft-deleted; their aliases and edges follow the target.
+              </span>
+              <select
+                value={mergeTargetId}
+                onChange={(e) => setMergeTargetId(e.target.value)}
+                aria-label="Merge target person"
+                style={{
+                  height: 38,
+                  border: "1px solid var(--border)",
+                  borderRadius: 6,
+                  padding: "0 8px",
+                  background: "transparent",
+                  ...T.bodySmall,
+                }}
+              >
+                <option value="">
+                  {peopleQuery.isPending
+                    ? "Loading people…"
+                    : sortedPeople.length === 0
+                      ? "No other people to merge into"
+                      : "Choose target…"}
+                </option>
+                {sortedPeople.map((p) => (
+                  <option key={p.id ?? p.lookupKey} value={p.id ?? p.lookupKey}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              <div style={{ display: "flex", gap: 8 }}>
+                <Button
+                  type="button"
+                  onClick={() => mergeMutation.mutate(mergeTargetId)}
+                  disabled={!mergeTargetId || mergeMutation.isPending}
+                >
+                  {mergeMutation.isPending ? "Merging…" : "Merge"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setMergePickerOpen(false);
+                    setMergeTargetId("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {actionError ? (
+            <span style={{ ...T.micro, color: "var(--destructive)" }}>
+              {actionError}
+            </span>
+          ) : null}
         </div>
 
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, paddingTop: 8 }}>

--- a/wiki/src/components/layout/Sidebar.tsx
+++ b/wiki/src/components/layout/Sidebar.tsx
@@ -62,7 +62,9 @@ const navigationData: SidebarSectionData = {
 };
 
 function useEntriesData(): SidebarSectionData {
-  const { data } = useEntries({ limit: 20 });
+  // #250: cap recent-entries at 5; the page entries view paginates, so the
+  // sidebar's role is "the most recent handful", not "every entry".
+  const { data } = useEntries({ limit: 5 });
   const items = useMemo<NavItem[]>(() => {
     const entries = data?.entries;
     if (!entries || entries.length === 0) return [];

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -91,12 +91,12 @@ const infoboxBodyMuted = {
 export function WikiInfoboxTypeUpdated({
   typeLabel,
   lastUpdated,
-  showSettings,
-  onSettingsClick,
 }: {
   typeLabel: string;
   lastUpdated?: string;
+  /** @deprecated #250: gear lives on the toolbar; this prop is now ignored. */
   showSettings?: boolean;
+  /** @deprecated #250: gear lives on the toolbar; this prop is now ignored. */
   onSettingsClick?: () => void;
 }) {
   return (
@@ -115,30 +115,6 @@ export function WikiInfoboxTypeUpdated({
         alignSelf: "flex-start",
       }}
     >
-      {showSettings ? (
-        <button
-          type="button"
-          aria-label="Infobox settings"
-          onClick={() => onSettingsClick?.()}
-          style={{
-            position: "absolute",
-            top: -1,
-            right: 0,
-            width: 28,
-            height: 28,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
-          }}
-        >
-          <SettingsIcon />
-        </button>
-      ) : null}
-
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={infoboxLabel}>Type</p>
         <p style={{ ...infoboxBodyMuted, margin: 0 }}>{typeLabel}</p>
@@ -167,15 +143,15 @@ export function WikiInfoboxGoalStyle({
   targetDate,
   momentum,
   lastUpdated,
-  showSettings,
-  onSettingsClick,
 }: {
   typeValue: string;
   startedAt?: string;
   targetDate?: string;
   momentum?: string;
   lastUpdated?: string;
+  /** @deprecated #250: gear lives on the toolbar; this prop is now ignored. */
   showSettings?: boolean;
+  /** @deprecated #250: gear lives on the toolbar; this prop is now ignored. */
   onSettingsClick?: () => void;
 }) {
   const linkValue = {
@@ -210,29 +186,6 @@ export function WikiInfoboxGoalStyle({
         ...T.micro,
       }}
     >
-      {showSettings ? (
-        <button
-          type="button"
-          aria-label="Infobox settings"
-          onClick={() => onSettingsClick?.()}
-          style={{
-            position: "absolute",
-            top: -1,
-            right: 0,
-            width: 28,
-            height: 28,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
-          }}
-        >
-          <SettingsIcon />
-        </button>
-      ) : null}
       {rows.map((row) => (
         <div
           key={row.label}
@@ -430,7 +383,14 @@ export function WikiEntityArticle({
   const displayChipIcon = getWikiTypeIcon(displayChipLabel);
   const draftChipColors = getWikiTypeColors(draftChipLabel);
   const wikiTypeLocked = isPeopleWikiType(displayChipLabel);
-  const showSettings = infobox.showSettings === true;
+  // #250: settings gear is permanent next to the eye toggle whenever the
+  // hosting page has somewhere to send the click — i.e. we have a real wiki
+  // id (sentinel 'preview' counts as a real id for prototype pages) OR the
+  // page has wired its own onSettingsClick handler. Pages that explicitly
+  // opt out (Fragments) pass infobox.showSettings === false; honour that.
+  const settingsOptedOut = infobox.showSettings === false;
+  const hasSettingsTarget = Boolean(wikiId) || Boolean(onSettingsClickProp);
+  const showSettings = !settingsOptedOut && hasSettingsTarget;
 
   const wikiSettingsPrefill = useMemo(
     () => ({ ...wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel, description, promptOverride }), bouncerMode }),

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -282,6 +282,10 @@ export type WikiEntityArticleProps = {
   description?: string;
   /** Current bouncer mode for settings modal prefill */
   bouncerMode?: 'auto' | 'review';
+  /** Current publish state — feeds the publish toggle in settings modal (#255). */
+  published?: boolean;
+  /** Public published-wiki nanoid slug (when published) for share-link UI. */
+  publishedSlug?: string | null;
   /** Real wiki id for settings-mode PUT. Prototype pages omit → 'preview' sentinel. */
   wikiId?: string;
   /** Called after local save completes — persist to backend here. */
@@ -332,6 +336,8 @@ export function WikiEntityArticle({
   description,
   wikiId,
   bouncerMode,
+  published,
+  publishedSlug,
   onSave,
   onSettingsClick: onSettingsClickProp,
   children,
@@ -393,8 +399,13 @@ export function WikiEntityArticle({
   const showSettings = !settingsOptedOut && hasSettingsTarget;
 
   const wikiSettingsPrefill = useMemo(
-    () => ({ ...wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel, description, promptOverride }), bouncerMode }),
-    [displayTitle, displayChipLabel, description, promptOverride, bouncerMode],
+    () => ({
+      ...wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel, description, promptOverride }),
+      bouncerMode,
+      published,
+      publishedSlug,
+    }),
+    [displayTitle, displayChipLabel, description, promptOverride, bouncerMode, published, publishedSlug],
   );
 
   const tabs = ["Read", "Edit", "View history"] as const;

--- a/wiki/src/lib/autoDatePrefix.ts
+++ b/wiki/src/lib/autoDatePrefix.ts
@@ -1,0 +1,55 @@
+/**
+ * #235 — Auto-date-prefix for short captures sent directly to a wiki.
+ *
+ * When a user picks a target wiki and types a body shorter than 120 chars
+ * with no leading date pattern, prepend `YYMMDD: ` (UTC). The format is
+ * compact so it doesn't dominate the rendered chronological-table row, but
+ * still gives Quill (the writer agent) a date anchor to slot the line by.
+ *
+ * The regex is intentionally generous: anything that already opens with a
+ * date-shaped prefix (YYYY-MM-DD, YY-MM-DD, YYMMDD, "DD Mmm YYYY", etc.) is
+ * left alone. We don't try to *correct* broken-but-date-shaped prefixes —
+ * leave that to humans.
+ */
+const SHORT_BODY_THRESHOLD = 120;
+
+const HAS_DATE_PREFIX = new RegExp(
+  [
+    // YYYY-MM-DD or YYYY/MM/DD
+    "^\\s*\\d{4}[-/]\\d{1,2}[-/]\\d{1,2}\\b",
+    // YY-MM-DD or YY/MM/DD or YYMMDD
+    "^\\s*\\d{2}[-/]?\\d{2}[-/]?\\d{2}\\b",
+    // 4 May 2026, 4-May-2026, 4 May, 04 May
+    "^\\s*\\d{1,2}[\\s-]+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)",
+    // ISO timestamps
+    "^\\s*\\d{4}-\\d{2}-\\d{2}T",
+  ].join("|"),
+  "i",
+);
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** UTC YYMMDD — matches what fork commit aca5853 ships. */
+export function utcYymmdd(now: Date = new Date()): string {
+  const yy = pad2(now.getUTCFullYear() % 100);
+  const mm = pad2(now.getUTCMonth() + 1);
+  const dd = pad2(now.getUTCDate());
+  return `${yy}${mm}${dd}`;
+}
+
+/**
+ * Returns the (possibly prefixed) capture text. No-op when:
+ *  - the body is empty
+ *  - the body is longer than the short-capture threshold
+ *  - the body already opens with a date-shaped prefix
+ */
+export function autoDatePrefix(body: string, now: Date = new Date()): string {
+  if (!body) return body;
+  const trimmed = body.trimStart();
+  if (trimmed.length === 0) return body;
+  if (trimmed.length > SHORT_BODY_THRESHOLD) return body;
+  if (HAS_DATE_PREFIX.test(trimmed)) return body;
+  return `${utcYymmdd(now)}: ${trimmed}`;
+}

--- a/wiki/src/lib/wikiSettingsPrefill.ts
+++ b/wiki/src/lib/wikiSettingsPrefill.ts
@@ -11,6 +11,10 @@ export type WikiSettingsPrefill = {
   promptOverride?: string;
   /** Current bouncer mode: 'auto' or 'review' */
   bouncerMode?: 'auto' | 'review';
+  /** Current publish state — drives the publish toggle in settings (#255) */
+  published?: boolean;
+  /** Public published-wiki nanoid slug (when published) */
+  publishedSlug?: string | null;
 };
 
 /** Placeholder — callers may supply a real description in the future. */


### PR DESCRIPTION
## Summary

Closes the Collections + UX completion cluster — five frontend features that round out v1's UI completeness.

- **#250** — sidebar/settings/nav polish: Recent Entries cap=5, permanent toolbar gear, "Profile" heading rename
- **#234** — person dedup UX: delete + merge + manual create
- **#255** — publish/unpublish toggle inside the wiki settings modal
- **#235** — AddEntry wiki picker: "Robin files it" (default) or send-direct-to-wiki + UTC YYMMDD auto-date prefix
- **#240** — UI rename "Wiki Prompt" → "Wiki Structure" + inline textarea + revert-to-default (storage mechanism unchanged per memory note: \`wikis.prompt\` remains a \`system_message\` override, not full YAML)

## UAT contract

5 new plans, all written before code; each had FAILing assertions on \`07bde75\` and now PASS.

| Issue | Plan | Pre-fix | Post-fix |
|-------|------|---------|----------|
| #250  | \`.uat/plans/35-sidebar-polish.md\` (A1, A2, B1-3, C1-2, D1) | 7 F / 1 P | 8 P / 0 F |
| #234  | \`.uat/plans/36-person-dedup-ux.md\` (0, A1-3, B1-3, C1, D1-4, E1) | 9 F / 4 P | 13 P / 0 F |
| #255  | \`.uat/plans/37-publish-toggle.md\` (A1-3, B0-2) | 3 F / 2 P | 6 P / 0 F |
| #235  | \`.uat/plans/38-add-entry-direct.md\` (A1-2, 0, B1-2, C1) | 3 F / 2 P | 6 P / 0 F |
| #240  | \`.uat/plans/39-wiki-structure-rename.md\` (A1-2, B1-4) | 6 F / 0 P | 6 P / 0 F |

## New core endpoints

- **POST /people** — body \`{ name, aliases?, relationship? }\` → 201 with \`verified=true\`/\`state=RESOLVED\`. 409 on duplicate canonical name.
- **POST /people/:id/merge** — body \`{ targetPersonId }\`. Repoints \`FRAGMENT_MENTIONS_PERSON\` edges, unions aliases, rewrites \`[[person:source-slug]]\` tokens in non-deleted wiki bodies, soft-deletes source, audits with delta.
- **POST /fragments/log** — body \`{ content, threadSlug, title?, tags? }\` mirrors MCP \`log_fragment\` (classifier-bypass path) for the send-direct-to-wiki feature. Reuses \`handleLogFragment\`.

## Files (high level)

- **wiki/src/components/layout/**: Sidebar.tsx, Header.tsx, AddPersonModal.tsx (NEW), AddEntryModal.tsx, AddWikiModal.tsx, PersonSettingsModal.tsx
- **wiki/src/components/wiki/**: WikiEntityArticle.tsx
- **wiki/src/app/**: profile/page.tsx, wiki/[id]/page.tsx
- **wiki/src/lib/**: autoDatePrefix.ts (NEW), wikiSettingsPrefill.ts
- **core/src/routes/**: people.ts, fragments.ts
- **core/src/schemas/**: people.schema.ts, fragments.schema.ts
- **core/src/db/**: slug.ts

LOC: +1882 / −247 across 21 files.

## Open follow-ups

- People merge SQL uses literal \`replace()\` on body text (not regex). Acceptable here — \`[[person:slug]]\` tokens are unambiguous and slug regex disallows special chars. If we ever expand the token grammar, regex would be safer.
- Publish toggle calls \`publishWiki\`/\`unpublishWiki\` eagerly (not gated by modal Save) — matched the \"toggle\" UX intent. If review wants gated save, the change is small.
- \`wikis.prompt\` storage NOT changed (memory note); only UI label and shape (popup → inline textarea + Revert).

Closes #250
Closes #234
Closes #255
Closes #235
Closes #240