### PR TITLE
feat: deploy onboarding refresh — README + backend root page

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 withrobinhq
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -299,4 +299,4 @@ The workspace packages (`@robin/agent`, `@robin/queue`, `@robin/shared`, `@robin
 
 ## License
 
-Private. All rights reserved.
+[MIT](LICENSE) © 2026 withrobinhq

--- a/README.md
+++ b/README.md
@@ -1,18 +1,59 @@
 # Robin
 
-Robin is an AI-powered second brain that captures raw thoughts through conversation (MCP or web UI) and automatically structures them into a searchable knowledge base. Behind the scenes, a 6-stage AI pipeline extracts atomic ideas (fragments), classifies them into topic clusters (wikis), resolves people mentions, and stores everything in Postgres with vector embeddings for hybrid search.
+*A second brain that organizes itself.*
+
+Talk to Robin through Claude Desktop, the web, or any MCP client. It listens, breaks what you say into atomic ideas, and files them into topic-clustered wikis you can search and edit. The point: capture without the friction of categorizing, then trust that whatever you said in March is one search away in November.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/1hBtzC?referralCode=55-uGO&utm_medium=integration&utm_source=template&utm_campaign=github)
+
+## Table of Contents
+
+- [What Robin does](#what-robin-does)
+- [Architecture](#architecture)
+- [Tech Stack](#tech-stack)
+- [Deploy](#deploy)
+  - [Strategy 1 — Template](#strategy-1--template)
+  - [Strategy 2 — Fork + Re-point](#strategy-2--fork--re-point)
+  - [Strategy 3 — Standalone (Eject)](#strategy-3--standalone-eject)
+- [Local Setup](#local-setup)
+- [Environment Variables](#environment-variables)
+- [MCP Tools](#mcp-tools)
+- [API](#api)
+- [Scripts](#scripts)
+- [Contributing](#contributing)
+- [License](#license)
+
+## What Robin does
+
+You think out loud. Robin keeps the thread.
+
+A typical capture looks like this:
+
+> *You, in Claude Desktop:* "I just realized the bouncer-mode flag should be per-wiki, not global. The whole point of strict review on the Decisions wiki is that it's high-stakes. Letting that bleed onto the Drafts wiki where I'm just thinking out loud would kill the value."
+
+Behind the scenes, Robin:
+
+1. **Captures the raw text** as an entry in the audit log
+2. **Splits it into fragments** — atomic ideas, one thought each, fluff stripped
+3. **Classifies each fragment** into a wiki by topic — "bouncer-mode design" goes to your *Decisions* wiki; the *Drafts* mention links a sibling fragment in *Drafts*
+4. **Regenerates the wiki bodies** so the new fragments show up in prose, with citations linking back to the original
+5. **Indexes everything** for search — both keyword (BM25) and semantic (vector cosine), fused with reciprocal rank fusion
+
+A week later, "what was my position on bouncer mode?" surfaces both fragments, the wiki body that synthesizes them, and the timeline of how the thought evolved.
 
 ## Architecture
 
-Monorepo managed by pnpm workspaces + Turborepo.
+Single-tenant, single-user, Postgres-backed. Everything you write lives as text rows in Postgres — no git-backed markdown store, no filesystem repo. The server owns auth, the API, the MCP endpoint, and the AI pipeline.
+
+Monorepo managed by pnpm workspaces + Turborepo:
 
 ```
-core/           @robin/core    — Hono API server, MCP server, AI pipeline, workers
-wiki/           @robin/wiki    — Next.js 16 web frontend (shadcn/ui)
-packages/agent  @robin/agent   — LLM agent utilities, person resolution
-packages/queue  @robin/queue   — BullMQ producer/consumer abstractions
-packages/shared @robin/shared  — Shared types, lookup keys, slug helpers
-packages/caslock @robin/caslock — CAS-based distributed locking
+core/             @robin/core    — Hono API server, MCP server, AI pipeline, workers
+wiki/             @robin/wiki    — Next.js 16 web frontend (shadcn/ui)
+packages/agent    @robin/agent   — LLM agent utilities, person resolution
+packages/queue    @robin/queue   — BullMQ producer/consumer abstractions
+packages/shared   @robin/shared  — Shared types, lookup keys, slug helpers
+packages/caslock  @robin/caslock — CAS-based distributed locking
 ```
 
 ## Tech Stack
@@ -25,142 +66,6 @@ packages/caslock @robin/caslock — CAS-based distributed locking
 | AI | OpenRouter (Claude, embeddings), Mastra |
 | Frontend | Next.js 16, React 19, Tailwind CSS, shadcn/ui |
 | Tooling | TypeScript, Biome, Vitest, Turborepo, pnpm |
-
-## Prerequisites
-
-- **Node.js** >= 20 (enable corepack: `corepack enable`)
-- **pnpm** >= 9 (installed automatically via corepack from `packageManager` field)
-- **PostgreSQL** with the [pgvector](https://github.com/pgvector/pgvector) extension
-- **Redis** (used by BullMQ for job queues)
-
-## Quick Start
-
-```bash
-# Enable corepack (provides the correct pnpm version)
-corepack enable
-
-# Clone and install
-git clone https://github.com/withrobinhq/robin.git
-cd robin
-pnpm install
-
-# Configure environment
-cp core/.env.example core/.env
-
-# Generate MASTER_KEY (required for encryption)
-openssl rand -hex 32
-# Paste the output into core/.env as MASTER_KEY=<value>
-
-# Fill in the remaining values:
-# - DATABASE_URL (Postgres with pgvector extension)
-# - REDIS_URL
-# - OPENROUTER_API_KEY
-# - BETTER_AUTH_SECRET (32+ chars)
-# - INITIAL_USERNAME / INITIAL_PASSWORD
-
-# Ensure pgvector is enabled on your database
-psql $DATABASE_URL -c 'CREATE EXTENSION IF NOT EXISTS vector;'
-
-# Push database schema
-pnpm --filter @robin/core db:push
-
-# Start dev servers (core API + wiki frontend)
-pnpm dev
-```
-
-Core runs on `http://localhost:3000`, wiki on `http://localhost:8080`.
-
-## Environment Variables
-
-All variables are configured in `core/.env`. See `core/.env.example` for the full template.
-
-| Variable | Required | Default | Purpose |
-|----------|----------|---------|---------|
-| `DATABASE_URL` | Yes | `postgresql://postgres@127.0.0.1:5432/robinwiki` | PostgreSQL connection string (must have pgvector) |
-| `REDIS_URL` | Yes | `redis://localhost:6379` | Redis connection string for BullMQ job queues |
-| `BETTER_AUTH_SECRET` | Yes | - | Session cookie signing secret (32+ chars) |
-| `MASTER_KEY` | Yes | - | Root encryption key, 64 hex chars (`openssl rand -hex 32`) |
-| `KEY_ENCRYPTION_SECRET` | Yes | - | AES-256-GCM key encryption secret (32+ chars) |
-| `OPENROUTER_API_KEY` | Yes | - | OpenRouter API key for LLM calls and embeddings |
-| `INITIAL_USERNAME` | Yes | - | Admin email address (created on first login via JIT) |
-| `INITIAL_PASSWORD` | Yes | - | Admin password |
-| `SERVER_PUBLIC_URL` | Yes | `http://localhost:3000` | Public URL for MCP endpoints, auth cookies |
-| `WIKI_ORIGIN` | Yes | `http://localhost:8080` | Wiki frontend URL(s) for CORS (comma-separated) |
-| `PORT` | No | `3000` | HTTP listen port |
-| `NODE_ENV` | No | `development` | Node environment (`production` enables secure cookies) |
-| `LOG_LEVEL` | No | `info` | Pino log level (trace/debug/info/warn/error/fatal) |
-| `WIKI_CLASSIFY_THRESHOLD` | No | `0.65` | LLM confidence threshold for filing fragments (0.0-1.0) |
-| `ENABLE_BATCH_REGEN` | No | `true` | Enable midnight batch wiki regeneration cron |
-
-## Scripts
-
-### Root
-
-| Script | Description |
-|--------|-------------|
-| `pnpm dev` | Start all dev servers in parallel (Turborepo) |
-| `pnpm build` | Build all workspaces |
-| `pnpm typecheck` | Type-check all workspaces |
-| `pnpm test` | Run tests across all workspaces |
-| `pnpm lint` | Lint all workspaces |
-| `pnpm format` | Format with Biome |
-| `pnpm serve` | Start core + wiki with concurrently (alternative to `dev`) |
-| `pnpm manifest` | Generate OpenAPI manifest and wiki client |
-
-### Core (`@robin/core`)
-
-| Script | Description |
-|--------|-------------|
-| `pnpm --filter @robin/core dev` | Start dev server with tsx watch |
-| `pnpm --filter @robin/core build` | Compile TypeScript |
-| `pnpm --filter @robin/core test` | Run Vitest tests |
-| `pnpm --filter @robin/core db:generate` | Generate Drizzle migrations |
-| `pnpm --filter @robin/core db:push` | Push schema to database |
-| `pnpm --filter @robin/core mcp:inspect` | Launch MCP inspector |
-
-### Wiki (`@robin/wiki`)
-
-| Script | Description |
-|--------|-------------|
-| `pnpm --filter @robin/wiki dev` | Start Next.js dev server |
-| `pnpm --filter @robin/wiki build` | Production build |
-| `pnpm --filter @robin/wiki manifest` | Regenerate TypeScript client from OpenAPI spec |
-
-## MCP Tools
-
-Robin exposes an MCP server for Claude, ChatGPT, and other AI clients.
-
-| Tool | Description |
-|------|-------------|
-| `log_entry` | Capture a thought — feeds the full 6-stage AI pipeline |
-| `log_fragment` | Write a fragment directly to a known wiki (fast path) |
-| `create_wiki` | Create a new wiki with auto-inferred type |
-| `edit_wiki` | Update wiki content with edit history preservation |
-| `list_wikis` | List all wikis with fragment counts and type info |
-| `get_wiki` | Get wiki details with full body and fragment snippets |
-| `get_fragment` | Get full fragment content by slug |
-| `find_person` | Find a person by ID or fuzzy name search |
-| `brief_person` | Get a formatted person briefing (no LLM call) |
-| `search` | Hybrid BM25 + semantic search across all entities |
-| `get_wiki_types` | List available wiki types and descriptors |
-| `create_wiki_type` | Define a custom wiki type |
-| `publish_wiki` | Publish a wiki with a stable public URL |
-| `unpublish_wiki` | Unpublish a wiki (preserves slug for re-publish) |
-| `get_timeline` | Audit timeline for a wiki and its fragments |
-
-## API
-
-The core server exposes a REST API alongside MCP. OpenAPI spec available at:
-
-```
-GET http://localhost:3000/openapi.json
-```
-
-Generate the TypeScript client for the wiki frontend:
-
-```bash
-pnpm --filter @robin/wiki openapi:generate
-```
 
 ## Deploy
 
@@ -220,20 +125,169 @@ git merge upstream/main
 git push
 ```
 
+## Local Setup
+
+If you want to run Robin on your own machine — for hacking on the code, or because you'd rather host on something other than Railway.
+
+### Prerequisites
+
+- **Node.js** ≥ 20 (run `corepack enable` to pin pnpm via the `packageManager` field)
+- **PostgreSQL** with the [pgvector](https://github.com/pgvector/pgvector) extension
+- **Redis** — used by BullMQ for the job queue
+- **An OpenRouter API key** — Robin uses Claude via OpenRouter for the AI pipeline. Get one at [openrouter.ai/keys](https://openrouter.ai/keys).
+
+### From clone to running
+
+```bash
+# Clone and install
+git clone https://github.com/withrobinhq/robinwiki.git
+cd robinwiki
+corepack enable
+pnpm install
+
+# Copy the env template
+cp core/.env.example core/.env
+```
+
+Generate three random secrets and paste them into `core/.env`:
+
+```bash
+openssl rand -hex 32   # paste into MASTER_KEY (must be 64 hex chars)
+openssl rand -hex 32   # paste into BETTER_AUTH_SECRET
+openssl rand -hex 32   # paste into KEY_ENCRYPTION_SECRET
+```
+
+Then fill in the rest of `core/.env`:
+
+```env
+DATABASE_URL=postgresql://postgres@127.0.0.1:5432/robinwiki
+REDIS_URL=redis://localhost:6379
+OPENROUTER_API_KEY=sk-or-v1-...
+INITIAL_USERNAME=you@example.com
+INITIAL_PASSWORD=something-you-can-remember
+```
+
+Bootstrap the database and start the dev servers:
+
+```bash
+# Make sure pgvector is enabled on your database
+psql $DATABASE_URL -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+
+# Apply schema
+pnpm --filter @robin/core db:push
+
+# Start core API + wiki frontend in parallel
+pnpm dev
+```
+
+Core runs on http://localhost:3000, wiki on http://localhost:8080. Log in with the `INITIAL_USERNAME` / `INITIAL_PASSWORD` you set above.
+
+## Environment Variables
+
+All variables live in `core/.env`. See `core/.env.example` for the canonical template.
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | `postgresql://postgres@127.0.0.1:5432/robinwiki` | PostgreSQL connection string (must have pgvector) |
+| `REDIS_URL` | Yes | `redis://localhost:6379` | Redis connection string for BullMQ job queues |
+| `BETTER_AUTH_SECRET` | Yes | — | Session cookie signing secret (32+ chars) |
+| `MASTER_KEY` | Yes | — | Root encryption key, 64 hex chars (`openssl rand -hex 32`) |
+| `KEY_ENCRYPTION_SECRET` | Yes | — | AES-256-GCM key encryption secret (32+ chars) |
+| `OPENROUTER_API_KEY` | Yes | — | OpenRouter API key for LLM calls and embeddings |
+| `INITIAL_USERNAME` | Yes | — | Admin email address (created on first boot if no users exist) |
+| `INITIAL_PASSWORD` | Yes | — | Admin password (rotate after first login) |
+| `SERVER_PUBLIC_URL` | Yes | `http://localhost:3000` | Public URL for MCP endpoints + auth cookies. Bare domains auto-prepend `https://`. |
+| `WIKI_ORIGIN` | Yes | `http://localhost:8080` | Wiki frontend URL(s) for CORS, comma-separated. Bare domains auto-prepend `https://`. |
+| `PORT` | No | `3000` | HTTP listen port |
+| `NODE_ENV` | No | `development` | `production` enables secure cookies |
+| `LOG_LEVEL` | No | `info` | Pino log level (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) |
+| `WIKI_CLASSIFY_THRESHOLD` | No | `0.65` | LLM confidence threshold for filing fragments (0.0–1.0) |
+| `ENABLE_BATCH_REGEN` | No | `true` | Enable midnight batch wiki regeneration cron |
+
+## MCP Tools
+
+Robin exposes an MCP server for Claude Desktop, ChatGPT, and other AI clients. The MCP layer is the canonical capture surface — anything the web UI can do, MCP can do, plus a few things only MCP can.
+
+| Tool | Description |
+|------|-------------|
+| `log_entry` | Capture a thought — feeds the full 6-stage AI pipeline |
+| `log_fragment` | Write a fragment directly to a known wiki (fast path) |
+| `create_wiki` | Create a new wiki with auto-inferred type |
+| `edit_wiki` | Update wiki content with edit history preservation |
+| `list_wikis` | List all wikis with fragment counts and type info |
+| `get_wiki` | Get wiki details with full body and fragment snippets |
+| `get_fragment` | Get full fragment content by slug |
+| `find_person` | Find a person by ID or fuzzy name search |
+| `brief_person` | Get a formatted person briefing (no LLM call) |
+| `search` | Hybrid BM25 + semantic search across all entities |
+| `get_wiki_types` | List available wiki types and descriptors |
+| `create_wiki_type` | Define a custom wiki type |
+| `publish_wiki` | Publish a wiki with a stable public URL |
+| `unpublish_wiki` | Unpublish a wiki (preserves slug for re-publish) |
+| `get_timeline` | Audit timeline for a wiki and its fragments |
+
+## API
+
+The core server exposes a REST API alongside MCP. OpenAPI spec at:
+
+```
+GET http://localhost:3000/openapi.json
+```
+
+The wiki frontend uses a generated TypeScript client. Regenerate after API changes:
+
+```bash
+pnpm --filter @robin/wiki openapi:generate
+```
+
+## Scripts
+
+### Root
+
+| Script | Description |
+|--------|-------------|
+| `pnpm dev` | Start all dev servers in parallel (Turborepo) |
+| `pnpm build` | Build all workspaces |
+| `pnpm typecheck` | Type-check all workspaces |
+| `pnpm test` | Run tests across all workspaces |
+| `pnpm lint` | Lint all workspaces |
+| `pnpm format` | Format with Biome |
+| `pnpm serve` | Start core + wiki with concurrently (alternative to `dev`) |
+| `pnpm manifest` | Generate OpenAPI manifest and wiki client |
+
+### Core (`@robin/core`)
+
+| Script | Description |
+|--------|-------------|
+| `pnpm --filter @robin/core dev` | Start dev server with tsx watch |
+| `pnpm --filter @robin/core build` | Compile TypeScript |
+| `pnpm --filter @robin/core test` | Run Vitest tests |
+| `pnpm --filter @robin/core db:generate` | Generate Drizzle migrations |
+| `pnpm --filter @robin/core db:push` | Push schema to database |
+| `pnpm --filter @robin/core mcp:inspect` | Launch MCP inspector |
+
+### Wiki (`@robin/wiki`)
+
+| Script | Description |
+|--------|-------------|
+| `pnpm --filter @robin/wiki dev` | Start Next.js dev server |
+| `pnpm --filter @robin/wiki build` | Production build |
+| `pnpm --filter @robin/wiki manifest` | Regenerate TypeScript client from OpenAPI spec |
+
 ## Contributing
 
-### Linting and formatting
+### Workflow
 
-- **core/ and packages/**: [Biome](https://biomejs.dev/) for linting and formatting (`pnpm format`, `pnpm lint`)
-- **wiki/**: [ESLint](https://eslint.org/) with `eslint-config-next` (wiki has its own config and does not use Biome)
+Work on feature branches. Open a GitHub issue before starting non-trivial work, then a PR that references the issue.
 
 ### Workspace boundaries
 
-The workspace packages (`@robin/agent`, `@robin/queue`, `@robin/shared`, `@robin/caslock`) have strict boundaries. Do not flatten them into core or merge packages together. Each package builds independently and exposes its own entry points.
+The workspace packages (`@robin/agent`, `@robin/queue`, `@robin/shared`, `@robin/caslock`) have strict boundaries. Don't flatten them into core or merge packages together. Each package builds independently and exposes its own entry points.
 
-### Branch workflow
+### Linting and formatting
 
-Work on feature branches. Create a GitHub issue before starting work, then open a PR that references the issue.
+- **`core/` and `packages/`**: [Biome](https://biomejs.dev/) (`pnpm format`, `pnpm lint`)
+- **`wiki/`**: [ESLint](https://eslint.org/) with `eslint-config-next` (wiki has its own config and does not use Biome)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,7 @@ All variables live in `core/.env`. See `core/.env.example` for the canonical tem
 Robin is single-user. Your password is set from `INITIAL_PASSWORD` on first boot — the env validator requires it to be at least 6 characters. Two ways to change it later:
 
 - **Logged in:** open `/profile` → **Change password**. Uses better-auth's standard flow; you'll need your current password.
-- **Locked out:** open `/recover` (public page). Paste the value of `BETTER_AUTH_SECRET` from your server env. The endpoint resets the account password to whatever `INITIAL_PASSWORD` is currently set to on the server — so to choose a new password this way: update `INITIAL_PASSWORD` on Railway, redeploy, then hit `/recover`. Rate-limited to 5 attempts per minute.
-
-There's no email-based reset. Robin assumes the operator owns the env vars; that's the recovery surface.
+- **Locked out:** open `/recover` (public page). Paste the value of `BETTER_AUTH_SECRET` from your server env. The endpoint resets the account password to whatever `INITIAL_PASSWORD` is currently set to on the server — so to choose a new password this way: update `INITIAL_PASSWORD` on Railway, redeploy, then hit `/recover`.
 
 ## MCP Tools
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Talk to Robin through Claude Desktop, the web, or any MCP client. It listens, br
   - [Strategy 3 — Standalone (Eject)](#strategy-3--standalone-eject)
 - [Local Setup](#local-setup)
 - [Environment Variables](#environment-variables)
+- [Account password](#account-password)
 - [MCP Tools](#mcp-tools)
 - [API](#api)
 - [Scripts](#scripts)
@@ -203,6 +204,15 @@ All variables live in `core/.env`. See `core/.env.example` for the canonical tem
 | `LOG_LEVEL` | No | `info` | Pino log level (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) |
 | `WIKI_CLASSIFY_THRESHOLD` | No | `0.65` | LLM confidence threshold for filing fragments (0.0–1.0) |
 | `ENABLE_BATCH_REGEN` | No | `true` | Enable midnight batch wiki regeneration cron |
+
+## Account password
+
+Robin is single-user. Your password is set from `INITIAL_PASSWORD` on first boot — the env validator requires it to be at least 6 characters. Two ways to change it later:
+
+- **Logged in:** open `/profile` → **Change password**. Uses better-auth's standard flow; you'll need your current password.
+- **Locked out:** open `/recover` (public page). Paste the value of `BETTER_AUTH_SECRET` from your server env. The endpoint resets the account password to whatever `INITIAL_PASSWORD` is currently set to on the server — so to choose a new password this way: update `INITIAL_PASSWORD` on Railway, redeploy, then hit `/recover`. Rate-limited to 5 attempts per minute.
+
+There's no email-based reset. Robin assumes the operator owns the env vars; that's the recovery surface.
 
 ## MCP Tools
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -113,6 +113,44 @@ const faviconBuf = readFileSync(new URL('../assets/favicon.ico', import.meta.url
  * Admin and BullBoard routes apply their own session middleware.
  ***********************************************************************/
 
+// Backend-root landing page. Users who deploy via Railway and click the
+// core service's public URL thinking it's the wiki land here. Renders
+// WIKI_ORIGIN as a clickable link so they can find the actual app.
+// Does NOT echo INITIAL_USERNAME / INITIAL_PASSWORD — only names them.
+app.get('/', (c) => {
+  const rawOrigin = process.env.WIKI_ORIGIN ?? ''
+  const wikiUrl = rawOrigin.split(',')[0]?.trim() ?? ''
+  const esc = (s: string) =>
+    s.replace(
+      /[&<>"']/g,
+      (ch) =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[ch] ?? ch,
+    )
+  const wikiBlock = wikiUrl
+    ? `<p>Your Robin wiki is at <a href="${esc(wikiUrl)}">${esc(wikiUrl)}</a>. Visit it to get started.</p>`
+    : `<p>Your Robin wiki origin is not configured yet — set <code>WIKI_ORIGIN</code> in your env vars.</p>`
+  return c.html(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Robin · Backend API</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 560px; margin: 80px auto; padding: 0 24px; color: #222; line-height: 1.55; }
+  h1 { font-weight: 600; margin: 0 0 8px; }
+  .hint { color: #666; margin-top: 0; }
+  a { color: #0066cc; }
+  code { background: #f5f5f5; padding: 2px 6px; border-radius: 3px; font-size: 0.95em; }
+</style>
+</head>
+<body>
+<h1>Hello.</h1>
+<p class="hint">You've reached the Robin <strong>Backend API</strong>. This isn't where the app lives.</p>
+${wikiBlock}
+<p>Log in with the <code>INITIAL_USERNAME</code> and <code>INITIAL_PASSWORD</code> you set in your env vars.</p>
+</body>
+</html>`)
+})
+
 app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
 app.get('/openapi.json', (c) => c.json(openapiSpec))
 // Favicon — MCP clients (and browsers hitting the core URL directly)


### PR DESCRIPTION
## What's in this PR

**README rewrite** — TOC, Deploy moved up to right after Tech Stack, Prereqs + Quick Start merged into Local Setup, new "What Robin does" walkthrough with a concrete example, "Account password" section documenting `/profile` + `/recover` flows, humanized voice. Fixes wrong clone URL (`robin.git` → `robinwiki.git`) and a broken `MASTER_KEY=$(openssl …)` env example.

**Backend root page** — new `GET /` on core. Renders a small HTML page pointing users at `WIKI_ORIGIN` so they don't get stuck on the API URL thinking it's the wiki. `INITIAL_USERNAME` / `INITIAL_PASSWORD` named only — values never echoed.

**License** — relicensed under MIT. New `LICENSE` file at repo root, README updated.