### PR TITLE
feat(wiki-types): structure-first-class + Roles/Skill sections + tightened rules + prose-not-chips + collection/principles renames

### DIFF
--- a/.uat/plans/41-per-wiki-structure-first-class.md
+++ b/.uat/plans/41-per-wiki-structure-first-class.md
@@ -1,0 +1,151 @@
+# 41 — Per-wiki structure as a first-class field (#244)
+
+## What it proves
+
+Wiki document structure is decoupled from the writing prompt:
+
+1. **Schema field** — every wiki-type YAML has a `default_structure`
+   string field, separate from `template`/`system_message`.
+2. **Template placeholder** — every wiki-type YAML's `template` body uses
+   the `{{structure}}` placeholder where the hardcoded `[DOCUMENT
+   STRUCTURE]` block used to live.
+3. **Storage sibling** — `wikis.structure` column exists in the schema
+   and migration; it's a SIBLING of `wikis.prompt`, not a replacement.
+4. **Resolution** — `loadWikiGenerationSpec` resolves `{{structure}}`
+   from a per-wiki override OR the type's `default_structure`.
+5. **Negative** — the literal `[DOCUMENT STRUCTURE]\n  Use this exact
+   structure:` text is no longer in the rendered prompt body of any
+   wiki-type yaml (it now lives in `default_structure`, not the body).
+
+## Prerequisites
+
+- repo root with `packages/shared/src/prompts/specs/wiki-types/*.yaml`
+- `grep`, `awk`, `node`
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+skip() { echo "  skip $1"; }
+
+echo "41 — Per-wiki structure as a first-class field (#244)"
+
+YAML_DIR=packages/shared/src/prompts/specs/wiki-types
+SCHEMA=packages/shared/src/prompts/schema.ts
+LOADER=packages/shared/src/prompts/loaders/wiki-generation.ts
+DB_SCHEMA=core/src/db/schema.ts
+MIGRATIONS_DIR=core/drizzle/migrations
+REGEN=core/src/lib/regen.ts
+
+# ── A. POSITIVE — default_structure field on every wiki-type yaml ───
+yamls=( agent belief collection decision log objective principles project skill voice )
+for slug in "${yamls[@]}"; do
+  if grep -qE '^default_structure:' "$YAML_DIR/$slug.yaml"; then
+    pass "A1.$slug yaml has top-level default_structure: field"
+  else
+    fail "A1.$slug yaml is MISSING default_structure: field"
+  fi
+done
+
+# ── A2. POSITIVE — {{structure}} mustache present in every yaml template ──
+for slug in "${yamls[@]}"; do
+  if grep -qF '{{structure}}' "$YAML_DIR/$slug.yaml"; then
+    pass "A2.$slug yaml template references {{structure}}"
+  else
+    fail "A2.$slug yaml does NOT reference {{structure}}"
+  fi
+done
+
+# ── A3. POSITIVE — schema declares default_structure ──
+if grep -qE 'default_structure' "$SCHEMA"; then
+  pass "A3. PromptSpecSchema declares default_structure"
+else
+  fail "A3. PromptSpecSchema is MISSING default_structure declaration"
+fi
+
+# ── A4. POSITIVE — wikis.structure column in db schema ──
+if grep -qE "structure: text\('structure'\)" "$DB_SCHEMA"; then
+  pass "A4. wikis.structure column declared in schema.ts"
+else
+  fail "A4. wikis.structure column NOT declared in schema.ts"
+fi
+
+# ── A5. POSITIVE — migration adds wikis.structure ──
+if grep -RqE 'ALTER TABLE "wikis" ADD COLUMN.*"structure"' "$MIGRATIONS_DIR"; then
+  pass "A5. migration adds wikis.structure column"
+else
+  fail "A5. no migration adds wikis.structure"
+fi
+
+# ── A6. POSITIVE — loader resolves {{structure}} from override OR default_structure ──
+if grep -qE 'structure' "$LOADER"; then
+  pass "A6. loader (wiki-generation.ts) references structure"
+else
+  fail "A6. loader does NOT reference structure"
+fi
+
+# ── A7. POSITIVE — regen passes wiki.structure into vars (override path) ──
+if grep -qE 'wiki\.structure|structure:' "$REGEN" | head -n1; then
+  pass "A7. regen.ts wires wiki.structure"
+else
+  fail "A7. regen.ts does NOT wire wiki.structure"
+fi
+
+# ── B. NEGATIVE — hardcoded headings removed from template body ──
+# The template body (everything after `template: |`) should reference
+# {{structure}} and NOT contain the per-type ## heading literals. We
+# slice out the template body via awk, then assert no `## ` heading
+# strings appear in it (apart from {{structure}} placeholder).
+for slug in "${yamls[@]}"; do
+  body=$(awk '/^template: \|$/{f=1;next} /^input_variables:/{f=0} f' "$YAML_DIR/$slug.yaml")
+  # Heading should NOT appear in template body — it has migrated to default_structure.
+  if echo "$body" | grep -qE '^\s*## '; then
+    fail "B1.$slug template body still contains hardcoded '## ' headings (structure should be in default_structure now)"
+  else
+    pass "B1.$slug template body has no hardcoded '## ' headings"
+  fi
+done
+
+# ── B2. NEGATIVE — yaml templates do not contain hand-typed `## Goal` etc. headings in template body ──
+# Heuristic: the template body, after we extract default_structure away, should not still
+# contain the per-type heading. Pick one canonical heading per type to assert.
+declare -A canonical_h2
+canonical_h2[agent]='## Purpose'
+canonical_h2[belief]='## The Position'
+canonical_h2[collection]='## Items'
+canonical_h2[decision]='## The Decision'
+canonical_h2[log]='## Timeline'
+canonical_h2[objective]='## Key Results'
+canonical_h2[principles]='## Core Principles'
+canonical_h2[project]='## Goal'
+canonical_h2[skill]='## Core Techniques'
+canonical_h2[voice]='## Tone and Style'
+for slug in "${yamls[@]}"; do
+  heading="${canonical_h2[$slug]}"
+  # The heading should appear in default_structure section but NOT in the template:
+  # We approximate by counting occurrences — exactly 1 (in default_structure block).
+  count=$(grep -cF "$heading" "$YAML_DIR/$slug.yaml" || true)
+  if [ "$count" -eq 1 ]; then
+    pass "B2.$slug heading '$heading' appears exactly once (in default_structure)"
+  else
+    fail "B2.$slug heading '$heading' appears $count times (expected 1)"
+  fi
+done
+
+# ── B3. NEGATIVE — wikis.prompt is NOT removed (sibling, not replacement) ──
+if grep -qE "prompt: text\('prompt'\)" "$DB_SCHEMA"; then
+  pass "B3. wikis.prompt column still present (sibling preserved)"
+else
+  fail "B3. wikis.prompt column removed — this would break #244 sibling rule"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+exit "$FAIL"
+```

--- a/.uat/plans/41-per-wiki-structure-first-class.md
+++ b/.uat/plans/41-per-wiki-structure-first-class.md
@@ -44,7 +44,7 @@ MIGRATIONS_DIR=core/drizzle/migrations
 REGEN=core/src/lib/regen.ts
 
 # ── A. POSITIVE — default_structure field on every wiki-type yaml ───
-yamls=( agent belief collection decision log objective principles project skill voice )
+yamls=( agent belief research decision log objective principle project skill voice )
 for slug in "${yamls[@]}"; do
   if grep -qE '^default_structure:' "$YAML_DIR/$slug.yaml"; then
     pass "A1.$slug yaml has top-level default_structure: field"
@@ -118,11 +118,11 @@ done
 declare -A canonical_h2
 canonical_h2[agent]='## Purpose'
 canonical_h2[belief]='## The Position'
-canonical_h2[collection]='## Items'
+canonical_h2[research]='## Sources'
 canonical_h2[decision]='## The Decision'
 canonical_h2[log]='## Timeline'
 canonical_h2[objective]='## Key Results'
-canonical_h2[principles]='## Core Principles'
+canonical_h2[principle]='## The Principle'
 canonical_h2[project]='## Goal'
 canonical_h2[skill]='## Core Techniques'
 canonical_h2[voice]='## Tone and Style'

--- a/.uat/plans/42-roles-and-skill-steps-sections.md
+++ b/.uat/plans/42-roles-and-skill-steps-sections.md
@@ -1,0 +1,97 @@
+# 42 — `## Roles` + `## The Skill, Step by Step` sections (#248)
+
+## What it proves
+
+Two surgical additions to wiki-type default_structure fields:
+
+1. **project.yaml** — `default_structure` declares a `## Roles`
+   section between Status and Progress (or anywhere — assertion is
+   presence + position).
+2. **skill.yaml** — `default_structure` declares a
+   `## The Skill, Step by Step` section.
+
+Stacks on #244 (default_structure must already exist).
+
+## Prerequisites
+
+- `default_structure` field present on every yaml (#244).
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+
+echo "42 — Roles + Skill steps sections (#248)"
+
+YAML_DIR=packages/shared/src/prompts/specs/wiki-types
+
+# Extract the default_structure block (everything between
+# `default_structure: |` and the next top-level YAML key).
+extract_default_structure() {
+  awk '/^default_structure: \|$/{f=1;next} /^[a-zA-Z_]+:/{f=0} f' "$1"
+}
+
+# ── A. POSITIVE — project.yaml has ## Roles in default_structure ──
+PROJECT_DS=$(extract_default_structure "$YAML_DIR/project.yaml")
+if echo "$PROJECT_DS" | grep -qE '^\s*## Roles\b'; then
+  pass "A1. project.yaml default_structure declares '## Roles'"
+else
+  fail "A1. project.yaml default_structure is MISSING '## Roles'"
+fi
+
+# ── A2. POSITIVE — skill.yaml has ## The Skill, Step by Step in default_structure ──
+SKILL_DS=$(extract_default_structure "$YAML_DIR/skill.yaml")
+if echo "$SKILL_DS" | grep -qE '^\s*## The Skill, Step by Step\b'; then
+  pass "A2. skill.yaml default_structure declares '## The Skill, Step by Step'"
+else
+  fail "A2. skill.yaml default_structure is MISSING '## The Skill, Step by Step'"
+fi
+
+# ── A3. POSITIVE — heading ordering: project Roles appears AFTER Status ──
+if awk '/## Status/{s=1} s && /## Roles/{print "ok"; exit}' "$YAML_DIR/project.yaml" | grep -q ok; then
+  pass "A3. project.yaml '## Roles' appears AFTER '## Status'"
+else
+  fail "A3. project.yaml '## Roles' does NOT appear after '## Status'"
+fi
+
+# ── A4. POSITIVE — skill steps appear AFTER Core Techniques ──
+if awk '/## Core Techniques/{s=1} s && /## The Skill, Step by Step/{print "ok"; exit}' "$YAML_DIR/skill.yaml" | grep -q ok; then
+  pass "A4. skill.yaml steps section appears AFTER '## Core Techniques'"
+else
+  fail "A4. skill.yaml steps section does NOT appear after '## Core Techniques'"
+fi
+
+# ── B. NEGATIVE — sections do NOT appear in template body (must live in default_structure) ──
+PROJECT_BODY=$(awk '/^template: \|$/{f=1;next} /^input_variables:/{f=0} f' "$YAML_DIR/project.yaml")
+if echo "$PROJECT_BODY" | grep -qE '^\s*## Roles\b'; then
+  fail "B1. project.yaml template body STILL contains '## Roles' (should only live in default_structure)"
+else
+  pass "B1. project.yaml template body has no inline '## Roles'"
+fi
+
+SKILL_BODY=$(awk '/^template: \|$/{f=1;next} /^input_variables:/{f=0} f' "$YAML_DIR/skill.yaml")
+if echo "$SKILL_BODY" | grep -qE '^\s*## The Skill, Step by Step\b'; then
+  fail "B2. skill.yaml template body STILL contains '## The Skill, Step by Step'"
+else
+  pass "B2. skill.yaml template body has no inline '## The Skill, Step by Step'"
+fi
+
+# ── B3. NEGATIVE — other yamls DON'T grow these sections by accident ──
+for slug in agent belief collection decision log objective principles voice; do
+  if grep -qE '## Roles\b|## The Skill, Step by Step' "$YAML_DIR/$slug.yaml"; then
+    fail "B3.$slug yaml unexpectedly grew a Roles or Steps heading"
+  else
+    pass "B3.$slug yaml is unaffected (no Roles/Steps)"
+  fi
+done
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+exit "$FAIL"
+```

--- a/.uat/plans/43-tighten-wiki-writing-rules.md
+++ b/.uat/plans/43-tighten-wiki-writing-rules.md
@@ -36,7 +36,7 @@ fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
 echo "43 — Tighten wiki-writing rules (#254)"
 
 YAML_DIR=packages/shared/src/prompts/specs/wiki-types
-yamls=( agent belief collection decision log objective principles project skill voice )
+yamls=( agent belief research decision log objective principle project skill voice )
 
 # Per-type sentinel strings that USED TO live in rule 3 (the layout-shape
 # rule we're killing). After the fix, NONE of these should appear in the
@@ -44,11 +44,11 @@ yamls=( agent belief collection decision log objective principles project skill 
 declare -A killed_rule3
 killed_rule3[agent]='Focus on configuration details and performance observations'
 killed_rule3[belief]='Present the position clearly, then supporting evidence'
-killed_rule3[collection]='Group items by sub-theme where it aids organization'
+killed_rule3[research]='Group items by sub-theme where it aids organization'
 killed_rule3[decision]='Present the decision first, then context and reasoning'
 killed_rule3[log]='Organize entries chronologically, most recent last'
 killed_rule3[objective]='Focus on measurable outcomes and progress signals'
-killed_rule3[principles]='State each principle as a clear commitment'
+killed_rule3[principle]='State each principle as a clear commitment'
 killed_rule3[project]='Reflect the current state of the project from the fragments'
 killed_rule3[skill]='Focus on actionable techniques and practical knowledge'
 killed_rule3[voice]='Focus on concrete language patterns and style observations'

--- a/.uat/plans/43-tighten-wiki-writing-rules.md
+++ b/.uat/plans/43-tighten-wiki-writing-rules.md
@@ -1,0 +1,124 @@
+# 43 — Tighten wiki-writing rules (#254)
+
+## What it proves
+
+Three coordinated edits to the [RULES — READ CAREFULLY] block of every
+wiki-type yaml:
+
+1. **Drop hardcoded layout rule 3** — the current rule 3 in each yaml
+   restates layout-shape content (e.g. "Organize entries chronologically",
+   "Present the decision first") that is now driven by `{{structure}}`.
+   Removing it eliminates duplicate sources of truth.
+2. **Strengthen structure-as-source-of-truth language** — rule 2 should
+   explicitly call out the [DOCUMENT STRUCTURE] block as the canonical
+   layout authority. The literal phrase "structure block is the source
+   of truth" should appear in every yaml.
+3. **Tighten chip-discipline rule** — the infobox rule (currently rule 11)
+   should explicitly forbid restating the same value as a markdown chip
+   in the body. The literal phrase "do not duplicate" or
+   "Do not restate infobox values" should appear in the rule.
+
+## Prerequisites
+
+- #244 + #248 already merged.
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+
+echo "43 — Tighten wiki-writing rules (#254)"
+
+YAML_DIR=packages/shared/src/prompts/specs/wiki-types
+yamls=( agent belief collection decision log objective principles project skill voice )
+
+# Per-type sentinel strings that USED TO live in rule 3 (the layout-shape
+# rule we're killing). After the fix, NONE of these should appear in the
+# yaml's [RULES] block.
+declare -A killed_rule3
+killed_rule3[agent]='Focus on configuration details and performance observations'
+killed_rule3[belief]='Present the position clearly, then supporting evidence'
+killed_rule3[collection]='Group items by sub-theme where it aids organization'
+killed_rule3[decision]='Present the decision first, then context and reasoning'
+killed_rule3[log]='Organize entries chronologically, most recent last'
+killed_rule3[objective]='Focus on measurable outcomes and progress signals'
+killed_rule3[principles]='State each principle as a clear commitment'
+killed_rule3[project]='Reflect the current state of the project from the fragments'
+killed_rule3[skill]='Focus on actionable techniques and practical knowledge'
+killed_rule3[voice]='Focus on concrete language patterns and style observations'
+
+# Helper — slice the [RULES — READ CAREFULLY] block.
+extract_rules() {
+  awk '/\[RULES — READ CAREFULLY\]/{f=1;next} /\[CITATIONS — PER SECTION/{f=0} f' "$1"
+}
+
+# ── A. NEGATIVE — rule-3 hardcoded layout language is gone ──
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  needle="${killed_rule3[$slug]}"
+  if echo "$RULES" | grep -qF "$needle"; then
+    fail "A1.$slug RULES block STILL contains rule-3 layout text: '$needle'"
+  else
+    pass "A1.$slug rule-3 layout text removed"
+  fi
+done
+
+# ── A2. NEGATIVE — literal '  3. ' rule numbering is gone (rules now start at 2 or jump ─
+# Actually after killing rule 3 we'd renumber 4..n down by 1. So '  3. '
+# can still exist (it's the new rule 4). Instead assert the structure-of-truth
+# language is the new rule 2 follow-up.
+
+# ── B. POSITIVE — structure-as-source-of-truth language present ──
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  if echo "$RULES" | grep -qE 'source of truth'; then
+    pass "B1.$slug structure source-of-truth phrase present"
+  else
+    fail "B1.$slug structure source-of-truth phrase MISSING"
+  fi
+done
+
+# ── C. POSITIVE — tightened chip discipline ──
+# Match "Do not\n duplicate" across lines using awk + state.
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  hit=$(echo "$RULES" | awk '
+    /[Dd]o not[[:space:]]*$/ { prev=1; next }
+    prev && /^[[:space:]]+duplicate/ { print "ok"; exit }
+    /[Dd]o not duplicate/ { print "ok"; exit }
+    /[Dd]o not[[:space:]]+(re)?state/ { print "ok"; exit }
+    { prev=0 }
+  ')
+  if [ "$hit" = "ok" ]; then
+    pass "C1.$slug chip-discipline tightened"
+  else
+    fail "C1.$slug chip-discipline NOT tightened"
+  fi
+done
+
+# ── D. NEGATIVE — rule numbering is sequential after dropping rule 3 ──
+# After dropping rule 3 + renumbering, rules 1..N must be present in order
+# in each yaml. We pull all top-level numbered lines and sanity-check.
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  # Extract leading "N." numbers from numbered list lines
+  nums=$(echo "$RULES" | grep -oE '^\s*[0-9]+\.' | grep -oE '[0-9]+' | tr '\n' ' ')
+  # Expect first three to be: 1 2 3 (sequence), allowing pause for sub-bullets
+  first3=$(echo "$nums" | awk '{print $1, $2, $3}')
+  if [ "$first3" = "1 2 3" ]; then
+    pass "D1.$slug rule numbering starts 1 2 3"
+  else
+    fail "D1.$slug rule numbering does NOT start 1 2 3 (got: $first3)"
+  fi
+done
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+exit "$FAIL"
+```

--- a/.uat/plans/44-prose-not-chips.md
+++ b/.uat/plans/44-prose-not-chips.md
@@ -32,7 +32,7 @@ skip() { echo "  skip $1"; }
 echo "44 — Prose, not chips (#243)"
 
 YAML_DIR=packages/shared/src/prompts/specs/wiki-types
-yamls=( agent belief collection decision log objective principles project skill voice )
+yamls=( agent belief research decision log objective principle project skill voice )
 
 extract_rules() {
   awk '/\[RULES — READ CAREFULLY\]/{f=1;next} /\[CITATIONS — PER SECTION/{f=0} f' "$1"

--- a/.uat/plans/44-prose-not-chips.md
+++ b/.uat/plans/44-prose-not-chips.md
@@ -1,0 +1,80 @@
+# 44 — Prose, not chips: weave fragments into sentences (#243)
+
+## What it proves
+
+Each wiki-type yaml's [RULES] block tells Quill to weave fragment
+content into prose. Quill must NOT bare-string the fragment title as a
+chip in the markdown body.
+
+POSITIVE: every yaml's RULES block contains a "weave" or "synthesize"
+or "into prose" directive plus an explicit prohibition against
+emitting bare fragment titles as chips.
+
+NEGATIVE: no yaml says "use the title as a chip" or any analogous
+phrase.
+
+## Prerequisites
+
+- #244 / #248 / #254 already merged.
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+skip() { echo "  skip $1"; }
+
+echo "44 — Prose, not chips (#243)"
+
+YAML_DIR=packages/shared/src/prompts/specs/wiki-types
+yamls=( agent belief collection decision log objective principles project skill voice )
+
+extract_rules() {
+  awk '/\[RULES — READ CAREFULLY\]/{f=1;next} /\[CITATIONS — PER SECTION/{f=0} f' "$1"
+}
+
+# ── A. POSITIVE — weave-into-prose directive present in every yaml ──
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  # Match weave/synthesize/into prose anywhere in the rules block.
+  if echo "$RULES" | grep -qiE 'weave|into prose|synthesi[sz]e'; then
+    pass "A1.$slug rules invoke 'weave/synthesize/into prose'"
+  else
+    fail "A1.$slug rules MISSING weave/synthesize/into prose directive"
+  fi
+done
+
+# ── A2. POSITIVE — explicit anti-chip language for fragment titles ──
+for slug in "${yamls[@]}"; do
+  RULES=$(extract_rules "$YAML_DIR/$slug.yaml")
+  if echo "$RULES" | grep -qiE 'fragment title|bare.*title|title as a chip|do not.*chip'; then
+    pass "A2.$slug rules forbid emitting fragment titles as chips"
+  else
+    fail "A2.$slug rules do NOT forbid bare fragment titles as chips"
+  fi
+done
+
+# ── B. NEGATIVE — no yaml encourages bare-title chip rendering ──
+for slug in "${yamls[@]}"; do
+  if grep -qiE 'use the title as a chip|emit.*title.*as a chip' "$YAML_DIR/$slug.yaml"; then
+    fail "B1.$slug yaml unexpectedly encourages bare-title chip rendering"
+  else
+    pass "B1.$slug yaml does NOT encourage bare-title chips"
+  fi
+done
+
+# ── C. SKIP — prose-quality assertion (Quill output adheres) ──
+# Asserting "the rendered wiki body weaves fragment content into sentences"
+# requires running the LLM and parsing markdown. This is prose quality, not
+# structural shape — out of scope for bash. Pre-fix this would be unverifiable.
+skip "C1. prose-quality (Quill output weaves fragments) — runtime/LLM, not bash"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+exit "$FAIL"
+```

--- a/.uat/plans/45-type-renames.md
+++ b/.uat/plans/45-type-renames.md
@@ -1,0 +1,210 @@
+# 45 — Wiki type renames: collection→research, principles→principle (#247)
+
+## What it proves
+
+The two wiki types are renamed end-to-end:
+
+1. YAML filenames: `research.yaml`, `principle.yaml` (singular).
+2. YAML internal fields: `display_label` and `description` reflect
+   the new names; `task:` token uses the new slug.
+3. Codebase references across `core/src/`, `packages/agent/src/`,
+   `packages/shared/src/` all use the new identifiers.
+4. A migration exists that updates the seeded `wiki_types` table
+   (single-tenant — no `user_id`).
+
+POSITIVE: presence of `research`, `principle` in code + yaml + migration.
+
+NEGATIVE: literal `collection` / `principles` strings absent from
+yaml filenames, the `WikiType` union, the `WIKI_TYPE_TO_GUIDE_KEY`
+map, the schemaMap, the `WIKI_TYPE_DESCRIPTORS` map, and
+`DEFAULT_WIKIS`.
+
+## Prerequisites
+
+- prior issues already merged.
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+
+echo "45 — Type renames collection→research, principles→principle (#247)"
+
+YAML_DIR=packages/shared/src/prompts/specs/wiki-types
+WIKI_TYPES_TS=packages/shared/src/types/wiki.ts
+CONFIG_TS=packages/shared/src/types/config.ts
+LOADER=packages/shared/src/prompts/loaders/wiki-generation.ts
+INFERENCE=core/src/mcp/wiki-type-inference.ts
+
+# ── A. POSITIVE — new yaml files exist ──
+if [ -f "$YAML_DIR/research.yaml" ]; then
+  pass "A1. research.yaml exists"
+else
+  fail "A1. research.yaml MISSING"
+fi
+if [ -f "$YAML_DIR/principle.yaml" ]; then
+  pass "A2. principle.yaml exists"
+else
+  fail "A2. principle.yaml MISSING"
+fi
+
+# ── A3. POSITIVE — new schema files exist ──
+if [ -f "$YAML_DIR/research.schema.ts" ]; then
+  pass "A3. research.schema.ts exists"
+else
+  fail "A3. research.schema.ts MISSING"
+fi
+if [ -f "$YAML_DIR/principle.schema.ts" ]; then
+  pass "A4. principle.schema.ts exists"
+else
+  fail "A4. principle.schema.ts MISSING"
+fi
+
+# ── A5. POSITIVE — WikiType union contains the new slugs ──
+if grep -qE "'research'" "$WIKI_TYPES_TS"; then
+  pass "A5. WikiType union contains 'research'"
+else
+  fail "A5. WikiType union does NOT contain 'research'"
+fi
+if grep -qE "'principle'\$|'principle'\b" "$WIKI_TYPES_TS"; then
+  pass "A6. WikiType union contains 'principle'"
+else
+  fail "A6. WikiType union does NOT contain 'principle'"
+fi
+
+# ── A7. POSITIVE — schemaMap uses new slugs ──
+if grep -qE 'research:' "$LOADER"; then
+  pass "A7. wiki-generation schemaMap has 'research'"
+else
+  fail "A7. wiki-generation schemaMap MISSING 'research'"
+fi
+if grep -qE 'principle:' "$LOADER"; then
+  pass "A8. wiki-generation schemaMap has 'principle'"
+else
+  fail "A8. wiki-generation schemaMap MISSING 'principle'"
+fi
+
+# ── A9. POSITIVE — descriptor map updated ──
+if grep -qE 'research:' "$INFERENCE"; then
+  pass "A9. inference descriptor map has 'research'"
+else
+  fail "A9. inference descriptor map MISSING 'research'"
+fi
+if grep -qE 'principle:' "$INFERENCE"; then
+  pass "A10. inference descriptor map has 'principle'"
+else
+  fail "A10. inference descriptor map MISSING 'principle'"
+fi
+
+# ── A11. POSITIVE — guide keys updated ──
+if grep -qE "wiki-guide-research" "$CONFIG_TS"; then
+  pass "A11. WIKI_TYPE_TO_GUIDE_KEY has wiki-guide-research"
+else
+  fail "A11. WIKI_TYPE_TO_GUIDE_KEY MISSING wiki-guide-research"
+fi
+if grep -qE "wiki-guide-principle\b" "$CONFIG_TS"; then
+  pass "A12. WIKI_TYPE_TO_GUIDE_KEY has wiki-guide-principle"
+else
+  fail "A12. WIKI_TYPE_TO_GUIDE_KEY MISSING wiki-guide-principle"
+fi
+
+# ── A13. POSITIVE — migration adds rename ──
+MIG_DIR=core/drizzle/migrations
+if grep -RqE "UPDATE.*wiki_types.*SET.*slug.*= 'research'" "$MIG_DIR" || \
+   grep -RqE "research" "$MIG_DIR"; then
+  pass "A13. migration references 'research'"
+else
+  fail "A13. no migration references 'research'"
+fi
+if grep -RqE "UPDATE.*wiki_types.*SET.*slug.*= 'principle'" "$MIG_DIR" || \
+   grep -RqE "wiki_types.*principle" "$MIG_DIR"; then
+  pass "A14. migration references 'principle'"
+else
+  fail "A14. no migration references singular 'principle'"
+fi
+
+# ── B. NEGATIVE — old slug filenames are gone ──
+if [ ! -e "$YAML_DIR/collection.yaml" ]; then
+  pass "B1. collection.yaml is gone"
+else
+  fail "B1. collection.yaml STILL exists"
+fi
+if [ ! -e "$YAML_DIR/principles.yaml" ]; then
+  pass "B2. principles.yaml is gone"
+else
+  fail "B2. principles.yaml STILL exists"
+fi
+
+# ── B3. NEGATIVE — old slug not in WikiType union ──
+# Slice the WikiType type-union block (between `export type WikiType =`
+# and the next `export`).
+UNION_BLOCK=$(awk '/export type WikiType =/{f=1} f; /^export (interface|const)/{if(f){f=0}}' "$WIKI_TYPES_TS")
+if echo "$UNION_BLOCK" | grep -qE "\| 'collection'"; then
+  fail "B3. WikiType union STILL contains 'collection'"
+else
+  pass "B3. WikiType union no longer contains 'collection'"
+fi
+if echo "$UNION_BLOCK" | grep -qE "\| 'principles'"; then
+  fail "B4. WikiType union STILL contains 'principles' as a type variant"
+else
+  pass "B4. WikiType union no longer contains 'principles' as a type variant"
+fi
+
+# ── B5. NEGATIVE — old slug not in schemaMap (loader) ──
+if grep -qE "^[[:space:]]*collection:" "$LOADER"; then
+  fail "B5. wiki-generation schemaMap STILL has 'collection:'"
+else
+  pass "B5. wiki-generation schemaMap no longer has 'collection:'"
+fi
+if grep -qE "^[[:space:]]*principles:" "$LOADER"; then
+  fail "B6. wiki-generation schemaMap STILL has 'principles:'"
+else
+  pass "B6. wiki-generation schemaMap no longer has 'principles:'"
+fi
+
+# ── B7. NEGATIVE — old slug not in descriptor map ──
+if grep -qE "^[[:space:]]*collection:" "$INFERENCE"; then
+  fail "B7. inference descriptor map STILL has 'collection:'"
+else
+  pass "B7. inference descriptor map no longer has 'collection:'"
+fi
+if grep -qE "^[[:space:]]*principles:" "$INFERENCE"; then
+  fail "B8. inference descriptor map STILL has 'principles:'"
+else
+  pass "B8. inference descriptor map no longer has 'principles:'"
+fi
+
+# ── B9. NEGATIVE — config guide-key map old keys gone ──
+if grep -qE "wiki-guide-collection" "$CONFIG_TS"; then
+  fail "B9. config STILL has wiki-guide-collection"
+else
+  pass "B9. config no longer has wiki-guide-collection"
+fi
+if grep -qE "wiki-guide-principles\b" "$CONFIG_TS"; then
+  fail "B10. config STILL has wiki-guide-principles (plural)"
+else
+  pass "B10. config no longer has wiki-guide-principles (plural)"
+fi
+
+# ── B11. NEGATIVE — yaml internal fields don't say Collection/Principles ──
+if grep -qE 'display_label: "Collection"' "$YAML_DIR/research.yaml"; then
+  fail "B11. research.yaml display_label still says 'Collection'"
+else
+  pass "B11. research.yaml display_label rewritten"
+fi
+if grep -qE 'display_label: "Principles"' "$YAML_DIR/principle.yaml"; then
+  fail "B12. principle.yaml display_label still says 'Principles' (plural)"
+else
+  pass "B12. principle.yaml display_label rewritten"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+exit "$FAIL"
+```

--- a/core/drizzle/migrations/0011_wikis_add_structure.sql
+++ b/core/drizzle/migrations/0011_wikis_add_structure.sql
@@ -1,0 +1,7 @@
+-- #244 — promote per-wiki document structure to a first-class field.
+-- Sibling of wikis.prompt (which is the system_message override): this
+-- column carries the user's override for the wiki-type's default_structure
+-- block, which the wiki-generation template now substitutes via the
+-- {{structure}} placeholder. Empty string means "fall back to the type
+-- default declared in the YAML spec".
+ALTER TABLE "wikis" ADD COLUMN IF NOT EXISTS "structure" text NOT NULL DEFAULT '';

--- a/core/drizzle/migrations/0012_wiki_types_rename_collection_principles.sql
+++ b/core/drizzle/migrations/0012_wiki_types_rename_collection_principles.sql
@@ -1,0 +1,22 @@
+-- #247 — rename wiki types: collection → research, principles → principle.
+-- wiki_types is permanently single-tenant (no user_id), so the rows we care
+-- about are the seeded defaults plus any user-modified copies. We do an
+-- in-place UPDATE rather than DELETE+reseed: the seed-wiki-types boot step
+-- preserves user_modified=true rows by slug, so changing the slug under it
+-- would silently DROP the user's customizations on the old slug.
+--
+-- Companion code change: WikiType union now lists 'research' / 'principle'
+-- (not 'collection' / 'principles'). Any FK-style references in `wikis.type`
+-- must be updated too — otherwise the next regen would fail to load the
+-- per-type yaml spec.
+
+-- Update wiki_types primary identifier.
+UPDATE wiki_types SET slug = 'research'  WHERE slug = 'collection';
+UPDATE wiki_types SET slug = 'principle' WHERE slug = 'principles';
+
+-- Update existing wikis.type values that reference the old slugs.
+-- wikis.type is a free-text column (no FK), but the application treats it
+-- as one of the WikiType enum values; bringing them back into the enum
+-- keeps regen / classification / preview rendering all consistent.
+UPDATE wikis SET type = 'research'  WHERE type = 'collection';
+UPDATE wikis SET type = 'principle' WHERE type = 'principles';

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778112000000,
       "tag": "0010_backfill_zombie_edges",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0011_wikis_add_structure",
+      "breakpoints": true
     }
   ]
 }

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778198400000,
       "tag": "0011_wikis_add_structure",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778284800000,
+      "tag": "0012_wiki_types_rename_collection_principles",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/__tests__/mcp-create-wiki.test.ts
+++ b/core/src/__tests__/mcp-create-wiki.test.ts
@@ -125,17 +125,17 @@ describe('handleCreateWiki — issue #154', () => {
   it('falls through to inferWikiType when `type` is omitted (regression guard)', async () => {
     const { db, insertCaptured } = makeDb(undefined)
     const deps = makeDeps(db)
-    inferWikiTypeMock.mockReturnValueOnce('collection')
+    inferWikiTypeMock.mockReturnValueOnce('research')
     const res = await handleCreateWiki(
       deps,
-      { title: 'Foo', description: 'a curated library of related items' },
+      { title: 'Foo', description: 'a curated library of references and findings on a topic' },
       'user-1'
     )
     expect(res.isError).toBeUndefined()
     expect(inferWikiTypeMock).toHaveBeenCalledOnce()
-    expect(insertCaptured.values?.type).toBe('collection')
+    expect(insertCaptured.values?.type).toBe('research')
     const payload = JSON.parse((res.content[0] as { text: string }).text)
-    expect(payload.type).toBe('collection')
-    expect(payload.inferredType).toBe('collection')
+    expect(payload.type).toBe('research')
+    expect(payload.inferredType).toBe('research')
   })
 })

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -241,6 +241,14 @@ export const wikis = pgTable(
     description: text('description').notNull().default(''),
     type: text('type').notNull().default('log'),
     prompt: text('prompt').notNull().default(''),
+    /**
+     * Per-wiki document structure override (#244). Sibling of `prompt`
+     * (which still acts as a `system_message` override). When non-empty,
+     * `loadWikiGenerationSpec` substitutes this for the type's
+     * `default_structure` before rendering the `{{structure}}` placeholder.
+     * Empty string means "use the type default".
+     */
+    structure: text('structure').notNull().default(''),
     lastRebuiltAt: timestamp('last_rebuilt_at'),
     published: boolean('published').notNull().default(false),
     publishedSlug: text('published_slug'),

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -619,6 +619,9 @@ export async function regenerateWiki(
     existingWiki: previousContent || undefined,
     edits: editsSummary,
     relatedWikis: relatedWikisText,
+    // #244 — per-wiki structure override. Empty string means "fall back to
+    // the type's default_structure" — the loader handles the precedence.
+    structure: wiki.structure || undefined,
   }
 
   // Load prompt spec with runtime fallback on override parse/validation failure.

--- a/core/src/mcp/wiki-type-inference.ts
+++ b/core/src/mcp/wiki-type-inference.ts
@@ -6,16 +6,16 @@ import type { WikiType } from '@robin/shared'
  * inference works without loading YAML specs at runtime.
  */
 const WIKI_TYPE_DESCRIPTORS: Record<WikiType, string> = {
-  log:        'a chronological synthesis of events and observations',
-  collection: 'a curated library of related items',
-  belief:     'a synthesis of a held position or mental model',
-  decision:   'a record of a discrete choice and its reasoning',
-  project:    'a living document of an active initiative',
-  objective:  'a high-level objective with measurable direction',
-  skill:      'a knowledge base for a capability being built',
-  agent:      'documentation for a configured AI assistant',
-  voice:      'a style guide for communication',
-  principles: 'a document of operating rules and commitments',
+  log:       'a chronological synthesis of events and observations',
+  research:  'a curated library of references and findings on a topic',
+  belief:    'a synthesis of a held position or mental model',
+  decision:  'a record of a discrete choice and its reasoning',
+  project:   'a living document of an active initiative',
+  objective: 'a high-level objective with measurable direction',
+  skill:     'a knowledge base for a capability being built',
+  agent:     'documentation for a configured AI assistant',
+  voice:     'a style guide for communication',
+  principle: 'a document of an operating rule or commitment',
 }
 
 /**

--- a/core/src/routes/wiki-types.test.ts
+++ b/core/src/routes/wiki-types.test.ts
@@ -146,11 +146,11 @@ const WIKI_TYPES_DIR = resolve(
 const ALL_SLUGS = [
   'agent',
   'belief',
-  'collection',
+  'research',
   'decision',
   'log',
   'objective',
-  'principles',
+  'principle',
   'project',
   'skill',
   'voice',

--- a/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
+++ b/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
@@ -16,7 +16,7 @@ const wikiFixtures = {
 
 const allTypes: WikiType[] = [
   'log',
-  'collection',
+  'research',
   'belief',
   'decision',
   'project',
@@ -24,7 +24,7 @@ const allTypes: WikiType[] = [
   'skill',
   'agent',
   'voice',
-  'principles',
+  'principle',
 ]
 
 describe('wiki-types specs', () => {

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -95,6 +95,9 @@ const inputSchema = z.object({
   existingWiki: z.string().optional(),
   edits: z.string().optional(),
   relatedWikis: z.string().optional(),
+  // #244 — per-wiki structure override (wikis.structure). When present this
+  // wins over the type's default_structure. Resolved before render.
+  structure: z.string().optional(),
 })
 
 const schemaMap: Record<WikiType, z.ZodType> = {
@@ -140,6 +143,11 @@ export function loadWikiGenerationSpec(
     existingWiki?: string
     edits?: string
     relatedWikis?: string
+    /**
+     * #244 — per-wiki structure override (from `wikis.structure`). When
+     * non-empty, replaces the type's `default_structure` before render.
+     */
+    structure?: string
   },
   override?: WikiGenerationOverride,
 ): PromptResult {
@@ -165,7 +173,21 @@ export function loadWikiGenerationSpec(
     }
   }
 
-  const user = renderTemplate(effective.template, validated)
+  // Resolve {{structure}} — per-wiki override beats the type's
+  // default_structure. Render the resolved structure block through
+  // Handlebars first so it can interpolate `{{title}}` etc. (the
+  // structure block is still a sub-template, not opaque text). Empty-
+  // string fallback keeps the outer render safe if a malformed yaml
+  // omits both.
+  const overrideStructure = validated.structure?.trim()
+  const rawStructure =
+    overrideStructure && overrideStructure.length > 0
+      ? overrideStructure
+      : (effective.default_structure ?? '')
+  const resolvedStructure = renderTemplate(rawStructure, validated)
+
+  const renderVars = { ...validated, structure: resolvedStructure }
+  const user = renderTemplate(effective.template, renderVars)
   return {
     system: effective.system_message,
     user,

--- a/packages/shared/src/prompts/loaders/wiki-generation.ts
+++ b/packages/shared/src/prompts/loaders/wiki-generation.ts
@@ -4,7 +4,7 @@ import type { PromptResult } from '../types.js'
 import type { PromptSpec } from '../schema.js'
 import type { WikiType } from '../../types/wiki.js'
 import { logWikiSchema } from '../specs/wiki-types/log.schema.js'
-import { collectionWikiSchema } from '../specs/wiki-types/collection.schema.js'
+import { researchWikiSchema } from '../specs/wiki-types/research.schema.js'
 import { beliefWikiSchema } from '../specs/wiki-types/belief.schema.js'
 import { decisionWikiSchema } from '../specs/wiki-types/decision.schema.js'
 import { projectWikiSchema } from '../specs/wiki-types/project.schema.js'
@@ -12,7 +12,7 @@ import { objectiveWikiSchema } from '../specs/wiki-types/objective.schema.js'
 import { skillWikiSchema } from '../specs/wiki-types/skill.schema.js'
 import { agentWikiSchema } from '../specs/wiki-types/agent.schema.js'
 import { voiceWikiSchema } from '../specs/wiki-types/voice.schema.js'
-import { principlesWikiSchema } from '../specs/wiki-types/principles.schema.js'
+import { principleWikiSchema } from '../specs/wiki-types/principle.schema.js'
 
 /**
  * Shape a fragment row into the [FRAGMENTS] inline-slug format consumed by
@@ -102,7 +102,7 @@ const inputSchema = z.object({
 
 const schemaMap: Record<WikiType, z.ZodType> = {
   log: logWikiSchema,
-  collection: collectionWikiSchema,
+  research: researchWikiSchema,
   belief: beliefWikiSchema,
   decision: decisionWikiSchema,
   project: projectWikiSchema,
@@ -110,7 +110,7 @@ const schemaMap: Record<WikiType, z.ZodType> = {
   skill: skillWikiSchema,
   agent: agentWikiSchema,
   voice: voiceWikiSchema,
-  principles: principlesWikiSchema,
+  principle: principleWikiSchema,
 }
 
 /**

--- a/packages/shared/src/prompts/schema.ts
+++ b/packages/shared/src/prompts/schema.ts
@@ -27,6 +27,11 @@ export const PromptSpecSchema = z.object({
   temperature: z.number().min(0).max(2),
   system_message: z.string(),
   template: z.string(),
+  // First-class document-structure field (#244). Wiki-type YAMLs declare the
+  // canonical layout here; the template body references it as `{{structure}}`.
+  // Optional because non–wiki-type specs (fragmenter, classifier, etc.) don't
+  // use it. A per-wiki override is stored separately in `wikis.structure`.
+  default_structure: z.string().optional(),
   input_variables: z.array(InputVariableSchema),
   output: OutputSchema.optional(),
   few_shot_examples: z.array(FewShotSchema).optional(),

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -99,29 +99,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_agent
 description: Generates an agent wiki — documentation for a configured AI assistant.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Agent: {{title}}
+
+  ## Purpose
+  What this agent is for and what problem it solves.
+
+  ## Configuration
+  Current instructions, prompts, or settings.
+
+  ## Performance Notes
+  Observations about what works, what does not, and edge cases.
+
+  ## Iteration History
+  Changes made over time and the reasoning behind them.
+
+
 system_message: |
   You are Quill, writing as an agent documenter. Your job is to produce
   documentation for a configured AI assistant from thread fragments.
@@ -40,20 +57,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Agent: {{title}}
-
-  ## Purpose
-  What this agent is for and what problem it solves.
-
-  ## Configuration
-  Current instructions, prompts, or settings.
-
-  ## Performance Notes
-  Observations about what works, what does not, and edge cases.
-
-  ## Iteration History
-  Changes made over time and the reasoning behind them.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -198,6 +202,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -97,28 +97,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Focus on configuration details and performance observations.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -99,29 +99,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_belief
 description: Generates a belief wiki — a synthesis of a held position or mental model.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Belief: {{title}}
+
+  ## The Position
+  A clear statement of what is believed.
+
+  ## Evidence and Reasoning
+  What observations and reasoning support this belief.
+
+  ## Nuances and Exceptions
+  Where this belief breaks down or requires qualification.
+
+  ## How This Shapes Behavior
+  How this belief influences decisions or actions.
+
+
 system_message: |
   You are Quill, writing as an argument author. Your job is to produce
   a synthesis of a held position or mental model from thread fragments.
@@ -40,20 +57,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Belief: {{title}}
-
-  ## The Position
-  A clear statement of what is believed.
-
-  ## Evidence and Reasoning
-  What observations and reasoning support this belief.
-
-  ## Nuances and Exceptions
-  Where this belief breaks down or requires qualification.
-
-  ## How This Shapes Behavior
-  How this belief influences decisions or actions.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -198,6 +202,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -97,28 +97,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Present the position clearly, then supporting evidence.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/collection.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/collection.yaml
@@ -96,29 +96,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/collection.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/collection.yaml
@@ -9,6 +9,20 @@ task: thread_wiki_collection
 description: Generates a collection wiki — a curated library of related items.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Collection: {{title}}
+
+  ## Overview
+  What this collection is for and what connects the items.
+
+  ## Items
+  Organized list of items in this collection, grouped by sub-theme if helpful.
+
+  ## When to Use
+  When to reach for this collection.
+
+
 system_message: |
   You are Quill, writing as a curator. Your job is to produce a curated
   library document organizing related items from thread fragments.
@@ -40,17 +54,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Collection: {{title}}
-
-  ## Overview
-  What this collection is for and what connects the items.
-
-  ## Items
-  Organized list of items in this collection, grouped by sub-theme if helpful.
-
-  ## When to Use
-  When to reach for this collection.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -195,6 +199,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/collection.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/collection.yaml
@@ -94,28 +94,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Group items by sub-theme where it aids organization.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -102,29 +102,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -9,6 +9,26 @@ task: thread_wiki_decision
 description: Generates a decision wiki — a record of a discrete choice and its reasoning.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Decision: {{title}}
+
+  ## The Decision
+  What was decided, stated plainly.
+
+  ## Context
+  The situation and constraints that made this decision necessary.
+
+  ## Alternatives Considered
+  Other options that were evaluated and why they were rejected.
+
+  ## Outcome
+  What happened as a result.
+
+  ## Retrospective
+  Whether this decision held up and what was learned.
+
+
 system_message: |
   You are Quill, writing as a decision recorder. Your job is to produce
   a record of a discrete choice and its reasoning from thread fragments.
@@ -40,23 +60,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Decision: {{title}}
-
-  ## The Decision
-  What was decided, stated plainly.
-
-  ## Context
-  The situation and constraints that made this decision necessary.
-
-  ## Alternatives Considered
-  Other options that were evaluated and why they were rejected.
-
-  ## Outcome
-  What happened as a result.
-
-  ## Retrospective
-  Whether this decision held up and what was learned.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -202,6 +206,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -100,28 +100,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Present the decision first, then context and reasoning.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -99,29 +99,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_log
 description: Generates a log wiki — a chronological synthesis of events and observations.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Log: {{title}}
+
+  ## Overview
+  What period or domain this log covers.
+
+  ## Timeline
+  Chronological entries distilled from fragments, most recent last.
+
+  ## Recurring Themes
+  Patterns or topics that appear repeatedly across the log.
+
+  ## Open Items
+  Unresolved questions or actions surfaced in the log.
+
+
 system_message: |
   You are Quill, writing as a changelog author. Your job is to produce
   a chronological synthesis of events and observations from thread fragments.
@@ -40,20 +57,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Log: {{title}}
-
-  ## Overview
-  What period or domain this log covers.
-
-  ## Timeline
-  Chronological entries distilled from fragments, most recent last.
-
-  ## Recurring Themes
-  Patterns or topics that appear repeatedly across the log.
-
-  ## Open Items
-  Unresolved questions or actions surfaced in the log.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -198,6 +202,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -97,28 +97,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Organize entries chronologically, most recent last.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_objective
 description: Generates an objective wiki — a high-level objective with measurable direction.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Objective: {{title}}
+
+  ## The Objective
+  What the desired outcome is and why it matters.
+
+  ## Key Results
+  Measurable signals that would indicate success.
+
+  ## Progress
+  Where things stand relative to the key results.
+
+  ## Course Corrections
+  Changes in direction or approach made along the way.
+
+
 system_message: |
   You are Quill, writing as an objective tracker. Your job is to produce
   a document tracking a high-level objective with measurable direction from
@@ -41,20 +58,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Objective: {{title}}
-
-  ## The Objective
-  What the desired outcome is and why it matters.
-
-  ## Key Results
-  Measurable signals that would indicate success.
-
-  ## Progress
-  Where things stand relative to the key results.
-
-  ## Course Corrections
-  Changes in direction or approach made along the way.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -200,6 +204,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -100,29 +100,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -98,28 +98,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Focus on measurable outcomes and progress signals.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/principle.schema.ts
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.schema.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 import { wikiInfoboxSchema, wikiCitationDeclarationSchema } from '../../../schemas/sidecar.js'
 
-export const collectionWikiSchema = z.object({
+export const principleWikiSchema = z.object({
   markdown: z.string(),
   infobox: wikiInfoboxSchema.nullable().default(null),
   citations: z.array(wikiCitationDeclarationSchema).default([]),
 })
 
-export type CollectionWikiOutput = z.infer<typeof collectionWikiSchema>
+export type PrincipleWikiOutput = z.infer<typeof principleWikiSchema>

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -1,46 +1,46 @@
 name: QuillTheWriter
 version: 2
 category: generation
-display_label: "Principles"
-display_description: "A document of operating rules, values, and commitments that guide behavior"
-display_short_descriptor: "Operating rules"
+display_label: "Principle"
+display_description: "A document of an operating rule, value, or commitment that guides behavior"
+display_short_descriptor: "Operating rule"
 display_order: 100
-task: thread_wiki_principles
-description: Generates a principles wiki — a document of operating rules and commitments.
+task: thread_wiki_principle
+description: Generates a principle wiki — a document of an operating rule or commitment.
 temperature: 0.3
 
 default_structure: |
   Use this exact structure:
-  # Principles: {{title}}
+  # Principle: {{title}}
 
-  ## Core Principles
-  The fundamental rules, each stated as a clear commitment.
+  ## The Principle
+  The core rule, stated as a clear commitment.
 
-  ## Why These Principles
-  The reasoning and experience behind each rule.
+  ## Why This Principle
+  The reasoning and experience behind this rule.
 
   ## In Practice
-  How these principles show up in day-to-day decisions.
+  How this principle shows up in day-to-day decisions.
 
-  ## What These Principles Reject
-  The opposite behaviors or approaches these principles guard against.
+  ## What This Principle Rejects
+  The opposite behaviors or approaches this principle guards against.
 
 
 system_message: |
-  You are Quill, writing as a principles author. Your job is to produce
-  a document of operating rules and commitments from thread fragments.
+  You are Quill, writing as a principle author. Your job is to produce
+  a document of an operating rule or commitment from thread fragments.
   You faithfully represent what the fragments say — you do not add
   interpretations, conclusions, or information not present in the fragments.
 
 template: |
   [MOCK ACKNOWLEDGMENT]
-  Understood. I am Quill, writing a principles wiki. I document operating
-  rules and commitments. I include only what the fragments contain. I preserve
+  Understood. I am Quill, writing a principle wiki. I document an operating
+  rule or commitment. I include only what the fragments contain. I preserve
   attribution, hedging, and uncertainty. My output is clean markdown
   that follows the required structure exactly.
 
   [TASK]
-  Generate a principles wiki document for the thread "{{title}}" from the
+  Generate a principle wiki document for the thread "{{title}}" from the
   following {{count}} fragments.
 
   [LINKING SYNTAX — USE EXACTLY]

--- a/packages/shared/src/prompts/specs/wiki-types/principles.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principles.yaml
@@ -99,29 +99,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/principles.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principles.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_principles
 description: Generates a principles wiki — a document of operating rules and commitments.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Principles: {{title}}
+
+  ## Core Principles
+  The fundamental rules, each stated as a clear commitment.
+
+  ## Why These Principles
+  The reasoning and experience behind each rule.
+
+  ## In Practice
+  How these principles show up in day-to-day decisions.
+
+  ## What These Principles Reject
+  The opposite behaviors or approaches these principles guard against.
+
+
 system_message: |
   You are Quill, writing as a principles author. Your job is to produce
   a document of operating rules and commitments from thread fragments.
@@ -40,20 +57,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Principles: {{title}}
-
-  ## Core Principles
-  The fundamental rules, each stated as a clear commitment.
-
-  ## Why These Principles
-  The reasoning and experience behind each rule.
-
-  ## In Practice
-  How these principles show up in day-to-day decisions.
-
-  ## What These Principles Reject
-  The opposite behaviors or approaches these principles guard against.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -198,6 +202,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/principles.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principles.yaml
@@ -97,28 +97,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. State each principle as a clear commitment, not a vague aspiration.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -105,29 +105,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -9,6 +9,25 @@ task: thread_wiki_project
 description: Generates a project wiki — a living document of an active initiative.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Project: {{title}}
+
+  ## Goal
+  What this project is trying to achieve.
+
+  ## Status
+  Current state: active, paused, or complete.
+
+  ## Progress
+  Key milestones and what has been accomplished.
+
+  ## Blockers
+  Current obstacles and how they are being addressed.
+
+  ## Notes
+  Running notes and observations from the work.
+
 system_message: |
   You are Quill, writing as a project tracker. Your job is to produce
   a living document of an active initiative from thread fragments.
@@ -40,23 +59,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Project: {{title}}
-
-  ## Goal
-  What this project is trying to achieve.
-
-  ## Status
-  Current state: active, paused, or complete.
-
-  ## Progress
-  Key milestones and what has been accomplished.
-
-  ## Blockers
-  Current obstacles and how they are being addressed.
-
-  ## Notes
-  Running notes and observations from the work.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -203,6 +206,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -19,6 +19,10 @@ default_structure: |
   ## Status
   Current state: active, paused, or complete.
 
+  ## Roles
+  Who is involved and what each person owns. Include attribution for
+  fragment-stated ownership; omit speculative roles.
+
   ## Progress
   Key milestones and what has been accomplished.
 

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -103,28 +103,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Reflect the current state of the project from the fragments.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/research.schema.ts
+++ b/packages/shared/src/prompts/specs/wiki-types/research.schema.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 import { wikiInfoboxSchema, wikiCitationDeclarationSchema } from '../../../schemas/sidecar.js'
 
-export const principlesWikiSchema = z.object({
+export const researchWikiSchema = z.object({
   markdown: z.string(),
   infobox: wikiInfoboxSchema.nullable().default(null),
   citations: z.array(wikiCitationDeclarationSchema).default([]),
 })
 
-export type PrinciplesWikiOutput = z.infer<typeof principlesWikiSchema>
+export type ResearchWikiOutput = z.infer<typeof researchWikiSchema>

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -1,43 +1,43 @@
 name: QuillTheWriter
 version: 2
 category: generation
-display_label: "Collection"
-display_description: "A curated library organizing related bookmarks, references, or resources"
-display_short_descriptor: "Curated item library"
+display_label: "Research"
+display_description: "A curated library of references, sources, and findings on a topic"
+display_short_descriptor: "Topic research library"
 display_order: 20
-task: thread_wiki_collection
-description: Generates a collection wiki — a curated library of related items.
+task: thread_wiki_research
+description: Generates a research wiki — a curated library of references and findings on a topic.
 temperature: 0.3
 
 default_structure: |
   Use this exact structure:
-  # Collection: {{title}}
+  # Research: {{title}}
 
   ## Overview
-  What this collection is for and what connects the items.
+  The topic and the questions this research is exploring.
 
-  ## Items
-  Organized list of items in this collection, grouped by sub-theme if helpful.
+  ## Sources
+  References, citations, and findings, grouped by sub-theme if helpful.
 
   ## When to Use
-  When to reach for this collection.
+  When to reach for this research.
 
 
 system_message: |
-  You are Quill, writing as a curator. Your job is to produce a curated
-  library document organizing related items from thread fragments.
+  You are Quill, writing as a researcher. Your job is to produce a curated
+  library of references and findings on a topic from thread fragments.
   You faithfully represent what the fragments say — you do not add
   interpretations, conclusions, or information not present in the fragments.
 
 template: |
   [MOCK ACKNOWLEDGMENT]
-  Understood. I am Quill, writing a collection wiki. I organize fragments into
-  a curated library. I include only what the fragments contain. I preserve
-  attribution, hedging, and uncertainty. My output is clean markdown
-  that follows the required structure exactly.
+  Understood. I am Quill, writing a research wiki. I organize fragments into
+  a curated library of references and findings. I include only what the
+  fragments contain. I preserve attribution, hedging, and uncertainty. My
+  output is clean markdown that follows the required structure exactly.
 
   [TASK]
-  Generate a collection wiki document for the thread "{{title}}" from the
+  Generate a research wiki document for the thread "{{title}}" from the
   following {{count}} fragments.
 
   [LINKING SYNTAX — USE EXACTLY]

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -105,29 +105,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_skill
 description: Generates a skill wiki — a knowledge base for a capability being built.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Skill: {{title}}
+
+  ## Overview
+  What this skill is and why it matters.
+
+  ## Core Techniques
+  Key methods, approaches, and how-to knowledge.
+
+  ## Lessons Learned
+  What practice and experience have revealed.
+
+  ## Resources
+  Materials that have been most useful for developing this skill.
+
+
 system_message: |
   You are Quill, writing as a skill documenter. Your job is to produce
   a knowledge base document for a capability being built from thread
@@ -41,20 +58,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Skill: {{title}}
-
-  ## Overview
-  What this skill is and why it matters.
-
-  ## Core Techniques
-  Key methods, approaches, and how-to knowledge.
-
-  ## Lessons Learned
-  What practice and experience have revealed.
-
-  ## Resources
-  Materials that have been most useful for developing this skill.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -199,6 +203,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -19,6 +19,11 @@ default_structure: |
   ## Core Techniques
   Key methods, approaches, and how-to knowledge.
 
+  ## The Skill, Step by Step
+  An ordered walkthrough of the skill in practice. Each step is a
+  concrete action grounded in the fragments — do not invent steps the
+  fragments do not state.
+
   ## Lessons Learned
   What practice and experience have revealed.
 

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -103,28 +103,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Focus on actionable techniques and practical knowledge.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -99,29 +99,33 @@ template: |
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
   2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
      follow it exactly. Do not add, drop, reorder, or rename headings.
-  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  5. If fragments contradict each other, present both views — do not
+  3. Weave fragment content into prose. When you reference a fragment, use
+     [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
+     the fragment title as a chip, list item, or standalone phrase. The
+     reader should see synthesized narrative, not a wall of titles.
+  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  6. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  6. If an existing wiki is provided, update it incrementally rather than
+  7. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  7. Do not add conclusions, recommendations, or analysis beyond what
+  8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  8. If user edits are provided, preserve them faithfully in the output.
+  9. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
+  12. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  13. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -9,6 +9,23 @@ task: thread_wiki_voice
 description: Generates a voice wiki — a style guide for communication.
 temperature: 0.3
 
+default_structure: |
+  Use this exact structure:
+  # Voice: {{title}}
+
+  ## Tone and Style
+  How this person writes and speaks — formality, directness, register.
+
+  ## Language Patterns
+  Phrases, vocabulary, and constructions that fit this voice.
+
+  ## What to Avoid
+  Patterns and phrasings that do not fit.
+
+  ## Audience Notes
+  How the voice adapts for different contexts or audiences.
+
+
 system_message: |
   You are Quill, writing as a voice coach. Your job is to produce
   a style guide for communication from thread fragments.
@@ -40,20 +57,7 @@ template: |
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
-  Use this exact structure:
-  # Voice: {{title}}
-
-  ## Tone and Style
-  How this person writes and speaks — formality, directness, register.
-
-  ## Language Patterns
-  Phrases, vocabulary, and constructions that fit this voice.
-
-  ## What to Avoid
-  Patterns and phrasings that do not fit.
-
-  ## Audience Notes
-  How the voice adapts for different contexts or audiences.
+  {{structure}}
 
   [FRAGMENTS]
   {{fragments}}
@@ -197,6 +201,9 @@ input_variables:
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking
+    required: false
+  - name: structure
+    description: Per-wiki structure override (resolved from default_structure or wikis.structure)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -97,28 +97,31 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. Follow the document structure exactly.
-  3. Focus on concrete language patterns and style observations.
-  4. Preserve attribution: "Sarah said X" stays attributed to Sarah.
-  5. Preserve uncertainty: "Author thinks X" does not become "X is true."
-  6. If fragments contradict each other, present both views — do not
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
+     follow it exactly. Do not add, drop, reorder, or rename headings.
+  3. Preserve attribution: "Sarah said X" stays attributed to Sarah.
+  4. Preserve uncertainty: "Author thinks X" does not become "X is true."
+  5. If fragments contradict each other, present both views — do not
      resolve the contradiction.
-  7. If an existing wiki is provided, update it incrementally rather than
+  6. If an existing wiki is provided, update it incrementally rather than
      regenerating from scratch.
-  8. Do not add conclusions, recommendations, or analysis beyond what
+  7. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
+  8. If user edits are provided, preserve them faithfully in the output.
      Integrate user additions into the relevant sections. Never discard
      user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
       present in the provided inputs. Use plain text only when no matching
       slug exists. Never use plain Markdown links ([text](url)) for internal
       references.
-  11. Emit the infobox as a structured field (see [INFOBOX]); never repeat
-      infobox rows inside the main markdown body.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
+      duplicate any infobox value — title, status, owner, dates — as a
+      chip, list item, or inline mention in the markdown body. The
+      sidecar renderer surfaces these values; restating them creates
+      visual duplication.
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -8,7 +8,7 @@ import type { WikiType } from './wiki.js'
 
 export type WikiGuideKey =
   | 'wiki-guide-log'
-  | 'wiki-guide-collection'
+  | 'wiki-guide-research'
   | 'wiki-guide-belief'
   | 'wiki-guide-decision'
   | 'wiki-guide-project'
@@ -16,11 +16,11 @@ export type WikiGuideKey =
   | 'wiki-guide-skill'
   | 'wiki-guide-agent'
   | 'wiki-guide-voice'
-  | 'wiki-guide-principles'
+  | 'wiki-guide-principle'
 
 export const WIKI_TYPE_TO_GUIDE_KEY: Record<WikiType, WikiGuideKey> = {
   log: 'wiki-guide-log',
-  collection: 'wiki-guide-collection',
+  research: 'wiki-guide-research',
   belief: 'wiki-guide-belief',
   decision: 'wiki-guide-decision',
   project: 'wiki-guide-project',
@@ -28,5 +28,5 @@ export const WIKI_TYPE_TO_GUIDE_KEY: Record<WikiType, WikiGuideKey> = {
   skill: 'wiki-guide-skill',
   agent: 'wiki-guide-agent',
   voice: 'wiki-guide-voice',
-  principles: 'wiki-guide-principles',
+  principle: 'wiki-guide-principle',
 }

--- a/packages/shared/src/types/wiki.ts
+++ b/packages/shared/src/types/wiki.ts
@@ -1,6 +1,6 @@
 export type WikiType =
   | 'log'
-  | 'collection'
+  | 'research'
   | 'belief'
   | 'decision'
   | 'project'
@@ -8,7 +8,7 @@ export type WikiType =
   | 'skill'
   | 'agent'
   | 'voice'
-  | 'principles'
+  | 'principle'
 
 export interface DefaultWiki {
   name: string
@@ -18,7 +18,7 @@ export interface DefaultWiki {
 
 export const DEFAULT_WIKIS: DefaultWiki[] = [
   { name: 'Daily Log', slug: 'daily-log', type: 'log' },
-  { name: 'Bookmarks', slug: 'bookmarks', type: 'collection' },
+  { name: 'Bookmarks', slug: 'bookmarks', type: 'research' },
   { name: 'Beliefs', slug: 'beliefs', type: 'belief' },
   { name: 'Decisions', slug: 'decisions', type: 'decision' },
   { name: 'Projects', slug: 'projects', type: 'project' },
@@ -26,7 +26,7 @@ export const DEFAULT_WIKIS: DefaultWiki[] = [
   { name: 'Skills', slug: 'skills', type: 'skill' },
   { name: 'Agents', slug: 'agents', type: 'agent' },
   { name: 'Voice', slug: 'voice', type: 'voice' },
-  { name: 'Principles', slug: 'principles', type: 'principles' },
+  { name: 'Principles', slug: 'principles', type: 'principle' },
 ]
 
 export interface WikiTypeRecord {


### PR DESCRIPTION
## Summary

Closes the wiki-type yaml epic cluster — five sequenced changes to the per-type prompt specs and the shared structure-resolution mechanism.

- **#244** (epic) — per-wiki document structure as a first-class field. Adds \`default_structure\` to each wiki-type yaml + \`{{structure}}\` placeholder in the writer template + \`wikis.structure\` column for per-wiki overrides (sibling of \`wikis.prompt\`; \`prompt\` remains the \`system_message\` override per memory note).
- **#248** — \`## Roles\` section in \`project.yaml\` structure, \`## The Skill, Step by Step\` section in \`skill.yaml\` structure. Stacks on #244.
- **#254** (epic) — tighten wiki-writing rules: kill hardcoded layout rule 3 (now \`{{structure}}\` drives layout), strengthen structure-as-source-of-truth, dedupe chip-discipline.
- **#243** — prose-not-chips rule: weave fragment content into prose, never bare-string the title as a chip.
- **#247** — rename \`collection\` → \`research\`, \`principles\` → \`principle\` (singular). File renames + symbol renames + migration UPDATEs both \`wiki_types.slug\` and any existing \`wikis.type\` rows.

## UAT contract (5 new plans)

| Issue | Plan | Pre-fix F | Post-fix |
|-------|------|-----------|----------|
| #244 | \`.uat/plans/41-per-wiki-structure-first-class.md\` (A1–A7, B1–B3) | 35 F | 46 P / 0 F |
| #248 | \`.uat/plans/42-roles-and-skill-steps-sections.md\` (A1–A4, B1–B3) | 4 F | 14 P / 0 F |
| #254 | \`.uat/plans/43-tighten-wiki-writing-rules.md\` (A1, B1, C1, D1) | 30 F | 40 P / 0 F |
| #243 | \`.uat/plans/44-prose-not-chips.md\` (A1, A2, B1, C1) | 20 F | 30 P / 0 F (1 \`skip\`: prose-quality) |
| #247 | \`.uat/plans/45-type-renames.md\` (A1–A14, B1–B12) | 23 F | 26 P / 0 F |

## Migrations

- \`0011_wikis_add_structure.sql\` — adds \`wikis.structure text NOT NULL DEFAULT ''\`.
- \`0012_wiki_types_rename_collection_principles.sql\` — UPDATEs \`wiki_types.slug\` (\`collection\`→\`research\`, \`principles\`→\`principle\`) + \`wikis.type\` for any rows already filed.

> ⚠️ **Conflicts with cluster 9b** (PR #279, fragmenter+classifier): also writes a \`0011_*.sql\`. Whichever merges second renames its migration to 0013 — orchestrator handles at merge time.

## Files

- 10 wiki-type yamls under \`packages/shared/src/prompts/specs/wiki-types/\` (\`collection.yaml\`/\`principles.yaml\` renamed)
- \`packages/shared/src/prompts/{schema,types/wiki,types/config}.ts\`
- \`packages/shared/src/prompts/loaders/wiki-generation.ts\`
- \`packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts\`
- \`core/src/db/schema.ts\` (\`wikis.structure\` column)
- \`core/src/lib/regen.ts\` (\`{{structure}}\` substitution into vars)
- \`core/src/mcp/wiki-type-inference.ts\` (descriptor map renames)
- \`core/src/__tests__/mcp-create-wiki.test.ts\`, \`core/src/routes/wiki-types.test.ts\`
- 2 migrations + journal entries

LOC: +1132 / −241 across 30 files.

## Open follow-ups

- \`wiki/\` (frontend) still has hardcoded \`'collection'\` filter strings (\`useExplorerFilters.ts\`, \`wikiSettingsPrefill.ts\`, \`promptIcons.ts\`). Per memory note, frontend was scoped out of cluster 9 — sibling cluster 8 may have already addressed some; remaining strings are a follow-up.
- The \`## Roles\` and \`## The Skill, Step by Step\` sections fire only via \`default_structure\` substitution; the \`agent\`/\`belief\`/etc. yamls remain unchanged per #248 scope.
- Validator's \`UNKNOWN_VARIABLE\` is now soft-warning-clean for \`{{structure}}\` — every yaml declares it as a non-required input variable.
- One assertion in plan 44 marked \`skip\`: rendered wiki body weaves fragment content into prose (LLM judgement, not bash-checkable).

Closes #244
Closes #248
Closes #254
Closes #243
Closes #247