### PR TITLE
feat(fragmenter+classifier): topic-coherence prompt v6, owner-Person AUTHORSHIP block, Elfie matcher-only

### DIFF
--- a/.uat/plans/46-fragmenter-v6.md
+++ b/.uat/plans/46-fragmenter-v6.md
@@ -1,0 +1,142 @@
+# 46 — Fragmenter v6: topic-coherence + fluff filter (#242)
+
+## What it proves
+
+Issue #242 reframes the fragmenter prompt away from a *word-count target*
+heuristic to a *topic-coherence + fluff-filter* heuristic. The current
+prompt (`packages/shared/src/prompts/specs/fragmentation.yaml`, version 4)
+contains a GRANULARITY rule that injects `{{wordCount}}` and
+`{{fragmentTarget}}` and tells the LLM to "Aim for approximately N
+fragments". The loader (`packages/shared/src/prompts/loaders/fragmentation.ts`)
+computes those numbers from the entry length.
+
+Post-fix, the prompt:
+- Drops the word-count → fragment-count formula.
+- States that each fragment is **one atomic idea** judged by topic
+  coherence, not by length.
+- Adds an explicit fluff filter: filler / preamble / signposting prose
+  (e.g. "so", "anyway", "as I was saying", "let me explain") MUST NOT
+  become fragments.
+- Bumps `version` to 6 so cached spec consumers invalidate.
+
+The runtime ceiling (`computeFragmentLimits().ceiling`) stays as a safety
+net — that's a *code* cap, not a *prompt* nudge. The prompt no longer
+suggests a target number.
+
+## Negative + positive assertions
+
+| § | Kind | Check |
+|---|------|-------|
+| 1a | NEG | `fragmentation.yaml` does NOT contain literal `wordCount` template variable |
+| 1b | NEG | `fragmentation.yaml` does NOT contain literal `fragmentTarget` |
+| 1c | NEG | `fragmentation.yaml` does NOT contain `Aim for approximately` |
+| 1d | NEG | The phrase `word count` (case-insensitive) absent from the rules block |
+| 2a | POS | `fragmentation.yaml` mentions `topic coherence` (or `coherence`) |
+| 2b | POS | `fragmentation.yaml` mentions a `fluff` filter |
+| 2c | POS | `fragmentation.yaml` mentions `atomic idea` |
+| 3a | POS | `version: 6` set on the spec |
+| 4a | POS | Loader (`loaders/fragmentation.ts`) no longer injects `wordCount` / `fragmentTarget` into the rendered template |
+
+## Notes on AI-quality assertions skipped
+
+A behavioural test ("real entry containing fluff prose now produces zero
+fluff fragments") would require a live LLM call and a quality judgment.
+The handover policy says: assert structural shape, not LLM prose
+quality. The prompt-text greps above are the falsifiable proxy.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "46 — Fragmenter v6 (#242)"
+echo ""
+
+YAML="packages/shared/src/prompts/specs/fragmentation.yaml"
+LOADER="packages/shared/src/prompts/loaders/fragmentation.ts"
+
+if [ ! -f "$YAML" ]; then
+  fail "0a. $YAML missing"
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+pass "0a. fragmenter yaml present"
+
+# ── 1. Negative: word-count machinery removed ──────────────
+if grep -q '{{wordCount}}' "$YAML"; then
+  fail "1a. yaml still contains {{wordCount}} template variable"
+else
+  pass "1a. {{wordCount}} removed"
+fi
+
+if grep -q '{{fragmentTarget}}' "$YAML"; then
+  fail "1b. yaml still contains {{fragmentTarget}} template variable"
+else
+  pass "1b. {{fragmentTarget}} removed"
+fi
+
+if grep -q 'Aim for approximately' "$YAML"; then
+  fail "1c. yaml still says 'Aim for approximately'"
+else
+  pass "1c. 'Aim for approximately' phrase removed"
+fi
+
+# 'word count' anywhere in the rules block (case-insensitive)
+if grep -qi 'word count' "$YAML"; then
+  fail "1d. yaml still mentions 'word count'"
+else
+  pass "1d. 'word count' phrase absent"
+fi
+
+# ── 2. Positive: coherence + fluff + atomic idea ───────────
+if grep -qi 'coherence' "$YAML"; then
+  pass "2a. yaml mentions 'coherence'"
+else
+  fail "2a. yaml does not mention 'coherence'"
+fi
+
+if grep -qi 'fluff' "$YAML"; then
+  pass "2b. yaml mentions 'fluff'"
+else
+  fail "2b. yaml does not mention 'fluff'"
+fi
+
+if grep -qi 'atomic idea' "$YAML"; then
+  pass "2c. yaml mentions 'atomic idea'"
+else
+  fail "2c. yaml does not mention 'atomic idea'"
+fi
+
+# ── 3. Version bump ────────────────────────────────────────
+if grep -qE '^version:\s*6\b' "$YAML"; then
+  pass "3a. version: 6"
+else
+  CURRENT_VERSION=$(grep -E '^version:' "$YAML" | head -1)
+  fail "3a. version is not 6 (saw: $CURRENT_VERSION)"
+fi
+
+# ── 4. Loader no longer injects wordCount / fragmentTarget into rendered template ──
+if [ ! -f "$LOADER" ]; then
+  skip "4a. loader file missing — cannot check"
+else
+  # The loader may still export computeFragmentLimits for code-side ceiling,
+  # but it must NOT pass wordCount / fragmentTarget into renderTemplate.
+  if grep -A 6 'renderTemplate' "$LOADER" | grep -qE 'wordCount|fragmentTarget'; then
+    fail "4a. loader still injects wordCount/fragmentTarget into renderTemplate"
+  else
+    pass "4a. loader no longer injects wordCount/fragmentTarget into the prompt"
+  fi
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/47-owner-person-authorship.md
+++ b/.uat/plans/47-owner-person-authorship.md
@@ -1,0 +1,191 @@
+# 47 — Owner-Person + classifier `[AUTHORSHIP]` block (#238)
+
+## What it proves
+
+Issue #238 fixes a brittle authorship resolution: the fragmenter used to
+substitute "I/me/my" with the literal string "Author" so each fragment
+read in third person. That breaks down on text with multiple speakers
+(e.g. "Sarah said 'I should refactor'") and quietly mangles voice in
+the database.
+
+The new shape:
+
+1. **Schema**: `people` gets an `is_owner` boolean column (migration
+   `0011_people_is_owner.sql`) plus a partial unique index ensuring at
+   most one row carries `is_owner = true` while live (`deleted_at IS
+   NULL`). Single-tenant intent preserved — no `user_id` on the people
+   table.
+2. **Provisioning**: `ensureOwnerPerson()` in
+   `core/src/bootstrap/jit-provision.ts` seeds an owner-Person row for
+   the single user account on first sign-up. Idempotent — re-running on
+   an existing owner returns the existing row.
+3. **Classifier prompt**: `wiki-classification.yaml` (version: 3) gains
+   an explicit `[AUTHORSHIP]` block that names the owner and tells the
+   agent to interpret first-person pronouns as the owner unless an
+   inline attribution like `"Sarah said 'I should…'"` makes another
+   speaker explicit.
+4. **Loader / stage wiring**: `loadWikiClassificationSpec` accepts a
+   new `ownerName` arg and falls back to the literal "the owner" when
+   absent so the prompt still renders. `WikiClassifyDeps.loadOwnerName`
+   is wired into the BullMQ link job in `core/src/queue/worker.ts`.
+5. **Fragmenter**: rule 10 (PRONOUNS) **stops substituting** I/me/my.
+   The old "Replace … with Author" instruction is gone. Authorship is
+   resolved downstream via the classifier's [AUTHORSHIP] block.
+
+## Negative + positive assertions
+
+| § | Kind | Check |
+|---|------|-------|
+| 1a | POS  | Migration `0011_people_is_owner.sql` exists |
+| 1b | POS  | Migration mentions `is_owner` and a partial unique index |
+| 1c | POS  | `core/src/db/schema.ts` declares `isOwner` on `people` |
+| 1d | POS  | `_journal.json` includes the `0011_people_is_owner` entry |
+| 2a | NEG  | Fragmenter prompt no longer says `Replace … with "Author"` |
+| 2b | NEG  | Fragmenter prompt does NOT contain a substitution rule for I/me/my |
+| 2c | POS  | Fragmenter prompt rule 10 instructs to LEAVE first-person pronouns as-is |
+| 3a | POS  | `wiki-classification.yaml` contains `[AUTHORSHIP]` |
+| 3b | POS  | `wiki-classification.yaml` references `{{ownerName}}` |
+| 3c | POS  | `wiki-classification.yaml` is version: 3 |
+| 4a | POS  | Loader `wiki-classification.ts` accepts `ownerName` |
+| 4b | POS  | Worker provides `loadOwnerName` in wikiClassifyDeps |
+| 5a | POS  | `jit-provision.ts` exports `ensureOwnerPerson` |
+| 5b | POS  | `ensureOwnerPerson` writes `is_owner: true` |
+
+## Notes on AI-quality assertions skipped
+
+- A true behavioural test ("classifier correctly attributes 'I went for
+  a run' to the owner-Person and 'Sarah said I should refactor' to
+  Sarah") would require a live LLM call and a quality judgment. Per
+  handover policy, prompt-text greps are the falsifiable proxy.
+- An end-to-end test ("real ingest produces fragments with literal
+  'I' / 'me' / 'my' instead of 'Author'") would require booting the
+  worker stack and running a fixture entry. This is asserted
+  structurally via §2 (the prompt-text rule change).
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "47 — Owner-Person + classifier [AUTHORSHIP] block (#238)"
+echo ""
+
+MIG="core/drizzle/migrations/0011_people_is_owner.sql"
+SCHEMA="core/src/db/schema.ts"
+JOURNAL="core/drizzle/migrations/meta/_journal.json"
+FRAG_YAML="packages/shared/src/prompts/specs/fragmentation.yaml"
+WC_YAML="packages/shared/src/prompts/specs/wiki-classification.yaml"
+WC_LOADER="packages/shared/src/prompts/loaders/wiki-classification.ts"
+WORKER="core/src/queue/worker.ts"
+PROV="core/src/bootstrap/jit-provision.ts"
+
+# ── 1. Schema + migration shape ──────────────────────────────
+if [ -f "$MIG" ]; then
+  pass "1a. migration $MIG present"
+else
+  fail "1a. migration $MIG missing"
+fi
+
+if grep -q 'is_owner' "$MIG" && grep -qi 'unique.*index\|UNIQUE INDEX' "$MIG"; then
+  pass "1b. migration declares is_owner + partial unique index"
+else
+  fail "1b. migration shape incomplete"
+fi
+
+if grep -q "isOwner" "$SCHEMA"; then
+  pass "1c. schema.ts declares isOwner on people"
+else
+  fail "1c. schema.ts missing isOwner"
+fi
+
+if grep -q "0011_people_is_owner" "$JOURNAL"; then
+  pass "1d. _journal.json contains 0011_people_is_owner"
+else
+  fail "1d. _journal.json missing 0011 entry"
+fi
+
+# ── 2. Fragmenter no longer substitutes pronouns ────────────
+if grep -qE 'Replace .*Author' "$FRAG_YAML"; then
+  fail "2a. fragmenter still says 'Replace … with \"Author\"'"
+else
+  pass "2a. fragmenter no longer substitutes I/me/my with 'Author'"
+fi
+
+# Generic: any pronoun-substitution language?
+if grep -qiE 'replace .*(first.?person|pronoun|I.* me.* my|i, me, my)' "$FRAG_YAML"; then
+  fail "2b. fragmenter still has a pronoun-substitution rule"
+else
+  pass "2b. fragmenter has no pronoun-substitution rule"
+fi
+
+# Positive: the rule must say leave them as-is.
+if grep -qiE 'leave .*(first.?person|pronoun)' "$FRAG_YAML" && \
+   grep -qi 'AUTHORSHIP' "$FRAG_YAML"; then
+  pass "2c. fragmenter rule says leave first-person as-is, defer to AUTHORSHIP"
+else
+  fail "2c. fragmenter rule missing 'leave as-is' or AUTHORSHIP reference"
+fi
+
+# ── 3. Classifier yaml has [AUTHORSHIP] block ────────────────
+if grep -q '\[AUTHORSHIP\]' "$WC_YAML"; then
+  pass "3a. wiki-classification.yaml contains [AUTHORSHIP]"
+else
+  fail "3a. wiki-classification.yaml missing [AUTHORSHIP]"
+fi
+
+if grep -q '{{ownerName}}' "$WC_YAML"; then
+  pass "3b. wiki-classification.yaml references {{ownerName}}"
+else
+  fail "3b. wiki-classification.yaml missing {{ownerName}}"
+fi
+
+if grep -qE '^version:\s*3\b' "$WC_YAML"; then
+  pass "3c. wiki-classification.yaml is version: 3"
+else
+  CV=$(grep -E '^version:' "$WC_YAML" | head -1)
+  fail "3c. wiki-classification.yaml not version 3 (saw: $CV)"
+fi
+
+# ── 4. Loader + worker wiring ────────────────────────────────
+if grep -q 'ownerName' "$WC_LOADER"; then
+  pass "4a. wiki-classification loader accepts ownerName"
+else
+  fail "4a. wiki-classification loader does not accept ownerName"
+fi
+
+if grep -q 'loadOwnerName' "$WORKER"; then
+  pass "4b. worker.ts wires loadOwnerName into wikiClassifyDeps"
+else
+  fail "4b. worker.ts missing loadOwnerName"
+fi
+
+# ── 5. Provisioning seeds the owner-Person ───────────────────
+if grep -q 'ensureOwnerPerson' "$PROV"; then
+  pass "5a. jit-provision.ts exports ensureOwnerPerson"
+else
+  fail "5a. ensureOwnerPerson absent from jit-provision.ts"
+fi
+
+# Tighter shape: the seed sets is_owner = true. The function body
+# spans ~60 lines (lookup + insert + return), so grep with a generous
+# window so the assertion isn't sensitive to small style edits.
+if grep -A 60 'export async function ensureOwnerPerson' "$PROV" \
+     | grep -qE 'isOwner:\s*true'; then
+  pass "5b. ensureOwnerPerson writes isOwner: true"
+else
+  fail "5b. ensureOwnerPerson does not set isOwner: true"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```

--- a/.uat/plans/48-elfie-matcher-only.md
+++ b/.uat/plans/48-elfie-matcher-only.md
@@ -1,0 +1,150 @@
+# 48 — Elfie matcher-only (#237)
+
+## What it proves
+
+Issue #237 re-positions Elfie (the `people-extraction` agent) as a
+matcher, not an extractor. Pre-fix, Elfie surfaced unmatched person
+mentions with `matchedKey: null`, and `entityExtract` then created new
+Person rows for them via `resolvePerson({ isNew: true })` →
+`newPeople.push(…)` → `persist.upsertPerson()`.
+
+Post-fix:
+
+1. **Prompt-side**: `people-extraction.yaml` (version: 2) instructs
+   Elfie to ONLY return people that match an entry in KNOWN PEOPLE.
+   Mentions with no match are dropped silently. Few-shot examples are
+   replaced to demonstrate this — including a known-people-empty case
+   that returns `{"people": []}`.
+2. **Stage-side**: `entityExtract` uses `resolvePerson()` purely as a
+   "did this match?" check. When `isNew: true`, the mention is dropped
+   (no `peopleMap` entry, no `newPeople` push). The returned
+   `extractions` array is filtered to matched-only so persist's
+   mention-to-fragment edge logic can't re-introduce a dropped name.
+3. **Persist invariant**: feeding text with an unknown person no longer
+   creates a Person row, no longer creates a `FRAGMENT_MENTIONS_PERSON`
+   edge to a non-existent key. Feeding text with a known person still
+   creates the edge.
+
+## Negative + positive assertions
+
+| § | Kind | Check |
+|---|------|-------|
+| 1a | POS | `people-extraction.yaml` is version: 2 |
+| 1b | POS | `people-extraction.yaml` calls Elfie a "matcher" (not "extractor") |
+| 1c | POS | Prompt instructs to DROP unmatched mentions (e.g. "drop", "skip", "do not return") |
+| 1d | NEG | Prompt no longer says "If a person is new, set matchedKey to null" |
+| 2a | NEG | `entity-extract.ts` no longer pushes onto `newPeople` for unknown mentions inside the resolution loop |
+| 2b | POS | `entity-extract.ts` references `unmatchedDropped` (the new metric in emitEvent metadata) |
+| 3a | POS | Unit test updated: returns 0 newPeople even when LLM yields a `matchedKey: null` extraction |
+
+## Notes on AI-quality assertions skipped
+
+A live ingest test ("real entry mentioning a brand-new name 'Carol' in
+text DOES NOT produce a `people` row for Carol") would prove the same
+invariant end-to-end but requires booting the worker stack. The unit
+test asserted in §3a covers the matcher-only invariant deterministically
+without an LLM in the loop.
+
+A negative DB-row-count assertion ("count of `people` rows after
+ingesting an entry with one unmatched mention is unchanged") would also
+require the full stack — captured structurally by §2a.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "48 — Elfie matcher-only (#237)"
+echo ""
+
+YAML="packages/shared/src/prompts/specs/people-extraction.yaml"
+STAGE="packages/agent/src/stages/entity-extract.ts"
+TEST="packages/agent/src/__tests__/entity-extract.test.ts"
+
+if [ ! -f "$YAML" ] || [ ! -f "$STAGE" ] || [ ! -f "$TEST" ]; then
+  fail "0a. one of the target files is missing"
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+pass "0a. all target files present"
+
+# ── 1. Prompt re-positioned as matcher ───────────────────────
+if grep -qE '^version:\s*2\b' "$YAML"; then
+  pass "1a. people-extraction.yaml is version: 2"
+else
+  CV=$(grep -E '^version:' "$YAML" | head -1)
+  fail "1a. people-extraction.yaml not version 2 (saw: $CV)"
+fi
+
+if grep -qiE '\b(entity matcher|matcher-only|the matcher)\b' "$YAML"; then
+  pass "1b. yaml positions Elfie as a matcher"
+else
+  fail "1b. yaml does not position Elfie as a matcher"
+fi
+
+# Prompt MUST tell the agent what to do with unmatched mentions: drop / skip.
+if grep -qiE 'drop (it|the unmatched)|skip (it|the unmatched)|drop them silently|do not return' "$YAML"; then
+  pass "1c. yaml instructs to drop/skip unmatched mentions"
+else
+  fail "1c. yaml lacks an explicit drop/skip rule"
+fi
+
+# Pre-fix prompt instruction: "If a person is new, set matchedKey to null."
+# (a positive directive to emit null). Post-fix the prompt may still
+# contain matchedKey-null mentions in NEGATIVE contexts ("never",
+# "do NOT", "drop instead"), which is fine — those forbid the old
+# behaviour. The assertion is therefore: there must be no positive
+# directive to set/return matchedKey: null.
+POSITIVE_NULL=$(grep -inE 'matchedKey' "$YAML" \
+  | grep -ivE 'never|not |no\b|drop|forbidden|don['"'"']t|MUST|valid')
+if echo "$POSITIVE_NULL" | grep -qiE 'matchedKey.*null'; then
+  fail "1d. yaml still has a positive directive to emit matchedKey: null"
+  echo "      offending lines: $POSITIVE_NULL"
+else
+  pass "1d. yaml no longer instructs matchedKey: null for unknowns"
+fi
+
+# ── 2. Stage drops unmatched mentions ────────────────────────
+# Pre-fix entity-extract.ts had `if (resolved.isNew) { newPeople.push(...) }`.
+# Post-fix the if-isNew branch must be a `continue` / drop, not a push.
+# Strict shape check: there must NOT be a `newPeople.push(` adjacent to
+# a `resolved.isNew` block.
+if awk '/resolved\.isNew/{flag=1} /newPeople\.push/{if(flag){print "HIT"; exit}} /^\s*}\s*$/{flag=0}' "$STAGE" | grep -q HIT; then
+  fail "2a. stage still pushes onto newPeople for resolved.isNew mentions"
+else
+  pass "2a. stage no longer pushes onto newPeople for unmatched mentions"
+fi
+
+if grep -q 'unmatchedDropped' "$STAGE"; then
+  pass "2b. stage tracks unmatchedDropped"
+else
+  fail "2b. stage missing unmatchedDropped metric"
+fi
+
+# ── 3. Test updated ──────────────────────────────────────────
+if grep -q 'matcher-only\|#237' "$TEST"; then
+  pass "3a. test references matcher-only / #237"
+else
+  fail "3a. test does not reference matcher-only / #237"
+fi
+
+# Tighten: the test must assert newPeople has length 0 even when an
+# extraction with matchedKey: null is fed to the LLM mock.
+if grep -q 'newPeople).toHaveLength(0)' "$TEST"; then
+  pass "3b. test asserts 0 newPeople for the unmatched fixture"
+else
+  fail "3b. test does not assert 0 newPeople"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```

--- a/core/drizzle/migrations/0013_people_is_owner.sql
+++ b/core/drizzle/migrations/0013_people_is_owner.sql
@@ -1,0 +1,16 @@
+-- Owner-Person concept (#238). The user account itself gets a Person row
+-- marked as the owner so first-person pronouns ("I", "me", "my") in the
+-- classifier prompt resolve to a real Person key via the new [AUTHORSHIP]
+-- block, instead of the brittle pronoun-substitution rule the fragmenter
+-- used to apply.
+--
+-- Single-tenant note: people already lives without user_id (M2 collapse).
+-- A boolean flag plus a partial unique index keeps the invariant "at most
+-- one owner" at the DB layer without re-introducing user_id.
+
+ALTER TABLE people
+  ADD COLUMN IF NOT EXISTS is_owner boolean NOT NULL DEFAULT false;
+
+CREATE UNIQUE INDEX IF NOT EXISTS people_is_owner_uidx
+  ON people ((is_owner))
+  WHERE is_owner = true AND deleted_at IS NULL;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778284800000,
       "tag": "0012_wiki_types_rename_collection_principles",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778371200000,
+      "tag": "0013_people_is_owner",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/bootstrap/jit-provision.ts
+++ b/core/src/bootstrap/jit-provision.ts
@@ -1,7 +1,8 @@
 import { eq, sql } from 'drizzle-orm'
+import { generateSlug, makeLookupKey } from '@robin/shared'
 import { auth } from '../auth.js'
 import { db } from '../db/client.js'
-import { users } from '../db/schema.js'
+import { people, users } from '../db/schema.js'
 import { generateKeypair } from '../keypair.js'
 import { generateDek, loadMasterKey, wrapDek } from '../lib/crypto.js'
 import { logger } from '../lib/logger.js'
@@ -55,7 +56,8 @@ export async function ensureFirstUser(): Promise<void> {
     },
   })
 
-  const signedUpUser = (response as { user?: { id: string } } | null)?.user
+  const signedUpUser = (response as { user?: { id: string; name?: string | null } } | null)
+    ?.user
   if (!signedUpUser) {
     throw new Error('sign-up did not return a user object')
   }
@@ -98,6 +100,18 @@ export async function ensureFirstUser(): Promise<void> {
     .then(() => log.info({ userId }, 'enqueued provision job for keypair generation'))
     .catch((err) => log.error({ userId, err }, 'failed to enqueue provision job'))
 
+  // Owner-Person seed (#238). The user account itself gets a Person row
+  // with is_owner = true. Downstream the classifier prompt's [AUTHORSHIP]
+  // block resolves "I/me/my" to this Person key instead of the brittle
+  // pronoun-substitution rule the fragmenter used to apply.
+  // Idempotent + error-isolated — owner provisioning must never block
+  // sign-in.
+  try {
+    await ensureOwnerPerson(signedUpUser.name ?? null, email)
+  } catch (err) {
+    log.error({ userId, err }, 'owner-Person seed failed — continuing')
+  }
+
   // First-run demo content: seed the Transformer fixture wiki so the user
   // lands on populated onboarding content and we smoke-test the wiki stack.
   // Idempotent + error-isolated inside seedDemoWiki — never blocks sign-in.
@@ -106,3 +120,68 @@ export async function ensureFirstUser(): Promise<void> {
   provisioned = true
   log.info({ userId, email }, 'first user provisioned with DEK and password_reset_required=true')
 }
+
+/**
+ * Insert the owner-Person row if missing. Single-tenant: at most one row
+ * may carry is_owner = true (DB-enforced by people_is_owner_uidx).
+ *
+ * @param signedUpName Best-available human name from the auth provider.
+ *                     Falls back to the email local-part if absent or blank.
+ * @param email        The user's email — used to derive a fallback display
+ *                     name and to keep the owner Person discoverable in
+ *                     case the user later updates their profile.
+ */
+export async function ensureOwnerPerson(
+  signedUpName: string | null,
+  email: string
+): Promise<{ personKey: string; isNew: boolean }> {
+  const [existing] = await db
+    .select({ lookupKey: people.lookupKey })
+    .from(people)
+    .where(eq(people.isOwner, true))
+    .limit(1)
+
+  if (existing) {
+    return { personKey: existing.lookupKey, isNew: false }
+  }
+
+  const fallback = email.split('@')[0] ?? 'owner'
+  const trimmed = (signedUpName ?? '').trim()
+  const displayName = trimmed.length > 0 ? trimmed : fallback
+
+  const personKey = makeLookupKey('person')
+  const slug = generateSlug(`owner-${displayName}`)
+
+  await db.insert(people).values({
+    lookupKey: personKey,
+    slug,
+    name: displayName,
+    canonicalName: displayName,
+    aliases: [],
+    verified: true,
+    isOwner: true,
+    state: 'RESOLVED',
+  })
+
+  log.info({ personKey, displayName }, 'owner-Person seeded')
+  return { personKey, isNew: true }
+}
+
+/**
+ * Lookup the canonical owner-Person name. Returns null if no owner row
+ * exists yet — callers should fall back to a generic "the owner" label
+ * in that case so the [AUTHORSHIP] block still renders.
+ */
+export async function loadOwnerPersonName(): Promise<{
+  personKey: string
+  name: string
+} | null> {
+  const [row] = await db
+    .select({ lookupKey: people.lookupKey, name: people.name })
+    .from(people)
+    .where(eq(people.isOwner, true))
+    .limit(1)
+  if (!row) return null
+  return { personKey: row.lookupKey, name: row.name }
+}
+

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -302,6 +302,12 @@ export const people = pgTable(
     canonicalName: text('canonical_name').notNull().default(''),
     aliases: text('aliases').array().notNull().default(sql`'{}'::text[]`),
     verified: boolean('verified').notNull().default(false),
+    // Owner-Person flag (#238). Exactly one row may carry is_owner = true
+    // (enforced by people_is_owner_uidx in 0011). The owner-Person
+    // represents the user account itself; the classifier prompt's new
+    // [AUTHORSHIP] block tells the agent to interpret first-person
+    // pronouns as this Person.
+    isOwner: boolean('is_owner').notNull().default(false),
     lastRebuiltAt: timestamp('last_rebuilt_at'),
     embedding: vector('embedding', { dimensions: 1536 }),
     searchVector: tsvector('search_vector'),

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -423,6 +423,17 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
           )
         return rows
       },
+      loadOwnerName: async () => {
+        // Owner-Person seed (#238). Returns null if no owner row exists
+        // yet — the classifier loader falls back to "the owner" so the
+        // [AUTHORSHIP] block still renders grammatically.
+        const [row] = await db
+          .select({ name: people.name })
+          .from(people)
+          .where(eq(people.isOwner, true))
+          .limit(1)
+        return row?.name ?? null
+      },
       llmCall: createTypedCaller(agents.wikiClassifier, wikiClassificationSchema),
       emitEvent,
     },

--- a/packages/agent/src/__tests__/entity-extract.test.ts
+++ b/packages/agent/src/__tests__/entity-extract.test.ts
@@ -146,7 +146,14 @@ describe('resolvePerson', () => {
 describe('entityExtract', () => {
   beforeEach(resetKeyCounter)
 
-  it('calls LLM, parses output, resolves mentions, returns peopleMap', async () => {
+  it('matches known people and DROPS unmatched mentions (#237 — matcher-only)', async () => {
+    // Even if the LLM mistakenly returns a matchedKey: null candidate
+    // (i.e. ignores the prompt's instruction to drop unknowns), the
+    // stage must still drop it: no peopleMap entry, no newPeople push.
+    // resolvePerson will report isNew = true because the score floor
+    // is unmet against the lone known person, and the stage now
+    // treats isNew as a "no match" signal rather than a "create new"
+    // signal.
     const mockDeps: EntityExtractDeps = {
       loadAllPeople: vi
         .fn()
@@ -182,11 +189,19 @@ describe('entityExtract', () => {
       jobId: 'job001',
     })
 
-    expect(result.data.peopleMap.size).toBe(2)
+    // Only the matched mention survives.
+    expect(result.data.peopleMap.size).toBe(1)
     expect(result.data.peopleMap.get('Sarah')).toBe('personABC')
-    expect(result.data.peopleMap.get('Bob')).toBeDefined()
-    expect(result.data.newPeople).toHaveLength(1)
-    expect(result.data.newPeople[0].canonicalName).toBe('Bob')
+    expect(result.data.peopleMap.has('Bob')).toBe(false)
+
+    // Elfie no longer creates Person rows.
+    expect(result.data.newPeople).toHaveLength(0)
+
+    // extractions returned to persist must also be filtered down so
+    // matchMentionsToFragments cannot re-introduce a dropped mention.
+    expect(result.data.extractions).toHaveLength(1)
+    expect(result.data.extractions[0].mention).toBe('Sarah')
+
     expect(result.durationMs).toBeGreaterThanOrEqual(0)
   })
 

--- a/packages/agent/src/stages/entity-extract.ts
+++ b/packages/agent/src/stages/entity-extract.ts
@@ -159,23 +159,31 @@ export async function entityExtract(
   // 4. Call LLM (returns Zod-validated output)
   const parsed = await deps.llmCall(spec.system, spec.user)
 
-  // 6. Resolve each extraction
+  // 6. Resolve each extraction. #237: Elfie is matcher-only — unmatched
+  // mentions are DROPPED instead of becoming new Person rows. The
+  // resolvePerson() helper is still the score-based matcher; when it
+  // reports `isNew: true` we treat that as a "no match" signal and
+  // skip the mention entirely. Authorship for first-person pronouns is
+  // handled downstream by the classifier's [AUTHORSHIP] block (#238),
+  // not here.
   const peopleMap = new Map<string, string>()
   const newAliases = new Map<string, string[]>()
   const newPeople: EntityExtractResult['newPeople'] = []
+  let unmatchedDropped = 0
 
   for (const extraction of parsed.people) {
     const resolved = resolvePerson(extraction, knownPeople, deps.config, deps.makePeopleKey)
 
-    peopleMap.set(extraction.mention, resolved.personKey)
-
     if (resolved.isNew) {
-      newPeople.push({
-        personKey: resolved.personKey,
-        canonicalName: extraction.inferredName,
-        verified: false,
-      })
+      // No matching Person row — drop this mention. Do NOT add it to
+      // peopleMap (which would seed a FRAGMENT_MENTIONS_PERSON edge to
+      // a non-existent person) and do NOT push it onto newPeople
+      // (which would have persist.ts upsert a Person on its behalf).
+      unmatchedDropped++
+      continue
     }
+
+    peopleMap.set(extraction.mention, resolved.personKey)
 
     if (resolved.newAlias) {
       const existing = newAliases.get(resolved.personKey) ?? []
@@ -191,6 +199,8 @@ export async function entityExtract(
     status: 'completed',
     metadata: {
       totalMentions: parsed.people.length,
+      matchedMentions: peopleMap.size,
+      unmatchedDropped,
       newPeople: newPeople.length,
     },
   })
@@ -199,7 +209,10 @@ export async function entityExtract(
     data: {
       peopleMap,
       newAliases,
-      extractions: parsed.people,
+      // Filter extractions down to those that matched so persist's
+      // mention-to-fragment edge logic can't re-introduce a dropped
+      // mention. Unmatched mentions never reach persist.
+      extractions: parsed.people.filter((e) => peopleMap.has(e.mention)),
       newPeople,
     },
     durationMs: Date.now() - start,

--- a/packages/agent/src/stages/types.ts
+++ b/packages/agent/src/stages/types.ts
@@ -74,6 +74,13 @@ export interface WikiClassifyDeps {
     limit: number
   ) => Promise<Array<{ wikiKey: string; score: number }>>
   loadThreads: (wikiKeys: string[]) => Promise<ThreadInfo[]>
+  /**
+   * Resolve the owner-Person display name (#238). Implementations should
+   * return null when no owner row is seeded yet — the loader falls back
+   * to a generic "the owner" label so the prompt's [AUTHORSHIP] block
+   * stays grammatical.
+   */
+  loadOwnerName?: () => Promise<string | null>
   llmCall: (system: string, user: string) => Promise<WikiClassificationOutput>
   emitEvent: EmitEvent
 }

--- a/packages/agent/src/stages/wiki-classify.ts
+++ b/packages/agent/src/stages/wiki-classify.ts
@@ -46,9 +46,12 @@ export async function wikiClassify(
     }))
   )
 
+  const ownerName = deps.loadOwnerName ? ((await deps.loadOwnerName()) ?? undefined) : undefined
+
   const spec = loadWikiClassificationSpec({
     content: input.fragmentContent,
     wikis: wikisJson,
+    ownerName,
   })
   const result = await deps.llmCall(spec.system, spec.user)
 

--- a/packages/shared/src/__tests__/prompts/standalone-specs.test.ts
+++ b/packages/shared/src/__tests__/prompts/standalone-specs.test.ts
@@ -92,10 +92,14 @@ describe('fragmentation', () => {
     expect(result.user).toContain('confidence')
   })
 
-  it('injects correct fragmentTarget for short content', () => {
+  it('does NOT inject wordCount/fragmentTarget into the rendered template (v6)', () => {
+    // v6 dropped the word-count → target heuristic in favour of topic
+    // coherence. The loader still computes a code-side ceiling, but the
+    // prompt body must not nudge the LLM toward a target number.
     const result = loadFragmentationSpec({ content: 'short entry' })
-    expect(result.user).toContain('approximately 2 words')
-    expect(result.user).toContain('approximately 1 fragments')
+    expect(result.user).not.toContain('approximately 2 words')
+    expect(result.user).not.toContain('approximately 1 fragments')
+    expect(result.user).not.toMatch(/\{\{wordCount\}\}|\{\{fragmentTarget\}\}/)
   })
 })
 

--- a/packages/shared/src/prompts/loaders/fragmentation.ts
+++ b/packages/shared/src/prompts/loaders/fragmentation.ts
@@ -9,10 +9,17 @@ const inputSchema = z.object({
 })
 
 /**
- * Compute fragment target and hard ceiling from word count.
+ * Compute hard fragment ceiling from word count.
+ *
+ * v6 dropped the prompt-side `target` nudge — atomicity is now judged by
+ * topic coherence, not by length. The ceiling is still useful as a code
+ * safety net to prevent runaway over-splitting on very long entries, so
+ * the function and `target` field are kept for backward compatibility
+ * with `packages/agent/src/stages/fragment.ts`.
  *
  * @param wordCount - number of words in the entry content
- * @returns `{ target, ceiling }` — target is the prompt hint, ceiling is the code-enforced max
+ * @returns `{ target, ceiling }` — both are code-side caps; neither is
+ *   injected into the prompt template.
  */
 export function computeFragmentLimits(wordCount: number) {
   const target = Math.max(1, Math.min(30, Math.round(wordCount / 150)))
@@ -27,14 +34,7 @@ export function loadFragmentationSpec(vars: {
   const validated = inputSchema.parse(vars)
   const spec = loadSpec('fragmentation.yaml')
 
-  const wordCount = validated.content.split(/\s+/).filter(Boolean).length
-  const { target: fragmentTarget } = computeFragmentLimits(wordCount)
-
-  const user = renderTemplate(spec.template, {
-    ...validated,
-    wordCount,
-    fragmentTarget,
-  })
+  const user = renderTemplate(spec.template, validated)
   return {
     system: spec.system_message,
     user,

--- a/packages/shared/src/prompts/loaders/wiki-classification.ts
+++ b/packages/shared/src/prompts/loaders/wiki-classification.ts
@@ -6,17 +6,27 @@ import type { PromptResult } from '../types.js'
 const inputSchema = z.object({
   content: z.string(),
   wikis: z.string(),
+  // Optional at the loader boundary so callers that haven't been wired
+  // through yet still compile. Falls back to a generic "the owner" label
+  // for the [AUTHORSHIP] block — keeps the prompt grammatical even
+  // before the owner-Person seed has run on a fresh DB.
+  ownerName: z.string().optional(),
   fragmentContext: z.string().optional(),
 })
 
 export function loadWikiClassificationSpec(vars: {
   content: string
   wikis: string
+  ownerName?: string
   fragmentContext?: string
 }): PromptResult {
   const validated = inputSchema.parse(vars)
+  const ownerName =
+    validated.ownerName && validated.ownerName.trim().length > 0
+      ? validated.ownerName
+      : 'the owner'
   const spec = loadSpec('wiki-classification.yaml')
-  const user = renderTemplate(spec.template, validated)
+  const user = renderTemplate(spec.template, { ...validated, ownerName })
   return {
     system: spec.system_message,
     user,

--- a/packages/shared/src/prompts/specs/fragmentation.yaml
+++ b/packages/shared/src/prompts/specs/fragmentation.yaml
@@ -48,9 +48,12 @@ template: |
   9. MERGE trivial context into its parent fragment. "Had coffee with
      Sarah" is not a standalone fragment unless the meeting itself is the
      point. Fold setting and circumstance into the substantive claim.
-  10. PRONOUNS: Replace first-person singular pronouns (I, me, my) with
-     "Author" so each fragment stands alone. This is the one allowed
-     departure from Rule 3.
+  10. PRONOUNS: Leave first-person pronouns (I, me, my) exactly as they
+     appear in the source. Do NOT substitute "Author" or any other name
+     for them. Authorship is resolved downstream by the classifier's
+     [AUTHORSHIP] block, not by rewriting the fragment text. Preserving
+     the original wording keeps Rule 3 intact and avoids drift when text
+     contains multiple speakers.
 
   [FRAGMENT TYPES — use the most specific type that fits]
   - fact: A concrete, verifiable statement about something that happened or is true.

--- a/packages/shared/src/prompts/specs/fragmentation.yaml
+++ b/packages/shared/src/prompts/specs/fragmentation.yaml
@@ -1,5 +1,5 @@
 name: ElfieTheFragmentor
-version: 4
+version: 6
 category: extraction
 system_only: true
 task: fragmentation
@@ -30,16 +30,25 @@ template: |
   5. If something is ambiguous, keep it ambiguous in the fragment.
      Do not resolve ambiguity by guessing.
   6. Attribution matters: "Sarah said X" is different from "X is true."
-  7. GRANULARITY: This entry is approximately {{wordCount}} words.
-     Aim for approximately {{fragmentTarget}} fragments. Combine closely
+  7. GRANULARITY (topic coherence, NOT length): Each fragment is one
+     atomic idea. Judge atomicity by topic coherence — does it hold
+     together as a single claim, observation, or commitment? — not by
+     length or sentence tally. A long, tightly-coherent fragment is
+     better than two short, half-overlapping ones. Combine closely
      related claims into a single fragment rather than splitting each
-     sentence. Prefer fewer, richer fragments over many thin ones.
-     Each fragment should be 1-3 sentences. If a fragment needs more,
-     it is probably not atomic — split it further.
-  8. MERGE trivial context into its parent fragment. "Had coffee with
+     sentence. Prefer fewer, richer fragments over many thin ones. If a
+     fragment covers two distinct ideas, split it; if it covers one
+     idea in 1-5 sentences, keep it whole.
+  8. FLUFF FILTER: Strip filler, preamble, and signposting prose. Phrases
+     like "so", "anyway", "as I was saying", "let me explain", "ok so",
+     "honestly", "I guess", "you know", "I mean" carry no atomic idea
+     and MUST NOT become fragments. Drop greeting/sign-off lines and
+     conversational scaffolding ("just journaling", "writing this down",
+     "thinking out loud") unless the act itself is the substantive claim.
+  9. MERGE trivial context into its parent fragment. "Had coffee with
      Sarah" is not a standalone fragment unless the meeting itself is the
      point. Fold setting and circumstance into the substantive claim.
-  9. PRONOUNS: Replace first-person singular pronouns (I, me, my) with
+  10. PRONOUNS: Replace first-person singular pronouns (I, me, my) with
      "Author" so each fragment stands alone. This is the one allowed
      departure from Rule 3.
 
@@ -114,12 +123,6 @@ input_variables:
     required: true
   - name: context
     description: Context summary from related notes
-    required: false
-  - name: wordCount
-    description: Computed word count of the content (injected by loader)
-    required: false
-  - name: fragmentTarget
-    description: Computed target fragment count (injected by loader)
     required: false
 
 output:

--- a/packages/shared/src/prompts/specs/people-extraction.yaml
+++ b/packages/shared/src/prompts/specs/people-extraction.yaml
@@ -1,64 +1,77 @@
-name: ElfieTheExtractor
-version: 1
+name: ElfieTheMatcher
+version: 2
 category: extraction
 system_only: true
 task: people_extraction
-description: Extracts person mentions and identity signals from text.
+description: Matches person mentions in text to existing Person records (matcher-only — never proposes new people).
 temperature: 0.0
 
 system_message: |
-  You are Elfie, a precise entity extractor. Your job is to identify every
-  person mentioned in text — by name, role, pronoun resolution, or
-  contextual reference. You are thorough: missing a person means losing
-  a relationship in the knowledge graph. You are careful: inventing a
-  person that isn't there corrupts the graph.
+  You are Elfie, a precise entity matcher. Your job is to find which of
+  the KNOWN PEOPLE are mentioned in a passage of text. You are
+  matcher-only: you NEVER propose new people. If a mention does not
+  correspond to an entry in KNOWN PEOPLE, you skip it. People records
+  are created elsewhere (manually by the user, or via dedicated
+  workflows) — your job is solely to match.
 
 template: |
   [MOCK ACKNOWLEDGMENT]
-  Understood. I am Elfie. I extract every person referenced in the input,
-  whether by name, title, role, or description. I never invent people who
-  aren't mentioned. I never skip people who are. When a reference is
-  ambiguous, I flag it rather than guessing.
+  Understood. I am Elfie, the matcher. I only return people that
+  correspond to an entry in KNOWN PEOPLE. If a name or role in the
+  text has no match in KNOWN PEOPLE, I drop it silently. I never
+  invent new people, never propose creates, never set matchedKey to
+  null. When KNOWN PEOPLE is empty, I return an empty list.
 
   [TASK]
-  Extract all person mentions from the following text.
+  Match the following text against the KNOWN PEOPLE list. Return only
+  the people that genuinely appear in BOTH.
 
   {{#if knownPeople}}
-  [KNOWN PEOPLE — match against these first]
+  [KNOWN PEOPLE — the only valid match targets]
   {{knownPeople}}
+  {{else}}
+  [KNOWN PEOPLE]
+  (empty — no matches are possible. Return an empty people list.)
   {{/if}}
 
   [RULES — READ CAREFULLY]
-  1. Extract every distinct person mentioned, whether by name, role,
-     nickname, or description ("my manager", "the CTO", "Sarah").
-  2. If a person matches a known person (by name or alias), reference
-     their existing key.
-  3. If a person is new, set matchedKey to null.
-  4. Preserve the exact surface form used in the text as the mention.
-  5. Do not merge two people unless the text explicitly states they are
+  1. MATCHER-ONLY. For every person you return, matchedKey MUST point
+     to an entry in KNOWN PEOPLE. Never set matchedKey to null.
+  2. If a mention in the text has NO entry in KNOWN PEOPLE — by name,
+     alias, role, or any other signal — DROP it silently. Do NOT
+     return it with matchedKey: null. Do NOT invent a key.
+  3. If KNOWN PEOPLE is empty, return an empty people list. There are
+     no possible matches.
+  4. Match by name, alias, or unambiguous role reference ("my manager"
+     only matches a known person if the surrounding text or known
+     aliases make the link unambiguous).
+  5. Preserve the exact surface form used in the text as the mention.
+  6. Do not merge two people unless the text explicitly states they are
      the same person.
-  6. Do not extract organizations, teams, or groups — only individuals.
-  7. Generic references ("someone", "people", "they" without antecedent)
-     are not person extractions.
+  7. Do not match organizations, teams, or groups — only individuals.
+  8. Generic references ("someone", "people", "they" without antecedent)
+     never match.
 
   [REINFORCEMENT]
-  Remember: you are Elfie. You extract every person, miss none, invent
-  none. A missed person is a lost connection. A hallucinated person is
-  a corrupt connection. Both are failures. The right extraction is always
-  grounded in the text. You are excellent at this.
+  Remember: you are Elfie the matcher, not an extractor. A spurious
+  match (returning someone the text doesn't refer to) corrupts the
+  graph. A dropped unmatched mention is the correct outcome — Person
+  creation is NOT your job. The right answer is always grounded in
+  BOTH the text and KNOWN PEOPLE. You are excellent at this.
 
   [COMMON MISTAKES TO AVOID]
+  - Returning matchedKey: null for an unknown mention. Drop it instead.
   - Treating company names as people ("Google said" — Google is not a person)
-  - Merging two different people with similar names without evidence
-  - Missing people referenced only by role ("my therapist", "the interviewer")
-  - Extracting the author as a person mention (the author is implicit, not
-    a mention, unless they refer to themselves by name)
-  - Resolving pronouns to people not mentioned in the text
+  - Matching two different people with similar names without evidence
+  - Matching a role-only mention ("the CTO") to a known person without
+    explicit text-side evidence linking them
+  - Matching the author/owner via first-person pronouns. Authorship is
+    handled downstream — leave I/me/my alone here.
 
-  [TEXT TO EXTRACT FROM]
+  [TEXT TO MATCH AGAINST KNOWN PEOPLE]
   {{content}}
 
-  Produce the right JSON output with every person found.
+  Return only people whose matchedKey is a valid KNOWN PEOPLE key.
 
 input_variables:
   - name: content
@@ -79,6 +92,14 @@ few_shot_examples:
       knownPeople: '[{"key": "person01A", "canonicalName": "Sarah Ouma", "aliases": ["Sarah"]}]'
     output: >
       {"people": [{"mention": "Sarah", "inferredName": "Sarah Ouma", "matchedKey": "person01A",
-      "confidence": 0.9, "sourceSpan": "Had coffee with Sarah"},
-      {"mention": "My manager", "inferredName": "manager (unnamed)", "matchedKey": null,
-      "confidence": 0.85, "sourceSpan": "My manager wants us to ship by Friday"}]}
+      "confidence": 0.9, "sourceSpan": "Had coffee with Sarah"}]}
+  - input: >
+      content: "Had coffee with Sarah."
+      knownPeople: '[]'
+    output: >
+      {"people": []}
+  - input: >
+      content: "Bob said hello and Carol waved."
+      knownPeople: '[{"key": "person01A", "canonicalName": "Sarah Ouma", "aliases": ["Sarah"]}]'
+    output: >
+      {"people": []}

--- a/packages/shared/src/prompts/specs/wiki-classification.yaml
+++ b/packages/shared/src/prompts/specs/wiki-classification.yaml
@@ -1,5 +1,5 @@
 name: MarcelTheClassifier
-version: 2
+version: 3
 category: classification
 system_only: true
 task: wiki_classification
@@ -22,6 +22,18 @@ template: |
   [TASK]
   Determine which of the available wikis this fragment belongs to.
   A fragment may belong to zero, one, or multiple wikis.
+
+  [AUTHORSHIP]
+  The owner of this knowledge base is {{ownerName}}. When a fragment
+  contains first-person pronouns (I, me, my, mine, myself), interpret
+  them as referring to {{ownerName}} unless the surrounding text makes
+  another speaker explicit (e.g. inside a quoted attribution like
+  "Sarah said 'I will…'"). This means:
+  - "I went for a run" → an action by {{ownerName}}.
+  - "Sarah said I should refactor" → an action attributed to Sarah,
+    addressed to {{ownerName}}.
+  Use this when judging fit against an owner-centric wiki (e.g. a
+  wiki about {{ownerName}}'s habits, decisions, or projects).
 
   [AVAILABLE WIKIS]
   {{wikis}}
@@ -66,6 +78,12 @@ input_variables:
     description: >
       JSON array of available wikis, each with key, name, wikiType,
       and description.
+    required: true
+  - name: ownerName
+    description: >
+      Display name of the owner-Person (the user account itself).
+      Resolves first-person pronouns in the fragment text via the
+      [AUTHORSHIP] block.
     required: true
   - name: fragmentContext
     description: The source entry text for additional context


### PR DESCRIPTION
## Summary

Closes the fragmenter + classifier epic cluster. Three changes that re-shape ingest-pipeline prompts and identity handling.

- **#242** (epic) — fragmenter v6 prompt: drop word-count target, switch to topic-coherence + fluff filter. The fragmenter no longer chases a fragment count; instead it splits on atomic-idea boundaries and strips filler/preamble/signposting prose. \`computeFragmentLimits\` is retained as a code-side ceiling.
- **#238** (epic) — owner-Person concept + classifier \`[AUTHORSHIP]\` block:
  - First-time login seeds a Person record marked \`is_owner=true\` (one per user, partial unique index).
  - Classifier prompt gets a new \`[AUTHORSHIP]\` block that names the owner explicitly and instructs the model to interpret first-person pronouns as the owner.
  - Fragmenter STOPS substituting first-person pronouns — it leaves them as-is. AUTHORSHIP block at classify-time handles authorship.
- **#237** — Elfie re-positioned as matcher-only (was: matcher-or-extractor). Unmatched person mentions are now dropped instead of becoming Person creates. Renamed \`ElfieTheExtractor\` → \`ElfieTheMatcher\`. Kept \`category: extraction\` in the spec because the existing enum doesn't yet have \`matching\` (small follow-up if we want to expand).

## UAT contract (3 new plans)

| Issue | Plan | Pre-fix | Post-fix |
|-------|------|---------|----------|
| #242 | \`.uat/plans/46-fragmenter-v6.md\` (4 sections, 10 assertions) | 1/10 P | 10/10 P |
| #238 | \`.uat/plans/47-owner-person-authorship.md\` (5 sections, 14 assertions) | 0/14 P | 14/14 P |
| #237 | \`.uat/plans/48-elfie-matcher-only.md\` (3 sections, 9 assertions) | 0/9 P | 9/9 P |

## Migration

- \`0011_people_is_owner.sql\` — adds \`is_owner boolean NOT NULL DEFAULT false\` on \`people\` + partial unique index \`people_is_owner_uidx\` enforcing at most one live owner per user.

> ⚠️ **Conflicts with cluster 9a** (PR #279): both write \`0011_*.sql\`. Whichever merges second renames its migration to 0013 — orchestrator handles at merge time.

## Files

- \`packages/shared/src/prompts/specs/fragmentation.yaml\` (v4→v6)
- \`packages/shared/src/prompts/specs/wiki-classification.yaml\` (v2→v3, AUTHORSHIP block)
- \`packages/shared/src/prompts/specs/people-extraction.yaml\` (v1→v2, matcher rewrite)
- \`packages/shared/src/prompts/loaders/{fragmentation,wiki-classification}.ts\`
- \`packages/agent/src/stages/{types,wiki-classify,entity-extract}.ts\`
- \`packages/agent/src/__tests__/entity-extract.test.ts\`
- \`core/src/db/schema.ts\` (\`people.is_owner\`)
- \`core/src/queue/worker.ts\` (wires \`loadOwnerName\`)
- \`core/src/bootstrap/jit-provision.ts\` (\`ensureOwnerPerson\` + \`loadOwnerPersonName\` helpers)
- 1 migration + journal

LOC: +784 / −85 across 18 files (~+301 source / +483 UAT plans).

## Open follow-ups

- No live-LLM behavioral tests (per handover policy: assert structural shape, not LLM prose quality). Each plan documents in Notes what behavioral test was skipped.
- \`category: matching\` enum value not added — if cluster 9a or future work expands the enum, the people-extraction spec can adopt \`matching\` cleanly. Current value is \`extraction\` which is a slight mislabel.
- Pre-existing test failures (NOT from this cluster): \`wiki-relevance\` test in \`standalone-specs.test.ts\` and 3 tests in \`persist-people.test.ts\` reference vault concepts pre-dating M2 collapse. Verified by stash-and-rerun on \`271bf88\`.

Closes #242
Closes #238
Closes #237