### PR TITLE
fix(env): normalize bare-domain SERVER_PUBLIC_URL + WIKI_ORIGIN to https://

### DIFF
--- a/core/src/bootstrap/__tests__/env.test.ts
+++ b/core/src/bootstrap/__tests__/env.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Required env vars must be present before the env module is first imported,
+// otherwise `createConfigVar` calls `process.exit(1)` at module load time.
+const baseProdlikeEnv: Record<string, string> = {
+  NODE_ENV: 'test',
+  DATABASE_URL: 'postgres://localhost/robin_test',
+  REDIS_URL: 'redis://localhost:6379',
+  BETTER_AUTH_SECRET: 'a'.repeat(40),
+  MASTER_KEY: 'a'.repeat(64),
+  KEY_ENCRYPTION_SECRET: 'b'.repeat(40),
+  INITIAL_USERNAME: 'admin@example.com',
+  INITIAL_PASSWORD: 'password123',
+  OPENROUTER_API_KEY: 'sk-test',
+  SERVER_PUBLIC_URL: 'https://api.example.com',
+  WIKI_ORIGIN: 'https://wiki.example.com',
+}
+for (const [k, v] of Object.entries(baseProdlikeEnv)) {
+  process.env[k] = v
+}
+
+// Import the helper after env is populated so the module doesn't blow up on load.
+const { normalizeOrigin } = await import('../env.js')
+
+describe('normalizeOrigin', () => {
+  it('prepends https:// to bare hostnames', () => {
+    expect(normalizeOrigin('api.example.com')).toBe('https://api.example.com')
+  })
+
+  it('preserves https:// URLs unchanged', () => {
+    expect(normalizeOrigin('https://api.example.com')).toBe('https://api.example.com')
+  })
+
+  it('preserves http:// URLs unchanged (local dev)', () => {
+    expect(normalizeOrigin('http://localhost:3000')).toBe('http://localhost:3000')
+  })
+
+  it('trims surrounding whitespace before deciding', () => {
+    expect(normalizeOrigin('  api.example.com  ')).toBe('https://api.example.com')
+    expect(normalizeOrigin('  https://api.example.com  ')).toBe('https://api.example.com')
+  })
+
+  it('treats existing scheme prefixes case-insensitively', () => {
+    expect(normalizeOrigin('HTTPS://api.example.com')).toBe('HTTPS://api.example.com')
+  })
+})
+
+// Each scenario re-imports `../env.js` after mutating process.env so we
+// observe a fresh schema parse + post-parse mutation.
+async function loadEnvModule(envOverrides: Record<string, string | undefined>) {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) {
+      delete process.env[k]
+    } else {
+      process.env[k] = v
+    }
+  }
+  return import('../env.js')
+}
+
+describe('env module post-parse normalization', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    for (const k of Object.keys(process.env)) {
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) {
+      delete process.env[k]
+    }
+    Object.assign(process.env, originalEnv)
+    vi.resetModules()
+  })
+
+  it('normalizes bare-hostname SERVER_PUBLIC_URL to https://', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'api.example.com',
+      WIKI_ORIGIN: 'https://wiki.example.com',
+    })
+    expect(process.env.SERVER_PUBLIC_URL).toBe('https://api.example.com')
+  })
+
+  it('leaves already-prefixed https SERVER_PUBLIC_URL unchanged', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'https://api.example.com',
+      WIKI_ORIGIN: 'https://wiki.example.com',
+    })
+    expect(process.env.SERVER_PUBLIC_URL).toBe('https://api.example.com')
+  })
+
+  it('preserves http:// SERVER_PUBLIC_URL for local dev', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'http://localhost:3000',
+      WIKI_ORIGIN: 'http://localhost:8080',
+    })
+    expect(process.env.SERVER_PUBLIC_URL).toBe('http://localhost:3000')
+  })
+
+  it('normalizes bare-hostname WIKI_ORIGIN to https://', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'https://api.example.com',
+      WIKI_ORIGIN: 'wiki.example.com',
+    })
+    expect(process.env.WIKI_ORIGIN).toBe('https://wiki.example.com')
+  })
+
+  it('normalizes mixed comma-separated WIKI_ORIGIN entries', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'https://api.example.com',
+      WIKI_ORIGIN: 'https://wiki.example.com,custom.example.com',
+    })
+    expect(process.env.WIKI_ORIGIN).toBe(
+      'https://wiki.example.com,https://custom.example.com',
+    )
+  })
+
+  it('preserves http:// entries while normalizing bare ones in WIKI_ORIGIN', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'https://api.example.com',
+      WIKI_ORIGIN: 'https://wiki.example.com,http://localhost:8080',
+    })
+    expect(process.env.WIKI_ORIGIN).toBe(
+      'https://wiki.example.com,http://localhost:8080',
+    )
+  })
+
+  it('trims whitespace around comma-separated WIKI_ORIGIN entries', async () => {
+    await loadEnvModule({
+      ...baseProdlikeEnv,
+      SERVER_PUBLIC_URL: 'https://api.example.com',
+      WIKI_ORIGIN: '  https://wiki.example.com ,  custom.example.com  ',
+    })
+    expect(process.env.WIKI_ORIGIN).toBe(
+      'https://wiki.example.com,https://custom.example.com',
+    )
+  })
+
+  it('rejects garbage SERVER_PUBLIC_URL even after normalization', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((_code?: number) => {
+        throw new Error('process.exit called')
+      }) as never)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      loadEnvModule({
+        ...baseProdlikeEnv,
+        SERVER_PUBLIC_URL: 'not a url at all',
+        WIKI_ORIGIN: 'https://wiki.example.com',
+      }),
+    ).rejects.toThrow('process.exit called')
+
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('rejects empty WIKI_ORIGIN entries from a stray comma', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((_code?: number) => {
+        throw new Error('process.exit called')
+      }) as never)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      loadEnvModule({
+        ...baseProdlikeEnv,
+        SERVER_PUBLIC_URL: 'https://api.example.com',
+        WIKI_ORIGIN: 'https://wiki.example.com,',
+      }),
+    ).rejects.toThrow('process.exit called')
+
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+})

--- a/core/src/bootstrap/env.ts
+++ b/core/src/bootstrap/env.ts
@@ -43,6 +43,18 @@ export function assertProdEnv(): void {
 // in production produces one clean error instead of a Zod-style wall of issues.
 assertProdEnv()
 
+/**
+ * Prepend `https://` to a bare hostname so values like the Railway interpolation
+ * `${{wiki.RAILWAY_PUBLIC_DOMAIN}}` (which resolves to `wiki-prod.up.railway.app`
+ * — no scheme) survive URL validation. Existing `http://` or `https://` prefixes
+ * are preserved so local dev stays untouched.
+ */
+export function normalizeOrigin(value: string): string {
+  const trimmed = value.trim()
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  return `https://${trimmed}`
+}
+
 export const env = createConfigVar({
   schema: {
     DATABASE_URL: z.string().min(1).describe('Postgres connection string'),
@@ -51,7 +63,14 @@ export const env = createConfigVar({
       .string()
       .min(32)
       .describe('32+ char session signing key (openssl rand -hex 32)'),
-    SERVER_PUBLIC_URL: z.string().url().describe('Server public URL, e.g. https://api.example.com'),
+    SERVER_PUBLIC_URL: z
+      .string()
+      .min(1)
+      .transform(normalizeOrigin)
+      .pipe(z.string().url())
+      .describe(
+        'Server public URL, e.g. https://api.example.com (bare domain auto-prepends https://)',
+      ),
     MASTER_KEY: z
       .string()
       .regex(/^[a-f0-9]{64}$/)
@@ -63,13 +82,32 @@ export const env = createConfigVar({
     WIKI_ORIGIN: z
       .string()
       .min(1)
-      .refine(
-        (val) => val.split(',').every((u) => /^https?:\/\//.test(u.trim())),
-        'Each comma-separated origin must start with http:// or https://',
+      .transform((val) =>
+        val
+          .split(',')
+          .map((entry) => normalizeOrigin(entry))
+          .join(','),
       )
-      .describe('Wiki frontend URL(s) for CORS — comma-separated for multiple origins'),
+      .pipe(
+        z
+          .string()
+          .refine(
+            (val) => val.split(',').every((u) => z.string().url().safeParse(u).success),
+            'Each comma-separated origin must be a valid URL (bare domain auto-prepends https://)',
+          ),
+      )
+      .describe(
+        'Wiki frontend URL(s) for CORS — comma-separated; bare domains auto-prepend https://',
+      ),
     PORT: z.coerce.number().default(3000).describe('Server port'),
     NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
     LOG_LEVEL: z.string().default('info'),
   },
 })
+
+// Propagate normalized values back to process.env. Several call sites read
+// `process.env.SERVER_PUBLIC_URL` / `process.env.WIKI_ORIGIN` directly
+// (auth.ts, index.ts, routes/users.ts) and won't see the schema's transform
+// otherwise. Mutating here keeps the validator the single source of truth.
+if (env.SERVER_PUBLIC_URL) process.env.SERVER_PUBLIC_URL = env.SERVER_PUBLIC_URL
+if (env.WIKI_ORIGIN) process.env.WIKI_ORIGIN = env.WIKI_ORIGIN


### PR DESCRIPTION
## Summary

Closes the Railway-deploy footgun where \`\${{wiki.RAILWAY_PUBLIC_DOMAIN}}\` interpolation returns a bare hostname (\`wiki-prod-1234.up.railway.app\`) and our env validator rejects it because Zod's \`.url()\` requires a protocol scheme.

Now both \`SERVER_PUBLIC_URL\` and \`WIKI_ORIGIN\` accept bare domains and auto-prepend \`https://\` if no protocol is present. \`http://\` is preserved (local dev still works). Comma-separated multi-origin support for \`WIKI_ORIGIN\` is preserved.

## What changed

- **\`core/src/bootstrap/env.ts\`** — added \`normalizeOrigin(value: string): string\` helper. Trims whitespace, returns unchanged if matches \`^https?:\/\/\` (case-insensitive), else prepends \`https://\`.
  - \`SERVER_PUBLIC_URL: z.string().min(1).transform(normalizeOrigin).pipe(z.string().url())\` — bare → https:// → validated as URL
  - \`WIKI_ORIGIN\` — split on comma, trim, normalize each, rejoin, then refine that every entry parses as URL
  - \`.describe()\` strings updated to mention bare-domain auto-prepending
- After \`createConfigVar\` returns, mutate \`process.env.SERVER_PUBLIC_URL\` and \`process.env.WIKI_ORIGIN\` from the parsed \`env.X\` values so downstream \`process.env.X\` reads (e.g. \`auth.ts:34\`, \`index.ts:80\`) see the normalized form.

## Tests

\`core/src/bootstrap/__tests__/env.test.ts\` (NEW) — **14 tests, all passing**:
- 5 unit tests for the \`normalizeOrigin\` helper (bare → https://, http:// preserved, https:// preserved, case-insensitive scheme detect, whitespace trim)
- 9 module-time integration tests (post-parse \`process.env\` mutation, comma-mix, whitespace around commas, garbage rejection, stray-comma rejection)

Pre-fix: 9/14 fail. Post-fix: 14/14 pass.

## What this fixes for the Railway redeploy

Before this PR, operators had to set:
```
SERVER_PUBLIC_URL = https://\${{core.RAILWAY_PUBLIC_DOMAIN}}
WIKI_ORIGIN       = https://\${{wiki.RAILWAY_PUBLIC_DOMAIN}}
```
(literal \`https://\` prefix mandatory, easy to forget)

After this PR, both forms work:
```
SERVER_PUBLIC_URL = \${{core.RAILWAY_PUBLIC_DOMAIN}}                # bare → auto-https://
SERVER_PUBLIC_URL = https://\${{core.RAILWAY_PUBLIC_DOMAIN}}        # explicit, also fine
SERVER_PUBLIC_URL = https://api.example.com                        # custom domain
```

## Files

- \`core/src/bootstrap/env.ts\` (+43 / −5)
- \`core/src/bootstrap/__tests__/env.test.ts\` (+187, NEW)

LOC: +230 / −5.

## Out of scope

- Other env validators (\`DATABASE_URL\`, \`REDIS_URL\`, etc.) — not Railway-domain-driven, no normalization needed.
- The remaining 7 description-only env vars in \`railway.template.json\` (\`MASTER_KEY\`, \`BETTER_AUTH_SECRET\`, etc.) still require operator-set values; this PR doesn't change those.