### PR TITLE
fix(bootstrap): auto-seed OpenRouter key from env at first boot

### DIFF
--- a/core/src/bootstrap/__tests__/check-openrouter-key.test.ts
+++ b/core/src/bootstrap/__tests__/check-openrouter-key.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// Drizzle-style chain stub for db.select(...).from(...).where(...).limit(...)
+// and db.select(...).from(...).limit(...) — both forms used by checkOpenRouterKey.
+//
+// Each call to db.select returns a fresh chain that resolves to the next entry
+// in `selectReturns`. Tests push the row arrays they want returned in order.
+const selectReturns: Array<Array<Record<string, unknown>>> = []
+
+vi.mock('../../db/client.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () =>
+            Promise.resolve(selectReturns.shift() ?? []),
+        }),
+        limit: () =>
+          Promise.resolve(selectReturns.shift() ?? []),
+      }),
+    }),
+  },
+}))
+
+vi.mock('../../db/schema.js', () => ({
+  configs: {
+    id: 'id',
+    kind: 'kind',
+    key: 'key',
+  },
+  users: {
+    id: 'id',
+  },
+}))
+
+const setConfigMock = vi.fn()
+vi.mock('../../lib/config.js', () => ({
+  setConfig: (...args: unknown[]) => setConfigMock(...args),
+}))
+
+// `loadOpenRouterConfig` is unused by checkOpenRouterKey but the module imports
+// it for the sibling `probeEmbeddingsOrRefuseWorkers`. Provide a stub so the
+// import graph resolves without booting the real config.
+vi.mock('../../lib/openrouter-config.js', () => ({
+  loadOpenRouterConfig: vi.fn(),
+}))
+
+vi.mock('@robin/agent', () => ({
+  NoOpenRouterKeyError: class NoOpenRouterKeyError extends Error {},
+  probeEmbeddingReachable: vi.fn(),
+}))
+
+const logInfoMock = vi.fn()
+const logWarnMock = vi.fn()
+const logErrorMock = vi.fn()
+vi.mock('../../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: (...args: unknown[]) => logInfoMock(...args),
+      warn: (...args: unknown[]) => logWarnMock(...args),
+      error: (...args: unknown[]) => logErrorMock(...args),
+      debug: vi.fn(),
+    }),
+  },
+}))
+
+// ── Import under test (after mocks) ────────────────────────────────────────
+
+const { checkOpenRouterKey } = await import('../check-openrouter-key.js')
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('checkOpenRouterKey', () => {
+  const originalEnv = process.env.OPENROUTER_API_KEY
+
+  beforeEach(() => {
+    selectReturns.length = 0
+    setConfigMock.mockReset()
+    logInfoMock.mockReset()
+    logWarnMock.mockReset()
+    logErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENROUTER_API_KEY
+    } else {
+      process.env.OPENROUTER_API_KEY = originalEnv
+    }
+  })
+
+  it('auto-seeds when env var set + no row + user exists', async () => {
+    process.env.OPENROUTER_API_KEY = 'sk-or-v1-test'
+    // First select: configs lookup returns no rows.
+    selectReturns.push([])
+    // Second select: users lookup returns one user.
+    selectReturns.push([{ id: 'user-123' }])
+    setConfigMock.mockResolvedValue(undefined)
+
+    await checkOpenRouterKey()
+
+    expect(setConfigMock).toHaveBeenCalledTimes(1)
+    expect(setConfigMock).toHaveBeenCalledWith({
+      scope: 'user',
+      userId: 'user-123',
+      kind: 'llm_key',
+      key: 'openrouter',
+      value: 'sk-or-v1-test',
+      encrypted: true,
+    })
+    expect(logInfoMock).toHaveBeenCalledWith(
+      { userId: 'user-123' },
+      'openrouter key auto-seeded from OPENROUTER_API_KEY env var',
+    )
+  })
+
+  it('does not seed when row already exists', async () => {
+    process.env.OPENROUTER_API_KEY = 'sk-or-v1-test'
+    selectReturns.push([{ id: 'config-1' }])
+
+    await checkOpenRouterKey()
+
+    expect(setConfigMock).not.toHaveBeenCalled()
+    expect(logInfoMock).toHaveBeenCalledWith('openrouter key present in configs')
+  })
+
+  it('does not seed when env var unset + no row', async () => {
+    delete process.env.OPENROUTER_API_KEY
+    selectReturns.push([])
+
+    await checkOpenRouterKey()
+
+    expect(setConfigMock).not.toHaveBeenCalled()
+    expect(logWarnMock).toHaveBeenCalledTimes(1)
+    expect(logWarnMock.mock.calls[0]?.[0]).toMatch(
+      /OPENROUTER_API_KEY env var unset/,
+    )
+  })
+
+  it('does not seed when env var set + no user yet', async () => {
+    process.env.OPENROUTER_API_KEY = 'sk-or-v1-test'
+    selectReturns.push([]) // configs: empty
+    selectReturns.push([]) // users: empty
+
+    await checkOpenRouterKey()
+
+    expect(setConfigMock).not.toHaveBeenCalled()
+    expect(logWarnMock).toHaveBeenCalledTimes(1)
+    expect(logWarnMock.mock.calls[0]?.[0]).toMatch(/retry on next boot/)
+  })
+
+  it('logs error but does not throw when setConfig fails', async () => {
+    process.env.OPENROUTER_API_KEY = 'sk-or-v1-test'
+    selectReturns.push([]) // configs: empty
+    selectReturns.push([{ id: 'user-123' }]) // users: present
+    const failure = new Error('encryption blew up')
+    setConfigMock.mockRejectedValue(failure)
+
+    await expect(checkOpenRouterKey()).resolves.toBeUndefined()
+
+    expect(logErrorMock).toHaveBeenCalledTimes(1)
+    expect(logErrorMock.mock.calls[0]?.[0]).toEqual({ err: failure })
+    expect(logErrorMock.mock.calls[0]?.[1]).toMatch(
+      /auto-seed of openrouter key failed/,
+    )
+  })
+})

--- a/core/src/bootstrap/check-openrouter-key.ts
+++ b/core/src/bootstrap/check-openrouter-key.ts
@@ -1,7 +1,8 @@
 import { and, eq } from 'drizzle-orm'
 import { NoOpenRouterKeyError, probeEmbeddingReachable } from '@robin/agent'
 import { db } from '../db/client.js'
-import { configs } from '../db/schema.js'
+import { configs, users } from '../db/schema.js'
+import { setConfig } from '../lib/config.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { logger } from '../lib/logger.js'
 
@@ -9,8 +10,9 @@ const log = logger.child({ component: 'bootstrap' })
 
 /**
  * Boot-time check for the OpenRouter API key. Does not throw — the server
- * can still serve non-ingest traffic without it. Logs an actionable warning
- * when the key is missing so the operator knows to run the seed script.
+ * can still serve non-ingest traffic without it. When the key is missing
+ * but `OPENROUTER_API_KEY` is set in the env and a user exists, auto-seeds
+ * the configs row so a fresh Railway deploy doesn't need a manual seed step.
  */
 export async function checkOpenRouterKey(): Promise<void> {
   const rows = await db
@@ -20,11 +22,41 @@ export async function checkOpenRouterKey(): Promise<void> {
     .limit(1)
 
   if (rows.length === 0) {
-    log.warn(
-      'No OpenRouter API key found in configs. ' +
-        'Ingest jobs will fail with "no_openrouter_key" until seeded. ' +
-        'Run: OPENROUTER_API_KEY=sk-or-v1-... pnpm seed-openrouter-key'
-    )
+    const apiKey = process.env.OPENROUTER_API_KEY
+    if (!apiKey) {
+      log.warn(
+        'No OpenRouter API key found in configs and OPENROUTER_API_KEY env var unset — ingest jobs will fail until seeded.'
+      )
+      return
+    }
+
+    const [firstUser] = await db.select({ id: users.id }).from(users).limit(1)
+    if (!firstUser) {
+      log.warn(
+        'OPENROUTER_API_KEY is set but no users exist yet — skipping auto-seed; will retry on next boot after first user is provisioned.'
+      )
+      return
+    }
+
+    try {
+      await setConfig({
+        scope: 'user',
+        userId: firstUser.id,
+        kind: 'llm_key',
+        key: 'openrouter',
+        value: apiKey,
+        encrypted: true,
+      })
+      log.info(
+        { userId: firstUser.id },
+        'openrouter key auto-seeded from OPENROUTER_API_KEY env var'
+      )
+    } catch (err) {
+      log.error(
+        { err },
+        'auto-seed of openrouter key failed — ingest jobs will fail until manually seeded'
+      )
+    }
     return
   }
 


### PR DESCRIPTION
## Summary

Removes a Railway one-click-deploy footgun. Previously: \`OPENROUTER_API_KEY\` env var was required by env validation, but the actual ingest pipeline reads the key from the encrypted \`configs\` table. The env var was only used by the manual seed script (\`pnpm seed-openrouter-key\`). Result: fresh deploys "succeeded," workers started, every job failed silently with \`no_openrouter_key\` until the operator shelled into the container and ran the seed script.

This PR makes \`checkOpenRouterKey\` (already on the boot path) auto-seed the row when:
- No \`configs.llm_key.openrouter\` row exists, AND
- \`OPENROUTER_API_KEY\` env var is set, AND
- A user exists (the encryption uses the first user's DEK)

Idempotent — subsequent boots find the row and skip the seed call. The manual seed script stays in place for key rotation / multi-key scenarios.

## Behavior matrix

| Configs row | Env var | User exists | Action |
|---|---|---|---|
| Yes | — | — | Skip; log \`openrouter key present\` |
| No | Yes | Yes | **Auto-seed**; log \`openrouter key auto-seeded from OPENROUTER_API_KEY env var\` |
| No | Yes | No | Skip; log warn \`will retry on next boot after first user is provisioned\` |
| No | No | — | Skip; log warn \`ingest jobs will fail until seeded\` |
| No | Yes | Yes (but \`setConfig\` throws) | Log error, function returns normally (no boot abort) |

## Tests

\`core/src/bootstrap/__tests__/check-openrouter-key.test.ts\` (NEW) — 5 cases covering all rows above. Vitest: 5/5 pass in 6ms.

## Files

- \`core/src/bootstrap/check-openrouter-key.ts\` — extended with auto-seed branch
- \`core/src/bootstrap/__tests__/check-openrouter-key.test.ts\` (NEW) — 5 cases

LOC: +209 / −8.

## Out of scope

The manual seed script (\`core/scripts/seed-openrouter-key.ts\`) is unchanged — useful when rotating the key without redeploying.