### PR TITLE
docs(readme): split Deploy into two paths + drop Milestones table

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,23 +205,6 @@ The workspace packages (`@robin/agent`, `@robin/queue`, `@robin/shared`, `@robin
 
 Work on feature branches. Create a GitHub issue before starting work, then open a PR that references the issue.
 
-## Milestones
-
-| # | Milestone | Status |
-|---|-----------|--------|
-| M1 | Foundation — repo scaffold, schema, single-user auth | Done |
-| M2 | Ingest Pipeline — 6-stage pipeline with inline-async | Done |
-| M3 | Wiki Composition — 10 wiki types with quality gates | Done |
-| M4 | Search — hybrid two-layer retrieval with RRF fusion | Done |
-| M5 | MCP Server — 15 tools for AI client integration | Done |
-| M6 | API Routes — REST API with wiki governance | Done |
-| M7 | Frontend Integration — Wikipedia-style web UI | Done |
-| M8 | Deploy & Ship — one-click deployment | Open |
-| M9 | Audit Log — append-only event store with timeline views | Done |
-| M10 | Interconnectivity & Trust Gates — wiki linking, source quality | Done |
-
-Track progress: [GitHub Issues](https://github.com/withrobinhq/robin/issues)
-
 ## License
 
 Private. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Robin is an AI-powered second brain that captures raw thoughts through conversation (MCP or web UI) and automatically structures them into a searchable knowledge base. Behind the scenes, a 6-stage AI pipeline extracts atomic ideas (fragments), classifies them into topic clusters (wikis), resolves people mentions, and stores everything in Postgres with vector embeddings for hybrid search.
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/1hBtzC?referralCode=55-uGO&utm_medium=integration&utm_source=template&utm_campaign=github)
-
 ## Architecture
 
 Monorepo managed by pnpm workspaces + Turborepo.
@@ -164,15 +162,33 @@ Generate the TypeScript client for the wiki frontend:
 pnpm --filter @robin/wiki openapi:generate
 ```
 
-## Deployment
+## Deploy
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/1hBtzC?referralCode=55-uGO&utm_medium=integration&utm_source=template&utm_campaign=github)
+### Path A: Quick deploy (recommended for trying it out)
 
-Robin is deployed on [Railway](https://railway.app). Staging is available at `*.tensorkit.net`.
+[Deploy on Railway →](https://railway.com/deploy/1hBtzC?referralCode=55-uGO&utm_medium=integration&utm_source=template&utm_campaign=github)
 
-The production topology runs four services: `core` (Hono API + workers), `wiki` (Next.js frontend), `postgres` (with pgvector), and `redis` (BullMQ). Wiki proxies all `/api/*` requests to core over Railway's private network.
+Connects directly to this repo. Auto-updates whenever we push to `main`.
+**You can't customize the code, and your instance redeploys when we update upstream — including breaking changes.**
+Best for trying Robin out or running a hosted demo.
 
-For full deployment instructions, environment variable reference, and troubleshooting, see [`docs/DEPLOY.md`](docs/DEPLOY.md).
+### Path B: Fork & deploy (recommended for personal use)
+
+1. [Fork this repo →](https://github.com/withrobinhq/robinwiki/fork)
+2. Click "Deploy on Railway" from your fork's README
+
+Connects to your fork. **You decide when to pull upstream updates, and you can edit the code.**
+Best if you want stability or want to customize prompts, models, UI, etc.
+Trade-off: you have to occasionally `git pull upstream main` to get new features.
+
+#### Keeping your fork in sync
+
+```bash
+git remote add upstream https://github.com/withrobinhq/robinwiki.git
+git fetch upstream
+git merge upstream/main
+git push
+```
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Two README changes bundled (you asked for both in the same pass):

1. **Split \`## Deploy\` into Path A (quick) + Path B (fork & deploy)** — mirrors the Plausible / Umami / Supabase self-host pattern. Path A is a one-click against this repo (auto-updates, no customization). Path B is fork-then-deploy (user controls upgrades + can customize). Includes a \`git remote add upstream\` footnote for users who pick Path B and want to track upstream later.
2. **Remove the M1–M10 milestones table** — project shipped through them; ongoing tracking lives in GitHub Issues, not the README.

## Verbatim text from the brief

Path A + Path B blocks shipped exactly as specified. Railway deploy URL preserved verbatim (referral + utm params intact). Existing top-of-file Railway button removed (was duplicated above the section).

## Diff stats

- Commit 1 \`84ebe56\` — Deploy section restructure: +23 / −7
- Commit 2 \`c19f8a0\` — Milestones section drop: 0 / −17

## Note on dropped lines

The previous \`## Deployment\` section had 3 lines of staging/topology/\`docs/DEPLOY.md\` reference prose that the verbatim spec replaced with the Path A/B blocks. \`docs/DEPLOY.md\` still exists with the migration-squash upgrade guidance — I can re-add a one-line pointer to it under Path B if you want operators to find it more easily.