### PR TITLE
feat: 5-item upstream bundle from builder-25 (nested-section, embedding completeness, Collections UI, prompt rule-2) + 0001 migration

### DIFF
--- a/core/drizzle/migrations/0001_wikis_people_embedding_retry_columns.sql
+++ b/core/drizzle/migrations/0001_wikis_people_embedding_retry_columns.sql
@@ -1,0 +1,13 @@
+-- Add embedding-retry bookkeeping columns to wikis + people, mirroring fragments.
+-- Generalises the retry worker (was fragments-only) to all three embeddable tables.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS so fresh installs that already received
+-- these columns via a future bootstrap update don't double-error.
+
+ALTER TABLE wikis
+  ADD COLUMN IF NOT EXISTS embedding_attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS embedding_last_attempt_at timestamp;
+
+ALTER TABLE people
+  ADD COLUMN IF NOT EXISTS embedding_attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS embedding_last_attempt_at timestamp;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777571058035,
       "tag": "0000_bootstrap",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1778457600000,
+      "tag": "0001_wikis_people_embedding_retry_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -256,6 +256,10 @@ export const wikis = pgTable(
     regenerate: boolean('regenerate').notNull().default(true),
     bouncerMode: text('bouncer_mode').notNull().default('auto'), // 'auto' | 'review'
     embedding: vector('embedding', { dimensions: 1536 }),
+    // Embedding retry bookkeeping — same shape as fragments. The retry
+    // worker scans rows where embedding IS NULL and self-heals.
+    embeddingAttemptCount: integer('embedding_attempt_count').notNull().default(0),
+    embeddingLastAttemptAt: timestamp('embedding_last_attempt_at'),
     searchVector: tsvector('search_vector'),
     progress: jsonb('progress').$type<{
       milestones: { label: string; completed: boolean }[]
@@ -310,6 +314,9 @@ export const people = pgTable(
     isOwner: boolean('is_owner').notNull().default(false),
     lastRebuiltAt: timestamp('last_rebuilt_at'),
     embedding: vector('embedding', { dimensions: 1536 }),
+    // Embedding retry bookkeeping — same shape as fragments and wikis.
+    embeddingAttemptCount: integer('embedding_attempt_count').notNull().default(0),
+    embeddingLastAttemptAt: timestamp('embedding_last_attempt_at'),
     searchVector: tsvector('search_vector'),
   },
   (t) => [

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -47,8 +47,9 @@ import {
 } from '../db/schema.js'
 import { resolveWikiBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { resolvePerson, DEFAULT_RESOLUTION_CONFIG } from '@robin/agent'
+import { resolvePerson, DEFAULT_RESOLUTION_CONFIG, embedText } from '@robin/agent'
 import type { KnownPerson } from '@robin/agent'
+import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { eq, and, isNull } from 'drizzle-orm'
 import { nanoid } from '../lib/id.js'
 import { logger } from '../lib/logger.js'
@@ -584,6 +585,30 @@ export async function handleCreateWiki(
       state: 'PENDING',
       prompt: '',
     })
+
+    // Embed the wiki at create time. Without this, freshly-created wikis are
+    // invisible to vector search until their first regen — which can be hours
+    // away. Mirrors the HTTP POST /wikis path. Falls through silently on
+    // failure; the row is still created.
+    try {
+      const orConfig = await loadOpenRouterConfig()
+      const textToEmbed = `${input.title.trim()} ${input.description.trim()}`.trim()
+      const wikiVec = await embedText(textToEmbed, {
+        apiKey: orConfig.apiKey,
+        model: orConfig.models.embedding,
+      })
+      if (wikiVec) {
+        await deps.db
+          .update(wikisTable)
+          .set({ embedding: wikiVec })
+          .where(eq(wikisTable.lookupKey, lookupKey))
+      }
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), wikiKey: lookupKey },
+        'mcp create_wiki embedding failed — wiki created without embedding'
+      )
+    }
 
     await emitAuditEvent(deps.db, {
       entityType: 'wiki',

--- a/core/src/queue/embedding-retry-worker.ts
+++ b/core/src/queue/embedding-retry-worker.ts
@@ -1,32 +1,235 @@
 import type { EmbeddingRetryJob, JobResult } from '@robin/queue'
-import { and, isNull, lt, or, sql } from 'drizzle-orm'
+import { and, eq, isNull, lt, or, sql } from 'drizzle-orm'
 import { embedText, takeLastEmbedFailure } from '@robin/agent'
 import { db } from '../db/client.js'
-import { fragments } from '../db/schema.js'
+import { fragments, wikis, people } from '../db/schema.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { logger } from '../lib/logger.js'
 
 const log = logger.child({ component: 'embedding-retry' })
 
-/** Max fragments to retry per tick. 15-min cron × 25 rows = 100/hour ceiling. */
+/** Max rows per table per tick. 15-min cron × 25 rows × 3 tables = 300/hour ceiling. */
 const BATCH_LIMIT = 25
 
-/** Attempt cap per fragment. Past this, the row is skipped until manual ops. */
+/** Attempt cap per row. Past this, the row is skipped until manual ops. */
 const MAX_ATTEMPTS = 5
 
 /** Minimum gap between retries of the same row, to avoid tick-level hammering. */
 const MIN_RETRY_GAP_MS = 60 * 60 * 1000 // 1 hour
 
+/** A row pulled from any embeddable table — just enough to feed embedText + write back. */
+type EmbeddableRow = {
+  lookupKey: string
+  text: string
+  attemptCount: number
+}
+
 /**
- * Scheduler-driven retry of fragments whose embedding column is still NULL
- * (likely because the original ingest hit an OpenRouter failure). Bounded:
- * - BATCH_LIMIT rows per tick
- * - MAX_ATTEMPTS attempts per row, tracked via fragments.embedding_attempt_count
+ * Heal one table's worth of unembedded rows. Each call selects up to
+ * BATCH_LIMIT eligible rows, embeds each, and writes the vector or bumps
+ * the attempt counter.
+ *
+ * Bounded:
+ * - BATCH_LIMIT rows per tick per table
+ * - MAX_ATTEMPTS attempts per row, tracked via embedding_attempt_count
  * - MIN_RETRY_GAP_MS between successive attempts on the same row
+ *
+ * NOTE: the cutoff Date must be passed via Drizzle's structured `lt()`
+ * operator — interpolating it into a raw `sql\`< ${cutoff}\`` template
+ * throws "Received an instance of Date" inside postgres-js parameter
+ * binding (it expects string/Buffer/ArrayBuffer). Structured operators
+ * know the column type (`timestamp`) and serialize Date → ISO. This was
+ * the bug that broke the original fragment-only worker for months.
+ */
+async function retryTable<TableName extends 'fragments' | 'wikis' | 'people'>(
+  tableName: TableName,
+  cutoff: Date,
+  embedConfig: { apiKey: string; model: string }
+): Promise<{ scanned: number; ok: number; failed: number }> {
+  let rows: EmbeddableRow[]
+
+  if (tableName === 'fragments') {
+    const out = await db
+      .select({
+        lookupKey: fragments.lookupKey,
+        title: fragments.title,
+        content: fragments.content,
+        attemptCount: fragments.embeddingAttemptCount,
+      })
+      .from(fragments)
+      .where(
+        and(
+          isNull(fragments.embedding),
+          isNull(fragments.deletedAt),
+          sql`${fragments.embeddingAttemptCount} < ${MAX_ATTEMPTS}`,
+          or(
+            isNull(fragments.embeddingLastAttemptAt),
+            lt(fragments.embeddingLastAttemptAt, cutoff)
+          )
+        )
+      )
+      .orderBy(sql`${fragments.embeddingLastAttemptAt} NULLS FIRST`)
+      .limit(BATCH_LIMIT)
+    rows = out.map((r) => ({
+      lookupKey: r.lookupKey,
+      // Fall back to title when content is empty. Some fragments (e.g.
+      // quick-capture title-only entries) have no content body but still
+      // carry a meaningful title — embed that so vector search has at
+      // least weak signal and the row stops cluttering health snapshots
+      // as null_embedding forever.
+      text:
+        r.content && r.content.trim().length > 0
+          ? r.content
+          : r.title ?? '',
+      attemptCount: r.attemptCount,
+    }))
+  } else if (tableName === 'wikis') {
+    const out = await db
+      .select({
+        lookupKey: wikis.lookupKey,
+        name: wikis.name,
+        description: wikis.description,
+        content: wikis.content,
+        attemptCount: wikis.embeddingAttemptCount,
+      })
+      .from(wikis)
+      .where(
+        and(
+          isNull(wikis.embedding),
+          isNull(wikis.deletedAt),
+          sql`${wikis.embeddingAttemptCount} < ${MAX_ATTEMPTS}`,
+          or(
+            isNull(wikis.embeddingLastAttemptAt),
+            lt(wikis.embeddingLastAttemptAt, cutoff)
+          )
+        )
+      )
+      .orderBy(sql`${wikis.embeddingLastAttemptAt} NULLS FIRST`)
+      .limit(BATCH_LIMIT)
+    rows = out.map((r) => ({
+      lookupKey: r.lookupKey,
+      // Embed body content if present; otherwise fall back to title +
+      // description (the same placeholder POST /wikis seeds with). Regen
+      // will overwrite this with a content-based embedding once the wiki
+      // synthesises.
+      text:
+        r.content && r.content.trim().length > 0
+          ? r.content
+          : `${r.name} ${r.description ?? ''}`.trim(),
+      attemptCount: r.attemptCount,
+    }))
+  } else {
+    const out = await db
+      .select({
+        lookupKey: people.lookupKey,
+        name: people.name,
+        aliases: people.aliases,
+        relationship: people.relationship,
+        content: people.content,
+        attemptCount: people.embeddingAttemptCount,
+      })
+      .from(people)
+      .where(
+        and(
+          isNull(people.embedding),
+          isNull(people.deletedAt),
+          sql`${people.embeddingAttemptCount} < ${MAX_ATTEMPTS}`,
+          or(
+            isNull(people.embeddingLastAttemptAt),
+            lt(people.embeddingLastAttemptAt, cutoff)
+          )
+        )
+      )
+      .orderBy(sql`${people.embeddingLastAttemptAt} NULLS FIRST`)
+      .limit(BATCH_LIMIT)
+    rows = out.map((r) => ({
+      lookupKey: r.lookupKey,
+      // People embed source: name + aliases + relationship + content.
+      // Mirrors what POST /people uses at create time, plus content if
+      // a regen has filled it in.
+      text: [
+        r.name,
+        ...(r.aliases ?? []),
+        r.relationship ?? '',
+        r.content ?? '',
+      ]
+        .filter((s) => s && s.length > 0)
+        .join(' '),
+      attemptCount: r.attemptCount,
+    }))
+  }
+
+  let ok = 0
+  let failed = 0
+
+  for (const row of rows) {
+    const vec = row.text.trim().length > 0 ? await embedText(row.text, embedConfig) : null
+
+    if (vec) {
+      if (tableName === 'fragments') {
+        await db
+          .update(fragments)
+          .set({ embedding: vec, embeddingLastAttemptAt: new Date() })
+          .where(eq(fragments.lookupKey, row.lookupKey))
+      } else if (tableName === 'wikis') {
+        await db
+          .update(wikis)
+          .set({ embedding: vec, embeddingLastAttemptAt: new Date() })
+          .where(eq(wikis.lookupKey, row.lookupKey))
+      } else {
+        await db
+          .update(people)
+          .set({ embedding: vec, embeddingLastAttemptAt: new Date() })
+          .where(eq(people.lookupKey, row.lookupKey))
+      }
+      ok++
+    } else {
+      const failure = takeLastEmbedFailure()
+      log.warn(
+        { table: tableName, lookupKey: row.lookupKey, attempt: row.attemptCount + 1, failure },
+        'embedding retry failed'
+      )
+      const nextAttempt = row.attemptCount + 1
+      if (tableName === 'fragments') {
+        await db
+          .update(fragments)
+          .set({
+            embeddingAttemptCount: nextAttempt,
+            embeddingLastAttemptAt: new Date(),
+          })
+          .where(eq(fragments.lookupKey, row.lookupKey))
+      } else if (tableName === 'wikis') {
+        await db
+          .update(wikis)
+          .set({
+            embeddingAttemptCount: nextAttempt,
+            embeddingLastAttemptAt: new Date(),
+          })
+          .where(eq(wikis.lookupKey, row.lookupKey))
+      } else {
+        await db
+          .update(people)
+          .set({
+            embeddingAttemptCount: nextAttempt,
+            embeddingLastAttemptAt: new Date(),
+          })
+          .where(eq(people.lookupKey, row.lookupKey))
+      }
+      failed++
+    }
+  }
+
+  return { scanned: rows.length, ok, failed }
+}
+
+/**
+ * Scheduler-driven retry of fragments, wikis, and people whose embedding
+ * column is still NULL (likely because the original ingest/create hit an
+ * OpenRouter failure). Runs every 15 minutes per the BullMQ scheduler.
  *
  * Pairs with the boot-time reachability probe (issue #150) — if the probe
  * refuses to start workers, this never runs; if it allows workers to start,
- * this worker opportunistically heals rows that failed at ingest time.
+ * this worker opportunistically heals rows that failed at create time.
  */
 export async function processEmbeddingRetryJob(
   job: EmbeddingRetryJob
@@ -47,69 +250,24 @@ export async function processEmbeddingRetryJob(
     }
   }
 
-  const now = new Date()
-  const cutoff = new Date(now.getTime() - MIN_RETRY_GAP_MS)
+  const cutoff = new Date(Date.now() - MIN_RETRY_GAP_MS)
+  const embedConfig = { apiKey: config.apiKey, model: config.models.embedding }
 
-  // SELECT eligible rows: unembedded, not tombstoned, attempt count below cap,
-  // and either never attempted or last attempt older than the gap. Ordered so
-  // never-attempted rows (NULL last_attempt_at) go first.
-  const rows = await db
-    .select({
-      lookupKey: fragments.lookupKey,
-      content: fragments.content,
-      attemptCount: fragments.embeddingAttemptCount,
-    })
-    .from(fragments)
-    .where(
-      and(
-        isNull(fragments.embedding),
-        isNull(fragments.deletedAt),
-        lt(fragments.embeddingAttemptCount, MAX_ATTEMPTS),
-        or(
-          isNull(fragments.embeddingLastAttemptAt),
-          lt(fragments.embeddingLastAttemptAt, cutoff)
-        )
-      )
-    )
-    .orderBy(sql`${fragments.embeddingLastAttemptAt} NULLS FIRST`)
-    .limit(BATCH_LIMIT)
-
-  let ok = 0
-  let failed = 0
-
-  for (const row of rows) {
-    const vec = await embedText(row.content ?? '', {
-      apiKey: config.apiKey,
-      model: config.models.embedding,
-    })
-    if (vec) {
-      await db
-        .update(fragments)
-        .set({
-          embedding: vec,
-          embeddingLastAttemptAt: new Date(),
-        })
-        .where(sql`${fragments.lookupKey} = ${row.lookupKey}`)
-      ok++
-    } else {
-      const failure = takeLastEmbedFailure()
-      log.warn(
-        { lookupKey: row.lookupKey, attempt: row.attemptCount + 1, failure },
-        'embedding retry failed'
-      )
-      await db
-        .update(fragments)
-        .set({
-          embeddingAttemptCount: row.attemptCount + 1,
-          embeddingLastAttemptAt: new Date(),
-        })
-        .where(sql`${fragments.lookupKey} = ${row.lookupKey}`)
-      failed++
-    }
-  }
+  const fragResult = await retryTable('fragments', cutoff, embedConfig)
+  const wikiResult = await retryTable('wikis', cutoff, embedConfig)
+  const peopleResult = await retryTable('people', cutoff, embedConfig)
 
   const elapsed = Math.round(performance.now() - t0)
-  log.info({ jobId: job.jobId, scanned: rows.length, ok, failed, ms: elapsed }, 'embedding retry batch done')
+  log.info(
+    {
+      jobId: job.jobId,
+      fragments: fragResult,
+      wikis: wikiResult,
+      people: peopleResult,
+      ms: elapsed,
+    },
+    'embedding retry batch done'
+  )
 
   return {
     jobId: job.jobId,

--- a/core/src/routes/people.ts
+++ b/core/src/routes/people.ts
@@ -10,6 +10,8 @@ import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
 import { makeSidecarDeps } from '../lib/wikiSidecarDeps.js'
+import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
+import { embedText } from '@robin/agent'
 import type { WikiInfobox } from '@robin/shared/schemas/sidecar'
 import {
   personDetailResponseSchema,
@@ -108,6 +110,32 @@ peopleRouter.post('/', zValidator('json', createPersonBodySchema, validationHook
       state: 'RESOLVED',
     })
     .returning()
+
+  // Embed the person at create time. Without this, manually-created people
+  // sit unembedded until the retry worker heals them. Embed text combines
+  // the canonical name + aliases + relationship — the same dimensions vector
+  // search would compare against. Falls through silently on failure.
+  try {
+    const embedSource = [trimmedName, ...(body.aliases ?? []), body.relationship ?? '']
+      .filter((s) => s && s.length > 0)
+      .join(' ')
+    const orConfig = await loadOpenRouterConfig()
+    const vec = await embedText(embedSource, {
+      apiKey: orConfig.apiKey,
+      model: orConfig.models.embedding,
+    })
+    if (vec) {
+      await db
+        .update(people)
+        .set({ embedding: vec })
+        .where(eq(people.lookupKey, lookupKey))
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), personKey: lookupKey },
+      'create-person embedding failed — row inserted without embedding'
+    )
+  }
 
   await emitAuditEvent(db, {
     entityType: 'person',

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -5,7 +5,7 @@ import { generateSlug, makeLookupKey } from '@robin/shared'
 import { NoOpenRouterKeyError, embedText } from '@robin/agent'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { wikis, edges, wikiTypes, fragments, people, auditLog, edits, groupWikis } from '../db/schema.js'
+import { wikis, edges, wikiTypes, fragments, people, auditLog, edits, groupWikis, groups } from '../db/schema.js'
 import { resolveWikiSlug } from '../db/slug.js'
 import { inferWikiType } from '../mcp/wiki-type-inference.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
@@ -40,6 +40,40 @@ import { timelineQuerySchema } from '../schemas/audit.schema.js'
 
 const log = logger.child({ component: 'wikis' })
 
+type WikiCollectionRow = { id: string; name: string; slug: string; color: string }
+
+/**
+ * Batched collection-membership lookup. Joined into the GET /wikis response
+ * so the Explorer collection filter (and any other consumer) can render
+ * which collection(s) a wiki belongs to without N+1 calls. Returns an
+ * empty map for empty input.
+ */
+async function loadWikiCollections(
+  wikiIds: string[]
+): Promise<Map<string, WikiCollectionRow[]>> {
+  const result = new Map<string, WikiCollectionRow[]>()
+  if (wikiIds.length === 0) return result
+
+  const rows = await db
+    .select({
+      wikiId: groupWikis.wikiId,
+      id: groups.id,
+      name: groups.name,
+      slug: groups.slug,
+      color: groups.color,
+    })
+    .from(groupWikis)
+    .innerJoin(groups, eq(groups.id, groupWikis.groupId))
+    .where(inArray(groupWikis.wikiId, wikiIds))
+
+  for (const row of rows) {
+    const arr = result.get(row.wikiId) ?? []
+    arr.push({ id: row.id, name: row.name, slug: row.slug, color: row.color })
+    result.set(row.wikiId, arr)
+  }
+  return result
+}
+
 /** Prepare a wiki row for schema parsing (add id alias + computed defaults) */
 function prepareWiki(
   t: typeof wikis.$inferSelect & {
@@ -47,6 +81,7 @@ function prepareWiki(
     lastUpdated?: string
     shortDescriptor?: string
     descriptor?: string
+    collections?: WikiCollectionRow[]
   }
 ) {
   return {
@@ -57,6 +92,7 @@ function prepareWiki(
     shortDescriptor: t.shortDescriptor ?? '',
     descriptor: t.descriptor ?? '',
     progress: t.progress ?? null,
+    collections: t.collections ?? [],
   }
 }
 
@@ -93,6 +129,8 @@ wikisRouter.get('/', zValidator('query', wikiListQuerySchema, validationHook), a
     .limit(limit)
     .offset(offset)
 
+  const collectionsByWiki = await loadWikiCollections(rows.map((r) => r.wiki.lookupKey))
+
   return c.json(
     wikiListResponseSchema.parse({
       wikis: rows.map((r) =>
@@ -102,6 +140,7 @@ wikisRouter.get('/', zValidator('query', wikiListQuerySchema, validationHook), a
             noteCount: r.fragmentCount,
             shortDescriptor: r.shortDescriptor ?? '',
             descriptor: r.descriptor ?? '',
+            collections: collectionsByWiki.get(r.wiki.lookupKey) ?? [],
           })
         )
       ),
@@ -316,12 +355,15 @@ wikisRouter.get('/:id', async (c) => {
     })
   }
 
+  const collectionsByWiki = await loadWikiCollections([wiki.lookupKey])
+
   return c.json(
     wikiDetailResponseSchema.parse({
       ...prepareWiki({
         ...wiki,
         shortDescriptor: row.shortDescriptor ?? '',
         descriptor: row.descriptor ?? '',
+        collections: collectionsByWiki.get(wiki.lookupKey) ?? [],
       }),
       wikiContent: wiki.content ?? '',
       fragments: frags.map((f) => ({

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -24,6 +24,13 @@ export const updateProgressResponseSchema = z.object({
 
 // ── Response schemas ────────────────────────────────────────────────────────
 
+export const wikiCollectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  color: z.string(),
+})
+
 export const wikiResponseSchema = z.object({
   id: lookupKeySchema,
   lookupKey: lookupKeySchema,
@@ -44,6 +51,7 @@ export const wikiResponseSchema = z.object({
   bouncerMode: z.enum(['auto', 'review']).default('auto'),
   published: z.boolean().default(false),
   publishedSlug: z.string().nullable().default(null),
+  collections: z.array(wikiCollectionSchema).default([]),
 })
 
 export const wikiWithContentResponseSchema = wikiResponseSchema.extend({

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -97,8 +97,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -97,8 +97,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -100,8 +100,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -97,8 +97,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -98,8 +98,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -97,8 +97,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -103,8 +103,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -94,8 +94,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -103,8 +103,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -97,8 +97,11 @@ template: |
 
   [RULES — READ CAREFULLY]
   1. Output ONLY markdown. No YAML frontmatter. No code fences around the output.
-  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout —
-     follow it exactly. Do not add, drop, reorder, or rename headings.
+  2. The [DOCUMENT STRUCTURE] block is the source of truth for layout,
+     ordering (chronological direction, grouping), and any per-section
+     formatting prose — follow it exactly. Do not add, drop, reorder, or
+     rename headings. Do not impose a default ordering or layout that
+     contradicts the structure.
   3. Weave fragment content into prose. When you reference a fragment, use
      [[fragment:<slug>]] tokens inside complete sentences — do NOT bare-string
      the fragment title as a chip, list item, or standalone phrase. The

--- a/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
@@ -49,6 +49,37 @@ const sectionHeadingStyle: Record<2 | 3 | 4, CSSProperties> = {
   },
 };
 
+/**
+ * Compute where a section's "own" body ends — i.e. the last line that
+ * isn't covered by a nested child section.
+ *
+ * The parser returns endLine = the line before the next same-or-higher
+ * heading. For an H2 with H3 children, that means the H2's range
+ * encompasses every H3 child too. If we render the H2's body as-is, the
+ * child H3 markdown is rendered nested inside the H2's `<MarkdownContent>`,
+ * AND each H3 then also renders as its own React block — every nested
+ * section is double-rendered. Triggered first by the Log default_structure
+ * (H2 "Entries" with H3 "[YYYY-MM-DD]" sub-entries) once a Log wiki has
+ * more than one date.
+ *
+ * Trim the parent's body to end just before its first nested child; the
+ * children then render as their own blocks below. Applies recursively —
+ * an H3 with H4 children gets the same trim.
+ */
+function effectiveBodyEndLine(
+  section: SectionInfo,
+  allSections: SectionInfo[],
+): number {
+  const firstChild = allSections.find(
+    (s) =>
+      s !== section &&
+      s.level > section.level &&
+      s.startLine > section.startLine &&
+      s.startLine <= section.endLine,
+  );
+  return firstChild ? firstChild.startLine - 1 : section.endLine;
+}
+
 function SectionHeadingWithEdit({
   section,
   onEdit,
@@ -170,8 +201,9 @@ export function SectionedMarkdownBody({
       section.level >= 2 && section.level <= 4 && onEditSection !== undefined;
 
     if (canExtractHeading) {
+      const bodyEnd = effectiveBodyEndLine(section, parsed);
       const bodyOnly = lines
-        .slice(section.startLine + 1, section.endLine + 1)
+        .slice(section.startLine + 1, bodyEnd + 1)
         .join("\n");
       blocks.push(
         <div key={section.anchor} id={section.anchor}>
@@ -191,9 +223,8 @@ export function SectionedMarkdownBody({
       continue;
     }
 
-    const body = lines
-      .slice(section.startLine, section.endLine + 1)
-      .join("\n");
+    const bodyEnd = effectiveBodyEndLine(section, parsed);
+    const body = lines.slice(section.startLine, bodyEnd + 1).join("\n");
     blocks.push(
       <div key={section.anchor} id={section.anchor}>
         <MarkdownContent content={body} refs={refs} style={style} />

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -302,6 +302,7 @@ export default function WikiDetailPage() {
       bouncerMode={wiki.bouncerMode as 'auto' | 'review' | undefined}
       published={wiki.published === true}
       publishedSlug={wiki.publishedSlug ?? null}
+      collections={wiki.collections ?? []}
       infobox={{ kind: "simple", typeLabel, lastUpdated: wiki.updatedAt, showSettings: true }}
       renderCustomInfobox={
         sidecarInfobox

--- a/wiki/src/components/layout/AddCollectionModal.tsx
+++ b/wiki/src/components/layout/AddCollectionModal.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { T } from "@/lib/typography";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface AddCollectionModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Label
+      className="text-[12px] font-normal leading-4 tracking-[0.32px]"
+      style={{ color: "#545353" }}
+    >
+      {children}
+    </Label>
+  );
+}
+
+/**
+ * Slug derivation for collection names. Mirrors common kebab-case rules:
+ * lowercase, ASCII-strip, collapse non-alphanumerics into single hyphens,
+ * trim hyphens from edges. Server-side validation (createGroupBodySchema)
+ * only requires non-empty; uniqueness is enforced via UNIQUE on groups.slug.
+ */
+function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const COLOR_PALETTE: { value: string; label: string }[] = [
+  { value: "#6b7280", label: "Gray" },
+  { value: "#2563eb", label: "Blue" },
+  { value: "#16a34a", label: "Green" },
+  { value: "#9333ea", label: "Purple" },
+  { value: "#d97706", label: "Amber" },
+  { value: "#dc2626", label: "Red" },
+];
+
+export default function AddCollectionModal({ open, onClose }: AddCollectionModalProps) {
+  const wasOpen = useRef(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [color, setColor] = useState<string>(COLOR_PALETTE[0].value);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("Collection created");
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (open) {
+      if (!wasOpen.current) {
+        setName("");
+        setDescription("");
+        setColor(COLOR_PALETTE[0].value);
+        setSubmitError(null);
+        setSubmitting(false);
+        setShowToast(false);
+      }
+      wasOpen.current = true;
+    } else {
+      wasOpen.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+        toastTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleSubmit = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setSubmitError("Name is required.");
+      return;
+    }
+    const slug = slugifyName(trimmedName);
+    if (!slug) {
+      setSubmitError("Name must contain at least one letter or number.");
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      // Groups routes have no SDK binding — use plain fetch (mirrors useCollections).
+      const res = await fetch("/api/groups", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: trimmedName,
+          slug,
+          color,
+          description: description.trim(),
+          icon: "",
+        }),
+      });
+
+      if (!res.ok) {
+        let message = `Create failed (${res.status})`;
+        try {
+          const parsed = (await res.json()) as { error?: string };
+          if (parsed?.error) {
+            message =
+              res.status === 409
+                ? `A collection with the slug "${slug}" already exists. Try a different name.`
+                : parsed.error;
+          }
+        } catch {
+          /* ignore JSON parse */
+        }
+        setSubmitError(message);
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ["collections"] });
+      onClose();
+      setToastMessage("Collection created");
+      setShowToast(true);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => {
+        setShowToast(false);
+        toastTimerRef.current = null;
+      }, 2000);
+    } catch {
+      setSubmitError("Network error. Check your connection and retry.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose();
+        }}
+      >
+        <DialogContent
+          className="flex flex-col gap-0 rounded-2xl border-black/10 p-0 sm:max-w-[571px]"
+          style={{ maxHeight: "min(500px, 90vh)", overflow: "hidden" }}
+        >
+          <DialogHeader className="shrink-0 px-5 pb-2 pt-5">
+            <DialogTitle
+              style={{
+                ...T.h1,
+                color: "#111111",
+                fontWeight: 400,
+                margin: 0,
+              }}
+            >
+              Add Collection
+            </DialogTitle>
+            <DialogDescription
+              style={{
+                ...T.micro,
+                lineHeight: "19px",
+                color: "#676d76",
+                margin: 0,
+              }}
+            >
+              A bucket for grouping wikis. Use it once your knowledge base
+              outgrows a single sidebar list.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Family, Work, Personal"
+                className="h-10"
+              />
+            </div>
+
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Color</FieldLabel>
+              <div className="flex flex-wrap gap-2">
+                {COLOR_PALETTE.map((swatch) => {
+                  const selected = color === swatch.value;
+                  return (
+                    <button
+                      key={swatch.value}
+                      type="button"
+                      aria-label={swatch.label}
+                      onClick={() => setColor(swatch.value)}
+                      className="inline-flex items-center justify-center"
+                      style={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: "50%",
+                        backgroundColor: swatch.value,
+                        border: selected
+                          ? "2px solid var(--wiki-article-text)"
+                          : "1px solid var(--wiki-card-border)",
+                        cursor: "pointer",
+                        padding: 0,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 px-5 pt-4">
+              <FieldLabel>Description (optional)</FieldLabel>
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What kind of wikis belong in this collection?"
+                rows={3}
+                className="min-h-[80px] resize-none"
+              />
+            </div>
+
+            <div className="pb-5" />
+
+            {submitError ? (
+              <div
+                role="alert"
+                className="px-5 pt-3 text-[13px]"
+                style={{ color: "#c0392b" }}
+              >
+                {submitError}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="h-px w-full shrink-0 bg-[#e5e5e5]" />
+
+          <div className="flex shrink-0 items-center justify-end gap-3 px-5 py-4">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
+            >
+              {submitting ? "Creating..." : "Add Collection"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Toast
+        message={toastMessage}
+        visible={!open && showToast}
+        onDismiss={() => setShowToast(false)}
+      />
+    </>
+  );
+}

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -23,6 +23,7 @@ import {
   type WikiTypeListItem,
 } from "@/hooks/useWikiTypesList";
 import { useToggleBouncerMode } from "@/hooks/useToggleBouncerMode";
+import { useCollections } from "@/hooks/useCollections";
 import { publishWiki, unpublishWiki, updateWiki } from "@/lib/generated";
 
 export type { WikiSettingsPrefill } from "@/lib/wikiSettingsPrefill";
@@ -106,11 +107,19 @@ export default function AddWikiModal({
   const [publishedSlug, setPublishedSlug] = useState<string | null>(null);
   const [publishBusy, setPublishBusy] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
+  /** Collection membership — settings mode persists immediately via API; create
+   *  mode stages locally and applies after POST /wikis returns the new id. */
+  const [localCollections, setLocalCollections] = useState<
+    Array<{ id: string; name: string; slug: string; color: string }>
+  >([]);
+  const [collectionPendingId, setCollectionPendingId] = useState<string | null>(null);
+  const [collectionError, setCollectionError] = useState<string | null>(null);
 
   const isSettingsView = Boolean(prefill);
 
   const queryClient = useQueryClient();
   const toggleBouncer = useToggleBouncerMode();
+  const { data: allCollections } = useCollections();
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -153,6 +162,9 @@ export default function AddWikiModal({
           setPublished(Boolean(prefill.published));
           setPublishedSlug(prefill.publishedSlug ?? null);
           setPublishError(null);
+          setLocalCollections(prefill.collections ?? []);
+          setCollectionPendingId(null);
+          setCollectionError(null);
           setFieldsEditable(false);
         } else {
           setName("");
@@ -167,6 +179,9 @@ export default function AddWikiModal({
           setPublished(false);
           setPublishedSlug(null);
           setPublishError(null);
+          setLocalCollections([]);
+          setCollectionPendingId(null);
+          setCollectionError(null);
           setFieldsEditable(true);
         }
       }
@@ -199,6 +214,80 @@ export default function AddWikiModal({
   }, [wikiType]);
 
   const locked = isSettingsView && !fieldsEditable;
+
+  const handleAddToCollection = async (groupId: string) => {
+    if (!groupId || collectionPendingId) return;
+    if (localCollections.some((c) => c.id === groupId)) return;
+    const added = (allCollections ?? []).find((c) => c.id === groupId);
+    if (!added) return;
+    const entry = { id: added.id, name: added.name, slug: added.slug, color: added.color };
+
+    // Create mode (or prototype sentinel) — stage locally; POST happens after
+    // the wiki itself is created in handleConfirm.
+    const isSentinel = !wikiId || wikiId === "preview";
+    if (isSentinel) {
+      setCollectionError(null);
+      setLocalCollections((prev) => [...prev, entry]);
+      return;
+    }
+
+    setCollectionPendingId(groupId);
+    setCollectionError(null);
+    try {
+      const res = await fetch(`/api/groups/${groupId}/wikis`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ wikiId }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        setCollectionError(body || `Failed to add to collection (${res.status})`);
+        return;
+      }
+      setLocalCollections((prev) => [...prev, entry]);
+      await queryClient.invalidateQueries({ queryKey: ["wikis"] });
+      await queryClient.invalidateQueries({ queryKey: ["wiki", wikiId] });
+      await queryClient.invalidateQueries({ queryKey: ["collections"] });
+    } catch {
+      setCollectionError("Network error. Check your connection and retry.");
+    } finally {
+      setCollectionPendingId(null);
+    }
+  };
+
+  const handleRemoveFromCollection = async (groupId: string) => {
+    if (collectionPendingId) return;
+
+    const isSentinel = !wikiId || wikiId === "preview";
+    if (isSentinel) {
+      setCollectionError(null);
+      setLocalCollections((prev) => prev.filter((c) => c.id !== groupId));
+      return;
+    }
+
+    setCollectionPendingId(groupId);
+    setCollectionError(null);
+    try {
+      const res = await fetch(`/api/groups/${groupId}/wikis/${wikiId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.text().catch(() => "");
+        setCollectionError(body || `Failed to remove from collection (${res.status})`);
+        return;
+      }
+      setLocalCollections((prev) => prev.filter((c) => c.id !== groupId));
+      await queryClient.invalidateQueries({ queryKey: ["wikis"] });
+      await queryClient.invalidateQueries({ queryKey: ["wiki", wikiId] });
+      await queryClient.invalidateQueries({ queryKey: ["collections"] });
+    } catch {
+      setCollectionError("Network error. Check your connection and retry.");
+    } finally {
+      setCollectionPendingId(null);
+    }
+  };
 
   const handleConfirm = async () => {
     if (locked) {
@@ -326,9 +415,47 @@ export default function AddWikiModal({
         setSubmitError(message);
         return;
       }
+
+      // Apply staged collection memberships against the new wiki id. Best-effort
+      // and parallel: a partial failure does not roll back the wiki create — the
+      // user can re-add from settings.
+      let createdWikiId: string | undefined;
+      try {
+        const created = (await res.clone().json()) as { lookupKey?: string };
+        createdWikiId = created.lookupKey;
+      } catch {
+        /* response wasn't JSON — proceed without applying collections */
+      }
+      let collectionFailures: string[] = [];
+      if (createdWikiId && localCollections.length > 0) {
+        const results = await Promise.all(
+          localCollections.map(async (c) => {
+            try {
+              const r = await fetch(`/api/groups/${c.id}/wikis`, {
+                method: "POST",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ wikiId: createdWikiId }),
+              });
+              return r.ok ? null : c.name;
+            } catch {
+              return c.name;
+            }
+          }),
+        );
+        collectionFailures = results.filter((x): x is string => x !== null);
+        if (localCollections.length > collectionFailures.length) {
+          await queryClient.invalidateQueries({ queryKey: ["collections"] });
+        }
+      }
+
       await queryClient.invalidateQueries({ queryKey: ["wikis"] });
       onClose();
-      setToastMessage("Wiki created");
+      setToastMessage(
+        collectionFailures.length > 0
+          ? `Wiki created. Failed to file in ${collectionFailures.length} collection${collectionFailures.length === 1 ? "" : "s"}.`
+          : "Wiki created",
+      );
       setShowSavedToast(true);
       if (saveCloseTimerRef.current) {
         clearTimeout(saveCloseTimerRef.current);
@@ -452,6 +579,100 @@ export default function AddWikiModal({
               disabled={locked}
               className="min-h-[96px] resize-none"
             />
+          </div>
+
+          {/* Collections — visible in both create and settings mode. In create
+              mode, selections are staged locally and applied after POST /wikis
+              succeeds (see handleConfirm). In settings mode, add/remove fire
+              direct API calls immediately. */}
+          <div className="px-5 pt-4 flex flex-col gap-2">
+            <FieldLabel>Collections</FieldLabel>
+            {localCollections.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {localCollections.map((c) => {
+                  const removing = collectionPendingId === c.id;
+                  return (
+                    <span
+                      key={c.id}
+                      className="inline-flex items-center gap-1.5 px-2 py-1 text-[12px] border rounded-none"
+                      style={{
+                        borderColor: "var(--wiki-card-border)",
+                        opacity: removing ? 0.5 : 1,
+                      }}
+                    >
+                      <span
+                        className="inline-block h-2 w-2 rounded-full"
+                        style={{ backgroundColor: c.color || "var(--wiki-count)" }}
+                        aria-hidden
+                      />
+                      <span style={{ color: "var(--wiki-article-text)" }}>{c.name}</span>
+                      <button
+                        type="button"
+                        aria-label={`Remove from ${c.name}`}
+                        onClick={() => handleRemoveFromCollection(c.id)}
+                        disabled={removing || collectionPendingId !== null}
+                        className="ml-1 inline-flex items-center justify-center w-4 h-4 text-[14px] leading-none disabled:opacity-30 disabled:cursor-not-allowed"
+                        style={{ color: "var(--wiki-count)" }}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            ) : (
+              <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
+                Not in any collection.
+              </span>
+            )}
+            {(() => {
+              const available = (allCollections ?? []).filter(
+                (c) => !localCollections.some((lc) => lc.id === c.id),
+              );
+              if (available.length === 0) {
+                return (
+                  <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
+                    {(allCollections ?? []).length === 0
+                      ? "No collections yet — create one from + Add → Collection."
+                      : "Already in every collection."}
+                  </span>
+                );
+              }
+              return (
+                <select
+                  value=""
+                  onChange={(e) => {
+                    const id = e.target.value;
+                    if (id) {
+                      void handleAddToCollection(id);
+                      e.target.value = "";
+                    }
+                  }}
+                  disabled={collectionPendingId !== null}
+                  className="border rounded-none px-2 py-1.5 text-[12px] bg-white"
+                  style={{
+                    borderColor: "var(--wiki-card-border)",
+                    color: "var(--wiki-article-text)",
+                  }}
+                >
+                  <option value="">Add to collection…</option>
+                  {available.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              );
+            })()}
+            {collectionError ? (
+              <span
+                role="alert"
+                className="text-[11px] leading-4"
+                style={{ color: "#c0392b" }}
+              >
+                {collectionError}
+              </span>
+            ) : null}
           </div>
 
           {/* Wiki Structure (#240) — inline textarea matching the

--- a/wiki/src/components/layout/Header.tsx
+++ b/wiki/src/components/layout/Header.tsx
@@ -9,6 +9,7 @@ import { useLogout } from "@/hooks/useLogout";
 import AddWikiModal from "@/components/layout/AddWikiModal";
 import AddEntryModal from "@/components/layout/AddEntryModal";
 import AddPersonModal from "@/components/layout/AddPersonModal";
+import AddCollectionModal from "@/components/layout/AddCollectionModal";
 import WikiHeaderSearch from "@/components/layout/WikiHeaderSearch";
 
 interface HeaderProps {
@@ -21,6 +22,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
   const [addWikiOpen, setAddWikiOpen] = useState(false);
   const [addEntryOpen, setAddEntryOpen] = useState(false);
   const [addPersonOpen, setAddPersonOpen] = useState(false);
+  const [addCollectionOpen, setAddCollectionOpen] = useState(false);
   const { session } = useSession();
   const router = useRouter();
   const pathname = usePathname();
@@ -234,6 +236,32 @@ export default function Header({ onMenuToggle }: HeaderProps) {
                 >
                   Person
                 </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setAddCollectionOpen(true);
+                  }}
+                  className="flex w-full cursor-pointer items-center"
+                  style={{
+                    gap: 10,
+                    padding: "8px 14px",
+                    background: "none",
+                    border: "none",
+                    ...T.caption,
+                    color: "var(--heading-color)",
+                    textAlign: "left",
+                  }}
+                  onMouseEnter={(e) =>
+                    (e.currentTarget.style.backgroundColor = "var(--card-border)")
+                  }
+                  onMouseLeave={(e) =>
+                    (e.currentTarget.style.backgroundColor = "transparent")
+                  }
+                >
+                  Collection
+                </button>
               </div>
             </>
           )}
@@ -385,6 +413,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
       <AddWikiModal open={addWikiOpen} onClose={() => setAddWikiOpen(false)} />
       <AddEntryModal open={addEntryOpen} onClose={() => setAddEntryOpen(false)} />
       <AddPersonModal open={addPersonOpen} onClose={() => setAddPersonOpen(false)} />
+      <AddCollectionModal open={addCollectionOpen} onClose={() => setAddCollectionOpen(false)} />
     </header>
   );
 }

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -286,6 +286,8 @@ export type WikiEntityArticleProps = {
   published?: boolean;
   /** Public published-wiki nanoid slug (when published) for share-link UI. */
   publishedSlug?: string | null;
+  /** Current collection memberships — feeds the Collections section in the modal. */
+  collections?: Array<{ id: string; name: string; slug: string; color: string }>;
   /** Real wiki id for settings-mode PUT. Prototype pages omit → 'preview' sentinel. */
   wikiId?: string;
   /** Called after local save completes — persist to backend here. */
@@ -338,6 +340,7 @@ export function WikiEntityArticle({
   bouncerMode,
   published,
   publishedSlug,
+  collections,
   onSave,
   onSettingsClick: onSettingsClickProp,
   children,
@@ -404,8 +407,9 @@ export function WikiEntityArticle({
       bouncerMode,
       published,
       publishedSlug,
+      collections,
     }),
-    [displayTitle, displayChipLabel, description, promptOverride, bouncerMode, published, publishedSlug],
+    [displayTitle, displayChipLabel, description, promptOverride, bouncerMode, published, publishedSlug, collections],
   );
 
   const tabs = ["Read", "Edit", "View history"] as const;

--- a/wiki/src/lib/generated/types.gen.ts
+++ b/wiki/src/lib/generated/types.gen.ts
@@ -261,6 +261,12 @@ export type ThreadResponseSchema = {
     };
     published?: boolean;
     publishedSlug?: string;
+    collections?: Array<{
+        id: string;
+        name: string;
+        slug: string;
+        color: string;
+    }>;
 };
 
 export type ThreadWithWikiResponseSchema = {
@@ -311,6 +317,12 @@ export type ThreadListResponseSchema = {
             }>;
             percentage: number;
         };
+        collections?: Array<{
+            id: string;
+            name: string;
+            slug: string;
+            color: string;
+        }>;
     }>;
 };
 
@@ -338,6 +350,12 @@ export type WikiDetailResponseSchema = {
     };
     published?: boolean;
     publishedSlug?: string;
+    collections?: Array<{
+        id: string;
+        name: string;
+        slug: string;
+        color: string;
+    }>;
     wikiContent: string;
     fragments: Array<{
         id: string;
@@ -564,6 +582,15 @@ export type UserProfileResponseSchema = {
     mcpEndpointUrl: string;
     apiKeyHint: string;
     onboardedAt: string;
+    /**
+     * The Person row that represents the knowledge-base owner. Hand-patched
+     * here in the codegen-output until the OpenAPI spec re-generates;
+     * kept in sync with userProfileResponseSchema in core/src/schemas/users.schema.ts.
+     */
+    ownerPerson: {
+        lookupKey: string;
+        name: string;
+    } | null;
 };
 
 export type UserStatsResponseSchema = {

--- a/wiki/src/lib/wikiSettingsPrefill.ts
+++ b/wiki/src/lib/wikiSettingsPrefill.ts
@@ -15,6 +15,8 @@ export type WikiSettingsPrefill = {
   published?: boolean;
   /** Public published-wiki nanoid slug (when published) */
   publishedSlug?: string | null;
+  /** Current collection memberships — feeds the Collections section in the modal. */
+  collections?: Array<{ id: string; name: string; slug: string; color: string }>;
 };
 
 /** Placeholder — callers may supply a real description in the future. */


### PR DESCRIPTION
## Summary

Bundles 5 fork-side improvements from \`builder-25/robinwiki:feat/upstream-proposal\` (commit \`f93fd99\`) plus the migration this side owed (Path A: bootstrap stays frozen, accumulate from \`0001\`+).

## What's included

### 1. Nested-section render bug — \`SectionedMarkdownBody.tsx\`
Parent H2 sections were rendering their full range INCLUDING nested H3 children, AND each H3 then re-rendered as its own block — every nested H3 appeared twice. Fix: new \`effectiveBodyEndLine(section, allSections)\` helper recursively trims a parent's body to end just before its first nested child (H2 trims at first H3+, H3 trims at first H4).

### 2. Embedding-retry worker generalised to wikis + people
Worker previously only scanned \`fragments.embedding IS NULL\`. Wikis with empty content and people with no fragments sat broken indefinitely. Worker now iterates fragments / wikis / people per tick with the same per-table \`BATCH_LIMIT\` / \`MAX_ATTEMPTS\` / \`MIN_RETRY_GAP_MS\`. **Closes the deferred follow-up explicitly noted in cluster 2's plan 34** ("wiki + person heal worker — only fragments have a retry scheduler today").

### 3. Embed-at-create on \`POST /people\` + MCP \`create_wiki\`
Both paths previously inserted with \`embedding=NULL\` — \`POST /wikis\` HTTP path already embeds at create; this mirrors it. Best-effort embed call after the insert; falls through silently on failure (row still created). New entities are searchable immediately instead of waiting for the retry worker. **Closes the deferred follow-up from cluster 2** ("People embed-at-create is deferred — \`upsertPerson\` doesn't call \`embedText\`").

### 4. Collections UI in AddWikiModal + Header
Backend routes \`/groups/:id/wikis\` exist (from earlier work) but had no UI driver — collections could only be created via MCP and there was no way to add a wiki to one from the modal. Restored end-to-end:
- Header \`+Add\` menu now has a \`Collection\` entry alongside \`Wiki\` / \`Person\` (opens new \`AddCollectionModal\`)
- \`AddWikiModal\` Collections section visible in BOTH create and settings modes; settings persists immediately via \`/api/groups/:id/wikis\`; create stages selections locally and POSTs in parallel after \`POST /wikis\` returns the new \`lookupKey\` (partial failures surface as "Wiki created. Failed to file in N collection(s).")
- \`GET /wikis\` and \`GET /wikis/:id\` populate \`collections\` via new \`loadWikiCollections\` helper (batched join through \`groupWikis\` → \`groups\`); schema gains \`wikiCollectionSchema\` + \`collections\` field on \`wikiResponseSchema\`

### 5. Wiki Structure rule-2 wording across all 10 type yamls
Current rule 2 says "follow [the structure] exactly. Do not add, drop, reorder, or rename headings." Issue: heading-order isn't the same as item-order WITHIN a section (chronological direction, grouping). Quill drifts to type-instinct defaults when a user-edited structure says e.g. "most recent first" but heading order alone doesn't enforce it. Beefed up rule 2 to explicitly own ordering + per-section formatting prose, plus a "do not impose a default that contradicts the structure" clause. Pairs cleanly with the existing #243 prose-not-chips rule (different rules, no overlap).

## Migration (this side owed)

Phyl's commit added \`embeddingAttemptCount\` + \`embeddingLastAttemptAt\` to \`wikis\` and \`people\` in \`schema.ts\` and noted the migration was left for upstream. Adding it as **Path A** per the discussion:

- **\`0000_bootstrap.sql\`** — untouched, stays as the frozen v1 baseline
- **\`0001_wikis_people_embedding_retry_columns.sql\`** (NEW) — \`ALTER TABLE wikis / people ADD COLUMN IF NOT EXISTS embedding_attempt_count integer NOT NULL DEFAULT 0\` + \`embedding_last_attempt_at timestamp\`. Idempotent.
- **\`meta/_journal.json\`** — second entry for \`0001\`

Future schema changes will accumulate as \`0002\`+ until the next squash.

## Diff stats

26 files changed, +1015 / −97 (Phyl's commit was 24 files; +0001 SQL + journal entry adds 2).

## Verification

- \`npx tsc --noEmit -p core/tsconfig.json\` — clean
- \`npx tsc --noEmit -p wiki/tsconfig.json\` — clean
- \`pnpm --filter @robin/shared build\`, \`pnpm --filter @robin/agent build\` — clean
- Cluster 9c env validator unit tests (PR #285) — 14/14 still pass

## Authorship

Phyl (\`builder-25 <phyl@withrobin.ai>\`) authored the bundled commit \`f15793d\`. The 0001 migration commit (\`c62a1ff\`) is from this side. \`Co-authored-by\` not added because the original commit is preserved with Phyl's authorship intact.

## Out of scope (kept as follow-ups)

- No new UAT plan for the Collections UI flow — could amend plan 35 (sidebar polish) or plan 36 (person dedup UX) with positive/negative assertions for the new modal flow. Not blocking.
- No vitest unit tests for the new \`effectiveBodyEndLine\` helper — fix is small and visually verifiable; could add later.
- The \`loadWikiCollections\` helper isn't paginated; for users with hundreds of collections per wiki this would matter. Acceptable for v1.