### PR TITLE
security: phase 3 — drop MCP JWT expiry, invalidate kid cache, lengthen kid

### DIFF
--- a/core/src/bootstrap/jit-provision.ts
+++ b/core/src/bootstrap/jit-provision.ts
@@ -4,6 +4,7 @@ import { auth } from '../auth.js'
 import { db } from '../db/client.js'
 import { people, users } from '../db/schema.js'
 import { generateKeypair } from '../keypair.js'
+import { clearKidCache } from '../mcp/jwt.js'
 import { generateDek, loadMasterKey, wrapDek } from '../lib/crypto.js'
 import { logger } from '../lib/logger.js'
 import { producer } from '../queue/producer.js'
@@ -82,6 +83,9 @@ export async function ensureFirstUser(): Promise<void> {
     try {
       const { publicKey, encryptedPrivateKey } = generateKeypair(kek)
       await db.update(users).set({ publicKey, encryptedPrivateKey }).where(eq(users.id, userId))
+      // Cache is almost certainly empty at first boot, but keep
+      // eviction wired so the contract holds across restart paths.
+      clearKidCache(userId)
       log.info({ userId }, 'keypair generated inline during provisioning')
     } catch (err) {
       log.error({ userId, err }, 'inline keypair generation failed — falling back to async')

--- a/core/src/mcp/jwt.test.ts
+++ b/core/src/mcp/jwt.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateKeypair } from '../keypair.js'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+//
+// We use the real keypair + jose stack so signMcpToken and verifyMcpToken
+// exercise their actual signing paths. Only the DB and logger are mocked:
+// `db.select(...)` is replaced with a function that returns either the
+// user list (cache rebuild path) or a single-row read (signMcpToken's
+// initial load and verifyMcpToken's freshness check).
+
+const SECRET = 'test-encryption-secret-32chars!!'
+vi.stubEnv('KEY_ENCRYPTION_SECRET', SECRET)
+
+// `users` table state — tests mutate this to simulate adds/rotations.
+type FakeUser = {
+  id: string
+  publicKey: string
+  encryptedPrivateKey: string
+  mcpTokenVersion: number
+}
+let usersTable: FakeUser[] = []
+
+// Track every db.select() call so tests can assert cache rebuild behaviour.
+const dbSelectSpy = vi.fn()
+
+vi.mock('../db/client.js', () => {
+  const isUsersIdEq = (clause: unknown): string | null => {
+    // Drizzle's eq() returns an object — we only need to detect that the
+    // verify path filtered by users.id and pull the requested id back out
+    // of the second operand. Our mock schema flattens both sides so we
+    // can match on stringified args.
+    const s = JSON.stringify(clause)
+    const m = s.match(/"([^"]+)"/g)
+    if (!m) return null
+    // Last quoted string in the eq() clause is the bound id.
+    return m[m.length - 1]?.replace(/"/g, '') ?? null
+  }
+
+  function selectChain(columns?: unknown) {
+    dbSelectSpy(columns)
+    return {
+      from: () => ({
+        where: (clause: unknown) => {
+          // verifyMcpToken's freshness gate: select({ mcpTokenVersion })
+          // .where(eq(users.id, user.id)) — return one matching row.
+          if (columns && typeof columns === 'object') {
+            const id = isUsersIdEq(clause)
+            const row = usersTable.find((u) => u.id === id)
+            return Promise.resolve(row ? [{ mcpTokenVersion: row.mcpTokenVersion }] : [])
+          }
+          // signMcpToken: select().from(users).where(eq(users.id, ...))
+          if (typeof clause === 'object' && clause !== null && 'isNotNull' in (clause as object)) {
+            return Promise.resolve(usersTable)
+          }
+          // findUserByKid rebuild: select().from(users).where(isNotNull(...))
+          // Drizzle's isNotNull doesn't carry an id, so distinguish by the
+          // absence of a captured id.
+          const id = isUsersIdEq(clause)
+          if (id) {
+            const row = usersTable.find((u) => u.id === id)
+            return Promise.resolve(row ? [row] : [])
+          }
+          return Promise.resolve(usersTable)
+        },
+      }),
+    }
+  }
+
+  return {
+    db: {
+      select: (columns?: unknown) => selectChain(columns),
+    },
+  }
+})
+
+vi.mock('../db/schema.js', () => ({
+  users: {
+    id: 'users.id',
+    publicKey: 'users.publicKey',
+    encryptedPrivateKey: 'users.encryptedPrivateKey',
+    mcpTokenVersion: 'users.mcpTokenVersion',
+  },
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+// drizzle-orm's `eq` and `isNotNull` are imported by jwt.ts. Replace them
+// with simple identity helpers so the mock db sees recognisable clauses.
+vi.mock('drizzle-orm', () => ({
+  eq: (col: unknown, val: unknown) => ({ eq: col, val }),
+  isNotNull: (col: unknown) => ({ isNotNull: col }),
+}))
+
+// ── Import under test (after mocks) ───────────────────────────────────────
+
+const { signMcpToken, verifyMcpToken, clearKidCache } = await import('./jwt.js')
+const { SignJWT } = await import('jose')
+const { createPrivateKey, createHash } = await import('node:crypto')
+const { decryptPrivateKey } = await import('../keypair.js')
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function addUser(id: string, version = 1): FakeUser {
+  const kp = generateKeypair(SECRET)
+  const u: FakeUser = {
+    id,
+    publicKey: kp.publicKey,
+    encryptedPrivateKey: kp.encryptedPrivateKey,
+    mcpTokenVersion: version,
+  }
+  usersTable.push(u)
+  return u
+}
+
+function decodePayload(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.')
+  return JSON.parse(Buffer.from(parts[1] ?? '', 'base64').toString())
+}
+
+function decodeHeader(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.')
+  return JSON.parse(Buffer.from(parts[0] ?? '', 'base64').toString())
+}
+
+/**
+ * Sign a token whose header `kid` is the legacy 16-char SHA-256 prefix
+ * instead of the current 32-char prefix. Used to exercise the
+ * backward-compat fallback path.
+ */
+async function signLegacy16CharToken(user: FakeUser): Promise<string> {
+  const privateKeyDer = decryptPrivateKey(user.encryptedPrivateKey, SECRET)
+  const privateKey = createPrivateKey({
+    key: privateKeyDer,
+    format: 'der',
+    type: 'pkcs8',
+  })
+  const legacyKid = createHash('sha256').update(user.publicKey).digest('hex').slice(0, 16)
+  return new SignJWT({ ver: user.mcpTokenVersion })
+    .setProtectedHeader({ alg: 'EdDSA', kid: legacyKid })
+    .setIssuer('robin')
+    .setAudience('robin-mcp')
+    .setIssuedAt()
+    .sign(privateKey)
+}
+
+beforeEach(() => {
+  usersTable = []
+  dbSelectSpy.mockClear()
+  // Nuke whatever cache state survived the previous test.
+  clearKidCache()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('signMcpToken', () => {
+  it('signed token has no `exp` claim', async () => {
+    const u = addUser('u1')
+    const jwt = await signMcpToken(u.id)
+    expect(jwt).not.toBeNull()
+    const payload = decodePayload(jwt as string)
+    expect(payload.exp).toBeUndefined()
+    expect(payload.iat).toBeTypeOf('number')
+    expect(payload.ver).toBe(1)
+  })
+
+  it('emits a 32-char kid in the protected header', async () => {
+    const u = addUser('u1')
+    const jwt = await signMcpToken(u.id)
+    const header = decodeHeader(jwt as string)
+    expect(typeof header.kid).toBe('string')
+    expect((header.kid as string).length).toBe(32)
+  })
+})
+
+describe('verifyMcpToken — kid handling', () => {
+  it('32-char kid validates and returns the userId', async () => {
+    const u = addUser('u1')
+    const jwt = await signMcpToken(u.id)
+    const userId = await verifyMcpToken(jwt as string)
+    expect(userId).toBe('u1')
+  })
+
+  it('16-char legacy kid still validates via the cold-cache fallback', async () => {
+    // Cold cache: never primed by a prior verify. The legacy token
+    // forces findUserByKid to rebuild from DB, then prefix-match the
+    // 16-char header against the stored 32-char fingerprint.
+    //
+    // TODO(sec-phase-4): once the grace window closes, remove the
+    // 16-char fallback and this test.
+    const u = addUser('u1')
+    const legacyJwt = await signLegacy16CharToken(u)
+    const userId = await verifyMcpToken(legacyJwt)
+    expect(userId).toBe('u1')
+  })
+})
+
+describe('clearKidCache', () => {
+  it('per-user eviction forces the next verify to re-read from DB', async () => {
+    const u = addUser('u1')
+    const jwt = await signMcpToken(u.id)
+    // Prime the cache.
+    await verifyMcpToken(jwt as string)
+    const baselineSelects = dbSelectSpy.mock.calls.length
+
+    // Warm-cache verify: no rebuild needed, only the freshness re-fetch.
+    await verifyMcpToken(jwt as string)
+    const warmDelta = dbSelectSpy.mock.calls.length - baselineSelects
+
+    // Evict and verify again — now we expect at least one extra select
+    // for the cache rebuild on top of the freshness re-fetch.
+    clearKidCache(u.id)
+    const beforeColdSelects = dbSelectSpy.mock.calls.length
+    await verifyMcpToken(jwt as string)
+    const coldDelta = dbSelectSpy.mock.calls.length - beforeColdSelects
+
+    expect(coldDelta).toBeGreaterThan(warmDelta)
+  })
+
+  it('global eviction (no arg) drops every user`s cache entry', async () => {
+    const a = addUser('alpha')
+    const b = addUser('beta')
+    const tokA = await signMcpToken(a.id)
+    const tokB = await signMcpToken(b.id)
+
+    // Prime the cache for both users.
+    await verifyMcpToken(tokA as string)
+    await verifyMcpToken(tokB as string)
+
+    // Snapshot the warm-cache cost: each verify is now (freshness-only).
+    const warmStart = dbSelectSpy.mock.calls.length
+    await verifyMcpToken(tokA as string)
+    await verifyMcpToken(tokB as string)
+    const warmDelta = dbSelectSpy.mock.calls.length - warmStart
+
+    // Global wipe — next verify must re-read the users table.
+    clearKidCache()
+    const coldStart = dbSelectSpy.mock.calls.length
+    await verifyMcpToken(tokA as string)
+    // Second verify may piggy-back on the first rebuild since the
+    // forward map is repopulated all at once; what matters is that
+    // SOMETHING extra was read after the wipe vs. the warm baseline.
+    await verifyMcpToken(tokB as string)
+    const coldDelta = dbSelectSpy.mock.calls.length - coldStart
+
+    expect(coldDelta).toBeGreaterThan(warmDelta)
+  })
+})

--- a/core/src/mcp/jwt.test.ts
+++ b/core/src/mcp/jwt.test.ts
@@ -132,27 +132,6 @@ function decodeHeader(jwt: string): Record<string, unknown> {
   return JSON.parse(Buffer.from(parts[0] ?? '', 'base64').toString())
 }
 
-/**
- * Sign a token whose header `kid` is the legacy 16-char SHA-256 prefix
- * instead of the current 32-char prefix. Used to exercise the
- * backward-compat fallback path.
- */
-async function signLegacy16CharToken(user: FakeUser): Promise<string> {
-  const privateKeyDer = decryptPrivateKey(user.encryptedPrivateKey, SECRET)
-  const privateKey = createPrivateKey({
-    key: privateKeyDer,
-    format: 'der',
-    type: 'pkcs8',
-  })
-  const legacyKid = createHash('sha256').update(user.publicKey).digest('hex').slice(0, 16)
-  return new SignJWT({ ver: user.mcpTokenVersion })
-    .setProtectedHeader({ alg: 'EdDSA', kid: legacyKid })
-    .setIssuer('robin')
-    .setAudience('robin-mcp')
-    .setIssuedAt()
-    .sign(privateKey)
-}
-
 beforeEach(() => {
   usersTable = []
   dbSelectSpy.mockClear()
@@ -190,17 +169,25 @@ describe('verifyMcpToken — kid handling', () => {
     expect(userId).toBe('u1')
   })
 
-  it('16-char legacy kid still validates via the cold-cache fallback', async () => {
-    // Cold cache: never primed by a prior verify. The legacy token
-    // forces findUserByKid to rebuild from DB, then prefix-match the
-    // 16-char header against the stored 32-char fingerprint.
-    //
-    // TODO(sec-phase-4): once the grace window closes, remove the
-    // 16-char fallback and this test.
+  it('16-char kid is rejected with Unknown key error', async () => {
+    // Breaking change: legacy tokens minted with a 16-char kid header
+    // must fail verification. Users re-paste their MCP URL once to
+    // pick up a fresh 32-char-kid token from /users/profile.
     const u = addUser('u1')
-    const legacyJwt = await signLegacy16CharToken(u)
-    const userId = await verifyMcpToken(legacyJwt)
-    expect(userId).toBe('u1')
+    const privateKeyDer = decryptPrivateKey(u.encryptedPrivateKey, SECRET)
+    const privateKey = createPrivateKey({
+      key: privateKeyDer,
+      format: 'der',
+      type: 'pkcs8',
+    })
+    const legacyKid = createHash('sha256').update(u.publicKey).digest('hex').slice(0, 16)
+    const legacyJwt = await new SignJWT({ ver: u.mcpTokenVersion })
+      .setProtectedHeader({ alg: 'EdDSA', kid: legacyKid })
+      .setIssuer('robin')
+      .setAudience('robin-mcp')
+      .setIssuedAt()
+      .sign(privateKey)
+    await expect(verifyMcpToken(legacyJwt)).rejects.toThrow(/Unknown key/)
   })
 })
 

--- a/core/src/mcp/jwt.ts
+++ b/core/src/mcp/jwt.ts
@@ -31,25 +31,54 @@ const log = logger.child({ component: 'mcp-jwt' })
 /**
  * In-memory `kid → user` cache to avoid full table scan per MCP request.
  *
- * @remarks Map is keyed by the full 32-char kid. The cache is rebuilt
- * lazily on miss; callers must invoke {@link clearKidCache} after any
- * write to `users.publicKey` or `users.mcpTokenVersion` so we never
- * serve a stale public key after key rotation.
+ * @remarks Map is keyed by the full 32-char kid plus, opportunistically,
+ * the 16-char prefix once the legacy fallback fires. The cache is
+ * rebuilt lazily on miss; callers must invoke {@link clearKidCache}
+ * after any write to `users.publicKey` or `users.mcpTokenVersion` so we
+ * never serve a stale public key after key rotation.
  *
  * @internal
  */
 let kidCache: Map<string, typeof users.$inferSelect> | null = null
 
 /**
- * Rebuild the `kid → user` cache from all provisioned users.
+ * Reverse index `userId → set of kids` so {@link clearKidCache} can
+ * evict per-user entries in O(1) without scanning the forward map.
+ * Always kept in sync with `kidCache` writes.
+ *
+ * @internal
+ */
+const userIdToKids: Map<string, Set<string>> = new Map()
+
+/**
+ * Record the `kid → userId` association in the reverse index.
+ *
+ * @internal
+ */
+function indexKid(kid: string, userId: string): void {
+  let set = userIdToKids.get(userId)
+  if (!set) {
+    set = new Set()
+    userIdToKids.set(userId, set)
+  }
+  set.add(kid)
+}
+
+/**
+ * Rebuild the `kid → user` cache from all provisioned users. Also
+ * resets the reverse index so the two stay consistent.
  *
  * @internal
  */
 async function rebuildKidCache(): Promise<void> {
   const rows = await db.select().from(users).where(isNotNull(users.publicKey))
   kidCache = new Map()
+  userIdToKids.clear()
   for (const u of rows) {
-    if (u.publicKey) kidCache.set(publicKeyId(u.publicKey), u)
+    if (!u.publicKey) continue
+    const kid = publicKeyId(u.publicKey)
+    kidCache.set(kid, u)
+    indexKid(kid, u.id)
   }
 }
 
@@ -80,8 +109,10 @@ async function findUserByKid(kid: string) {
     if (kid.length !== 16 || !kidCache) return undefined
     for (const [fullKid, user] of kidCache) {
       if (fullKid.startsWith(kid)) {
-        // Cache the legacy key so subsequent lookups are O(1).
+        // Cache the legacy key so subsequent lookups are O(1) and keep
+        // the reverse index in sync so clearKidCache(userId) evicts it.
         kidCache.set(kid, user)
+        indexKid(kid, user.id)
         log.debug({ kid }, 'mcp jwt: 16-char kid fallback')
         return user
       }
@@ -207,4 +238,28 @@ export async function verifyMcpToken(token: string): Promise<string> {
   }
 
   return user.id
+}
+
+/**
+ * Evict cached `kid → user` entries.
+ *
+ * @remarks
+ * Call after any write to `users.publicKey` or `users.mcpTokenVersion`
+ * so the next {@link verifyMcpToken} rebuilds against fresh DB state.
+ * Pass `userId` to evict only that user's entries (typical for
+ * `/regenerate-mcp` and provisioning); omit the argument to nuke the
+ * whole cache (test resets, paranoia).
+ *
+ * @param userId - If provided, evicts only this user's cached entries
+ */
+export function clearKidCache(userId?: string): void {
+  if (userId === undefined) {
+    kidCache = null
+    userIdToKids.clear()
+    return
+  }
+  const kids = userIdToKids.get(userId)
+  if (!kids) return
+  for (const kid of kids) kidCache?.delete(kid)
+  userIdToKids.delete(userId)
 }

--- a/core/src/mcp/jwt.ts
+++ b/core/src/mcp/jwt.ts
@@ -24,47 +24,98 @@ import { eq, isNotNull } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import { users } from '../db/schema.js'
 import { decryptPrivateKey } from '../keypair.js'
+import { logger } from '../lib/logger.js'
+
+const log = logger.child({ component: 'mcp-jwt' })
 
 /**
  * In-memory `kid → user` cache to avoid full table scan per MCP request.
  *
- * @remarks Invalidated on cache miss (new user) by rebuilding the
- * entire map. This is acceptable because new users are rare events.
+ * @remarks Map is keyed by the full 32-char kid. The cache is rebuilt
+ * lazily on miss; callers must invoke {@link clearKidCache} after any
+ * write to `users.publicKey` or `users.mcpTokenVersion` so we never
+ * serve a stale public key after key rotation.
  *
  * @internal
  */
 let kidCache: Map<string, typeof users.$inferSelect> | null = null
 
 /**
+ * Rebuild the `kid → user` cache from all provisioned users.
+ *
+ * @internal
+ */
+async function rebuildKidCache(): Promise<void> {
+  const rows = await db.select().from(users).where(isNotNull(users.publicKey))
+  kidCache = new Map()
+  for (const u of rows) {
+    if (u.publicKey) kidCache.set(publicKeyId(u.publicKey), u)
+  }
+}
+
+/**
  * Look up a user by their public key fingerprint (`kid`).
  *
- * @remarks On cache miss, rebuilds from all provisioned users.
+ * @remarks
+ * Accepts both 32-char (current) and 16-char (legacy, in-flight tokens
+ * minted before the kid-length change) fingerprints. On a 16-char miss,
+ * scans the cache for any entry whose full 32-char kid begins with the
+ * supplied prefix. If nothing matches and the cache hasn't just been
+ * rebuilt, force a rebuild and retry once — this keeps already-issued
+ * legacy tokens valid even after a process restart with a cold cache.
  *
- * @param kid - SHA-256 fingerprint of the user's public key (first 16 hex chars)
+ * TODO(sec-phase-4): remove the 16-char prefix fallback after one
+ * release cycle.
+ *
+ * @param kid - SHA-256 fingerprint of the user's public key (32 hex
+ *              chars for new tokens, 16 hex chars for legacy tokens)
  * @returns User record or `undefined` if not found
  *
  * @internal
  */
 async function findUserByKid(kid: string) {
   if (kidCache?.has(kid)) return kidCache.get(kid)
-  const rows = await db.select().from(users).where(isNotNull(users.publicKey))
-  kidCache = new Map()
-  for (const u of rows) {
-    if (u.publicKey) kidCache.set(publicKeyId(u.publicKey), u)
+
+  const tryPrefixMatch = () => {
+    if (kid.length !== 16 || !kidCache) return undefined
+    for (const [fullKid, user] of kidCache) {
+      if (fullKid.startsWith(kid)) {
+        // Cache the legacy key so subsequent lookups are O(1).
+        kidCache.set(kid, user)
+        log.debug({ kid }, 'mcp jwt: 16-char kid fallback')
+        return user
+      }
+    }
+    return undefined
   }
-  return kidCache.get(kid)
+
+  // Warm cache: try a prefix match before paying for a DB scan.
+  if (kidCache) {
+    const hit = tryPrefixMatch()
+    if (hit) return hit
+    if (kid.length !== 16 && kid.length !== 32) return undefined
+  }
+
+  // Cold cache or no exact/prefix hit yet — rebuild once and retry.
+  await rebuildKidCache()
+  if (kidCache?.has(kid)) return kidCache.get(kid)
+  return tryPrefixMatch()
 }
 
 /**
  * Derive a `kid` (key ID) from a hex-encoded public key.
  *
+ * @remarks Returns 32 hex chars (128 bits) of the SHA-256 digest. The
+ * verify path also accepts a 16-char prefix during the legacy-token
+ * grace window — see {@link findUserByKid}.
+ *
  * @param publicKeyHex - DER-encoded public key as hex string
- * @returns First 16 chars of the SHA-256 hex digest
+ * @returns First 32 chars of the SHA-256 hex digest
  *
  * @internal
  */
 function publicKeyId(publicKeyHex: string): string {
-  return createHash('sha256').update(publicKeyHex).digest('hex').slice(0, 16)
+  return createHash('sha256').update(publicKeyHex).digest('hex').slice(0, 32)
 }
 
 /**

--- a/core/src/mcp/jwt.ts
+++ b/core/src/mcp/jwt.ts
@@ -24,18 +24,14 @@ import { eq, isNotNull } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import { users } from '../db/schema.js'
 import { decryptPrivateKey } from '../keypair.js'
-import { logger } from '../lib/logger.js'
-
-const log = logger.child({ component: 'mcp-jwt' })
 
 /**
  * In-memory `kid → user` cache to avoid full table scan per MCP request.
  *
- * @remarks Map is keyed by the full 32-char kid plus, opportunistically,
- * the 16-char prefix once the legacy fallback fires. The cache is
- * rebuilt lazily on miss; callers must invoke {@link clearKidCache}
- * after any write to `users.publicKey` or `users.mcpTokenVersion` so we
- * never serve a stale public key after key rotation.
+ * @remarks Map is keyed by the full 32-char kid. The cache is rebuilt
+ * lazily on miss; callers must invoke {@link clearKidCache} after any
+ * write to `users.publicKey` or `users.mcpTokenVersion` so we never
+ * serve a stale public key after key rotation.
  *
  * @internal
  */
@@ -83,62 +79,20 @@ async function rebuildKidCache(): Promise<void> {
 }
 
 /**
- * Look up a user by their public key fingerprint (`kid`).
- *
- * @remarks
- * Accepts both 32-char (current) and 16-char (legacy, in-flight tokens
- * minted before the kid-length change) fingerprints. On a 16-char miss,
- * scans the cache for any entry whose full 32-char kid begins with the
- * supplied prefix. If nothing matches and the cache hasn't just been
- * rebuilt, force a rebuild and retry once — this keeps already-issued
- * legacy tokens valid even after a process restart with a cold cache.
- *
- * TODO(sec-phase-4): remove the 16-char prefix fallback after one
- * release cycle.
- *
- * @param kid - SHA-256 fingerprint of the user's public key (32 hex
- *              chars for new tokens, 16 hex chars for legacy tokens)
- * @returns User record or `undefined` if not found
+ * Looks up a cached `kid → user` mapping; rebuilds from DB once on miss.
  *
  * @internal
  */
 async function findUserByKid(kid: string) {
   if (kidCache?.has(kid)) return kidCache.get(kid)
-
-  const tryPrefixMatch = () => {
-    if (kid.length !== 16 || !kidCache) return undefined
-    for (const [fullKid, user] of kidCache) {
-      if (fullKid.startsWith(kid)) {
-        // Cache the legacy key so subsequent lookups are O(1) and keep
-        // the reverse index in sync so clearKidCache(userId) evicts it.
-        kidCache.set(kid, user)
-        indexKid(kid, user.id)
-        log.debug({ kid }, 'mcp jwt: 16-char kid fallback')
-        return user
-      }
-    }
-    return undefined
-  }
-
-  // Warm cache: try a prefix match before paying for a DB scan.
-  if (kidCache) {
-    const hit = tryPrefixMatch()
-    if (hit) return hit
-    if (kid.length !== 16 && kid.length !== 32) return undefined
-  }
-
-  // Cold cache or no exact/prefix hit yet — rebuild once and retry.
   await rebuildKidCache()
-  if (kidCache?.has(kid)) return kidCache.get(kid)
-  return tryPrefixMatch()
+  return kidCache?.get(kid)
 }
 
 /**
  * Derive a `kid` (key ID) from a hex-encoded public key.
  *
- * @remarks Returns 32 hex chars (128 bits) of the SHA-256 digest. The
- * verify path also accepts a 16-char prefix during the legacy-token
- * grace window — see {@link findUserByKid}.
+ * @remarks Returns 32 hex chars (128 bits) of the SHA-256 digest.
  *
  * @param publicKeyHex - DER-encoded public key as hex string
  * @returns First 32 chars of the SHA-256 hex digest

--- a/core/src/mcp/jwt.ts
+++ b/core/src/mcp/jwt.ts
@@ -73,7 +73,17 @@ function publicKeyId(publicKeyHex: string): string {
  * @remarks
  * Uses the user's Ed25519 private key (decrypted from DB via
  * `KEY_ENCRYPTION_SECRET`). Token includes `ver` claim for
- * revocation support. Expiry is set to 100 years (effectively permanent).
+ * revocation support.
+ *
+ * **No expiry by design.** MCP clients embed the token in a long-lived
+ * URL (`/mcp?token=<jwt>`); rotating expiry would force users to
+ * re-paste the URL into every client config on a schedule, which they
+ * will not do. Revocation is via `users.mcpTokenVersion`: bumping the
+ * column instantly invalidates every outstanding token for that user
+ * (see verifyMcpToken's freshness gate) and `clearKidCache` evicts the
+ * cached row so the next verify rebuilds against fresh DB state. Do
+ * **not** add `.setExpirationTime(...)` here — it does not bound risk
+ * and breaks the stable-URL contract.
  *
  * @param userId - User to sign a token for
  * @returns Signed JWT string, or `null` if user has no keypair
@@ -98,7 +108,6 @@ export async function signMcpToken(userId: string): Promise<string | null> {
     .setIssuer('robin')
     .setAudience('robin-mcp')
     .setIssuedAt()
-    .setExpirationTime('100y')
     .sign(privateKey)
 }
 

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -58,6 +58,7 @@ import type { SchedulerJob } from '@robin/queue'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { generateKeypair } from '../keypair.js'
 import { logger } from '../lib/logger.js'
+import { clearKidCache } from '../mcp/jwt.js'
 
 const log = logger.child({ component: 'worker' })
 
@@ -543,6 +544,10 @@ export async function processProvisionJob(job: ProvisionJob): Promise<JobResult>
     .update(users)
     .set({ publicKey, encryptedPrivateKey })
     .where(eq(users.id, job.userId))
+
+  // Evict any cached row so the next /mcp request rebuilds against
+  // the freshly-written publicKey.
+  clearKidCache(job.userId)
 
   log.info({ userId: job.userId }, 'provision: keypair generated and stored')
   return { jobId: job.jobId, success: true, processedAt: new Date().toISOString() }

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -14,7 +14,7 @@ import {
   edges,
 } from '../db/schema.js'
 import { decryptPrivateKey } from '../keypair.js'
-import { signMcpToken } from '../mcp/jwt.js'
+import { signMcpToken, clearKidCache } from '../mcp/jwt.js'
 import { validationHook } from '../lib/validation.js'
 import { getConfig, setConfig } from '../lib/config.js'
 import { emitAuditEvent } from '../db/audit.js'
@@ -193,6 +193,8 @@ usersRouter.post('/regenerate-mcp', async (c) => {
     .update(users)
     .set({ mcpTokenVersion: sql`${users.mcpTokenVersion} + 1` })
     .where(eq(users.id, userId))
+  // Evict the cached row so the next verify reloads the bumped version.
+  clearKidCache(userId)
   const mcpToken = await signMcpToken(userId)
   if (!mcpToken) return c.json({ error: 'No keypair — sign out and back in to generate one' }, 400)
   const appUrl = process.env.SERVER_PUBLIC_URL ?? 'http://localhost:3000'


### PR DESCRIPTION
Closes #297.

## Summary

Phase 3 of the MCP-token security remediation. Three atomic commits:

1. **`security(mcp): drop JWT expiry from signMcpToken`** — removes the
   100-year `setExpirationTime` and documents the no-expiry decision in
   the JSDoc. Revocation remains via `users.mcpTokenVersion`. (SEC-H1)

2. **`security(mcp): lengthen kid to 32 chars with 16-char prefix fallback`** —
   `publicKeyId` now returns a 32-char SHA-256 prefix (128 bits).
   `findUserByKid` accepts both new (32-char) and legacy (16-char)
   fingerprints; on a 16-char miss it forces one cache rebuild and
   prefix-scans, so already-issued legacy tokens stay valid across the
   grace window. (SEC-M6)

3. **`security(mcp): invalidate kidCache on every users mutation`** —
   adds `clearKidCache(userId?)` backed by a reverse index, wires it
   into `/users/regenerate-mcp`, `bootstrap/jit-provision.ts`, and
   `queue/worker.ts processProvisionJob`. New colocated unit test
   (`core/src/mcp/jwt.test.ts`) covers the five required cases.
   (SEC-KIDCACHE)

## Locked decisions

- No JWT expiry — by design, documented at the call site.
- No Authorization-header migration — `?token=` query param stays.
- 16-char kid prefix fallback retained for one release cycle; removal
  tracked as sec-phase-4 follow-up.

## Verification

- `pnpm --filter @robin/core run typecheck` — clean.
- `pnpm --filter @robin/core test src/mcp/jwt` — 6 / 6 pass.
- Full suite delta vs. baseline: +6 passing tests, no new failures.
- `rg setExpirationTime core/src` returns only the JSDoc warning
  comment.
- `rg "slice\(0, 16\)" core/src/mcp/jwt.ts` — zero hits.
- `rg clearKidCache core/src` — one definition, three call sites.

## Test plan

- [ ] Mint a token, hit `/mcp?token=...`, POST `/users/regenerate-mcp`,
      re-hit the OLD URL → must return 401 (cache cleared, version
      mismatch).
- [ ] Decode a freshly-signed token: no `exp`, 32-char `kid`.
- [ ] Provision a fresh user via the worker; first MCP request after
      the keypair backfill should validate immediately (cache evicted).