### PR TITLE
security: phase 5 — singleton index, slug rotation, regen lock, anchored regex

### DIFF
--- a/core/drizzle/migrations/0002_users_singleton_uidx.sql
+++ b/core/drizzle/migrations/0002_users_singleton_uidx.sql
@@ -1,0 +1,6 @@
+-- Single-tenant invariant (#audit-M1). Replaces a JS count check that has a
+-- TOCTOU window with a DB-enforced guarantee that the users table holds at
+-- most one row. The expression `((true))` collapses every row to the same
+-- key; the second insert raises SQLSTATE 23505.
+CREATE UNIQUE INDEX IF NOT EXISTS users_singleton_uidx
+  ON users ((true));

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778457600000,
       "tag": "0001_wikis_people_embedding_retry_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778120351456,
+      "tag": "0002_users_singleton_uidx",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/auth.ts
+++ b/core/src/auth.ts
@@ -51,7 +51,20 @@ export const auth = betterAuth({
       if (ctx.path === '/sign-in/email') {
         await ensureFirstUser()
       }
-      // Single-user gate: block sign-up if any user exists
+      // Single-user gate: block sign-up if any user exists.
+      //
+      // This JS pre-check is the FAST PATH for the common case (sequential
+      // sign-ups against an already-populated DB get a clean 403). The
+      // authoritative gate is the DB unique partial index
+      // `users_singleton_uidx` (see migration 0002), which closes the TOCTOU
+      // window between this count and better-auth's INSERT.
+      //
+      // Locked decision (#audit-M1): two concurrent /sign-up/email requests
+      // may both pass this check; the loser's INSERT raises SQLSTATE 23505
+      // and surfaces as a 500. Acceptable — single-tenant deployments hit
+      // this only during onboarding. Engineering an after-hook interceptor
+      // for provider-layer DB errors adds maintenance cost not justified by
+      // the corner case.
       if (ctx.path === '/sign-up/email') {
         const [row] = await db.execute<{ count: number }>(sql`SELECT count(*)::int AS count FROM users`)
         if (row && row.count > 0) {

--- a/core/src/db/locks.ts
+++ b/core/src/db/locks.ts
@@ -1,7 +1,7 @@
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import { CasLock } from '@robin/caslock'
 import { db } from './client.js'
-import { entries, fragments } from './schema.js'
+import { entries, fragments, wikis } from './schema.js'
 import { logger } from '../lib/logger.js'
 
 const lockLog = logger.child({ component: 'caslock' })
@@ -30,7 +30,23 @@ export const fragmentLock = new CasLock({
   lockTtlMs: 60_000,
 })
 
-for (const lock of [entryLock, fragmentLock]) {
+// Per-wiki regenerate lock (#audit-M5). Wraps POST /wikis/:id/regenerate so
+// concurrent calls produce one 200 + one 409 instead of both burning LLM
+// budget. TTL-based stolen-lock recovery (cas-lock.ts:89-91) takes over a
+// stale lock once locked_at is older than lockTtlMs, so a crashed regen
+// does not pin the wiki at LINKING forever. Regen can run for ~30s on long
+// wikis; pad to 90s.
+export const wikiRegenLock = new CasLock({
+  db: lockDb,
+  table: wikis,
+  keyColumn: 'lookup_key',
+  stateColumn: 'state',
+  lockedByColumn: 'locked_by',
+  lockedAtColumn: 'locked_at',
+  lockTtlMs: 90_000,
+})
+
+for (const lock of [entryLock, fragmentLock, wikiRegenLock]) {
   lock.on('acquired', (e) => lockLog.debug(e, 'lock acquired'))
   lock.on('stolen', (e) => lockLog.warn(e, 'stole expired lock'))
   lock.on('contended', (e) => lockLog.debug(e, 'lock contended'))

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -29,24 +29,31 @@ const tsvector = customType<{ data: string; driverData: string }>({
 // All other domain tables dropped user_id in M2 (single-user collapse). Do not
 // re-add user_id to domain tables — single user means unscoped queries.
 
-export const users = pgTable('users', {
-  id: text('id').primaryKey(),
-  email: text('email').notNull().unique(),
-  emailVerified: boolean('email_verified').notNull().default(false),
-  name: text('name'),
-  image: text('image'),
-  // MCP JWT signing + token revocation (preserved from prior schema):
-  publicKey: text('public_key').notNull().default(''),
-  encryptedPrivateKey: text('encrypted_private_key').notNull().default(''),
-  mcpTokenVersion: integer('mcp_token_version').notNull().default(1),
-  // Single-user additions (M1):
-  encryptedDek: text('encrypted_dek').notNull().default(''),
-  passwordResetRequired: boolean('password_reset_required').notNull().default(false),
-  onboardingComplete: boolean('onboarding_complete').notNull().default(false),
-  onboardedAt: timestamp('onboarded_at'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
+export const users = pgTable(
+  'users',
+  {
+    id: text('id').primaryKey(),
+    email: text('email').notNull().unique(),
+    emailVerified: boolean('email_verified').notNull().default(false),
+    name: text('name'),
+    image: text('image'),
+    // MCP JWT signing + token revocation (preserved from prior schema):
+    publicKey: text('public_key').notNull().default(''),
+    encryptedPrivateKey: text('encrypted_private_key').notNull().default(''),
+    mcpTokenVersion: integer('mcp_token_version').notNull().default(1),
+    // Single-user additions (M1):
+    encryptedDek: text('encrypted_dek').notNull().default(''),
+    passwordResetRequired: boolean('password_reset_required').notNull().default(false),
+    onboardingComplete: boolean('onboarding_complete').notNull().default(false),
+    onboardedAt: timestamp('onboarded_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  // Single-tenant invariant (#audit-M1). Mirrors migration
+  // 0002_users_singleton_uidx.sql. The `(true)` expression collapses every
+  // row to the same key, so the second insert raises SQLSTATE 23505.
+  (_t) => [uniqueIndex('users_singleton_uidx').on(sql`(true)`)],
+)
 
 export const sessions = pgTable('sessions', {
   id: text('id').primaryKey(),

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -421,6 +421,11 @@ export async function regenerateWiki(
 
   // Optimistic lock: transition to LINKING to prevent concurrent regen runs.
   // If the wiki is already LINKING, another worker owns it — bail out.
+  //
+  // First-line defence is the wikiRegenLock CAS in db/locks.ts (used by
+  // POST /wikis/:id/regenerate). This in-function CAS is a belt-and-braces
+  // backstop for the regen-worker queue path which does not yet sit behind
+  // the same CasLock.
   const [lockedWiki] = await database
     .update(wikis)
     .set({ state: 'LINKING' })

--- a/core/src/routes/wikis.publish.test.ts
+++ b/core/src/routes/wikis.publish.test.ts
@@ -30,6 +30,7 @@ vi.mock('../db/schema.js', () => ({
     published: 'wikis.published',
     updatedAt: 'wikis.updated_at',
   },
+  entries: {},
   edges: {},
   wikiTypes: {},
   fragments: {},
@@ -38,6 +39,14 @@ vi.mock('../db/schema.js', () => ({
   edits: {},
   groupWikis: {},
   groups: {},
+}))
+
+// db/locks.ts pulls drizzle tables at module load — stub to avoid
+// running the real CasLock constructor against the test schema mocks.
+vi.mock('../db/locks.js', () => ({
+  wikiRegenLock: { using: vi.fn() },
+  entryLock: { using: vi.fn() },
+  fragmentLock: { using: vi.fn() },
 }))
 
 vi.mock('../middleware/session.js', () => ({

--- a/core/src/routes/wikis.publish.test.ts
+++ b/core/src/routes/wikis.publish.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks (must come before dynamic import) ────────────────────────────────
+//
+// Covers the publish/unpublish slug-rotation flow (#audit-M2). The unpublish
+// handler must null `publishedSlug` so the next publish mints a fresh slug;
+// `publishedAt` must be preserved.
+
+const mockDbSelect = vi.fn()
+const mockDbUpdate = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    update: (...args: unknown[]) => mockDbUpdate(...args),
+  },
+}))
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookup_key',
+    slug: 'wikis.slug',
+    name: 'wikis.name',
+    type: 'wikis.type',
+    prompt: 'wikis.prompt',
+    state: 'wikis.state',
+    publishedSlug: 'wikis.published_slug',
+    publishedAt: 'wikis.published_at',
+    published: 'wikis.published',
+    updatedAt: 'wikis.updated_at',
+  },
+  edges: {},
+  wikiTypes: {},
+  fragments: {},
+  people: {},
+  auditLog: {},
+  edits: {},
+  groupWikis: {},
+  groups: {},
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('userId', 'test-user')
+    await next()
+  }),
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../queue/producer.js', () => ({
+  producer: { enqueueRegen: vi.fn() },
+}))
+
+vi.mock('../mcp/wiki-type-inference.js', () => ({
+  inferWikiType: vi.fn().mockReturnValue('log'),
+}))
+
+const { wikisRoutes } = await import('./wikis.js')
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = new Hono()
+  app.route('/wikis', wikisRoutes)
+  return app
+}
+
+const fixedNow = new Date('2026-04-20T12:00:00Z')
+
+function makeWiki(overrides: Record<string, unknown> = {}) {
+  return {
+    lookupKey: 'wiki01TEST',
+    slug: 'engineering-log',
+    name: 'Engineering Log',
+    type: 'log',
+    prompt: '',
+    state: 'RESOLVED',
+    description: '',
+    structure: '',
+    content: 'some published content',
+    published: false,
+    publishedSlug: null,
+    publishedAt: null,
+    regenerate: true,
+    bouncerMode: 'auto',
+    lastRebuiltAt: null,
+    embedding: null,
+    embeddingAttemptCount: 0,
+    embeddingLastAttemptAt: null,
+    progress: null,
+    metadata: null,
+    citationDeclarations: [],
+    deletedAt: null,
+    dedupHash: null,
+    lockedBy: null,
+    lockedAt: null,
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    searchVector: null,
+    ...overrides,
+  }
+}
+
+function selectChainMock(rows: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockResolvedValue(rows)
+  return chain
+}
+
+function updateChainMock(returning: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.set = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockReturnValue(chain)
+  chain.returning = vi.fn().mockResolvedValue(returning)
+  return chain
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('POST /wikis/:id/publish — slug minting (#audit-M2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('mints a fresh 24-char slug when publishedSlug is null', async () => {
+    const wiki = makeWiki({ publishedSlug: null, publishedAt: null })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([wiki]))
+
+    const updateChain = updateChainMock([
+      makeWiki({ published: true, publishedSlug: 'PLACEHOLDER', publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/publish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const setArg = updateChain.set.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.published).toBe(true)
+    expect(typeof setArg.publishedSlug).toBe('string')
+    expect((setArg.publishedSlug as string).length).toBe(24)
+  })
+
+  it('reuses existing publishedSlug when present (idempotent re-publish)', async () => {
+    const existingSlug = 'abcdefghijklmnopqrstuvwx'
+    const wiki = makeWiki({ publishedSlug: existingSlug, publishedAt: fixedNow })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([wiki]))
+
+    const updateChain = updateChainMock([
+      makeWiki({ published: true, publishedSlug: existingSlug, publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/publish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const setArg = updateChain.set.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.publishedSlug).toBe(existingSlug)
+  })
+})
+
+describe('POST /wikis/:id/unpublish — slug rotation (#audit-M2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('nulls publishedSlug AND preserves publishedAt', async () => {
+    const wiki = makeWiki({
+      published: true,
+      publishedSlug: 'abcdefghijklmnopqrstuvwx',
+      publishedAt: fixedNow,
+    })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([wiki]))
+
+    const updateChain = updateChainMock([
+      makeWiki({ published: false, publishedSlug: null, publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/unpublish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const setArg = updateChain.set.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.published).toBe(false)
+    expect(setArg.publishedSlug).toBeNull()
+    // publishedAt MUST NOT be in the SET clause — it stays as-is in the row.
+    expect('publishedAt' in setArg).toBe(false)
+  })
+})
+
+describe('publish → unpublish → publish round-trip mints a NEW slug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('second publish (after unpublish nulled the slug) generates a different slug', async () => {
+    // First publish: starts with publishedSlug=null, mints slug A.
+    const initialWiki = makeWiki({ publishedSlug: null, publishedAt: null })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([initialWiki]))
+    const firstUpdateChain = updateChainMock([
+      makeWiki({ published: true, publishedSlug: 'first-slug-recorded', publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(firstUpdateChain)
+
+    const app = createApp()
+    await app.request('/wikis/wiki01TEST/publish', { method: 'POST' })
+    const slugA = firstUpdateChain.set.mock.calls[0][0].publishedSlug as string
+
+    // Unpublish: nulls publishedSlug.
+    const publishedWiki = makeWiki({
+      published: true,
+      publishedSlug: slugA,
+      publishedAt: fixedNow,
+    })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([publishedWiki]))
+    const unpublishUpdateChain = updateChainMock([
+      makeWiki({ published: false, publishedSlug: null, publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(unpublishUpdateChain)
+    await app.request('/wikis/wiki01TEST/unpublish', { method: 'POST' })
+    expect(unpublishUpdateChain.set.mock.calls[0][0].publishedSlug).toBeNull()
+
+    // Second publish: row now has publishedSlug=null again. Mint slug B.
+    const reUnpublishedWiki = makeWiki({
+      published: false,
+      publishedSlug: null,
+      publishedAt: fixedNow,
+    })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([reUnpublishedWiki]))
+    const secondPublishChain = updateChainMock([
+      makeWiki({ published: true, publishedSlug: 'second-slug-recorded', publishedAt: fixedNow }),
+    ])
+    mockDbUpdate.mockReturnValueOnce(secondPublishChain)
+    await app.request('/wikis/wiki01TEST/publish', { method: 'POST' })
+    const slugB = secondPublishChain.set.mock.calls[0][0].publishedSlug as string
+
+    expect(slugA).not.toBe(slugB)
+    expect(typeof slugA).toBe('string')
+    expect(typeof slugB).toBe('string')
+    expect(slugA.length).toBe(24)
+    expect(slugB.length).toBe(24)
+
+    // Round-trip: the second publish preserves publishedAt from the original row.
+    const secondPublishSetArg = secondPublishChain.set.mock.calls[0][0] as Record<string, unknown>
+    expect(secondPublishSetArg.publishedAt).toEqual(fixedNow)
+  })
+})

--- a/core/src/routes/wikis.regen.lock.test.ts
+++ b/core/src/routes/wikis.regen.lock.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks (must come before dynamic import) ────────────────────────────────
+//
+// Covers wikiRegenLock wrapping on POST /wikis/:id/regenerate (#audit-M5).
+// Asserts:
+//   - Concurrent calls produce one 200 + one 409
+//   - Disabled-regenerate wikis short-circuit with 400 (no lock attempted)
+//   - successState='PENDING' (and failureState='PENDING') is observed in the
+//     params passed to wikiRegenLock.using
+//   - CasLock contended error translates to 409 with the documented body
+
+const mockDbSelect = vi.fn()
+const mockUsing = vi.fn()
+const mockRegenerateWiki = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+  },
+}))
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookup_key',
+    name: 'wikis.name',
+    type: 'wikis.type',
+    state: 'wikis.state',
+    regenerate: 'wikis.regenerate',
+  },
+  edges: {},
+  wikiTypes: {},
+  fragments: {},
+  people: {},
+  auditLog: {},
+  edits: {},
+  groupWikis: {},
+  groups: {},
+}))
+
+vi.mock('../db/locks.js', () => ({
+  wikiRegenLock: {
+    using: (...args: unknown[]) => mockUsing(...args),
+  },
+}))
+
+vi.mock('../lib/regen.js', () => ({
+  regenerateWiki: (...args: unknown[]) => mockRegenerateWiki(...args),
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('userId', 'test-user')
+    await next()
+  }),
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../queue/producer.js', () => ({
+  producer: { enqueueRegen: vi.fn() },
+}))
+
+vi.mock('../mcp/wiki-type-inference.js', () => ({
+  inferWikiType: vi.fn().mockReturnValue('log'),
+}))
+
+const { wikisRoutes } = await import('./wikis.js')
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = new Hono()
+  app.route('/wikis', wikisRoutes)
+  return app
+}
+
+function selectChainMock(rows: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockResolvedValue(rows)
+  return chain
+}
+
+function makeWiki(overrides: Record<string, unknown> = {}) {
+  return {
+    lookupKey: 'wiki01TEST',
+    name: 'Engineering Log',
+    type: 'log',
+    regenerate: true,
+    state: 'PENDING',
+    ...overrides,
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('POST /wikis/:id/regenerate — wikiRegenLock wrapping (#audit-M5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes successState and failureState as PENDING and runs regenerateWiki inside the lock', async () => {
+    mockDbSelect.mockReturnValueOnce(selectChainMock([makeWiki()]))
+    mockUsing.mockImplementationOnce(async (_params, routine) => {
+      await routine()
+    })
+    mockRegenerateWiki.mockResolvedValueOnce({
+      content: 'x',
+      fragmentCount: 3,
+      hasEmbedding: true,
+      timing: { classify: 1, gatherFragments: 2, llmCall: 3, embed: 4, total: 10 },
+    })
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/regenerate', { method: 'POST' })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.ok).toBe(true)
+    expect(body.fragmentCount).toBe(3)
+
+    expect(mockUsing).toHaveBeenCalledTimes(1)
+    const params = mockUsing.mock.calls[0][0]
+    expect(params.key).toBe('wiki01TEST')
+    expect(params.fromState).toBe('PENDING')
+    expect(params.toState).toBe('LINKING')
+    expect(params.successState).toBe('PENDING')
+    expect(params.failureState).toBe('PENDING')
+    expect(params.autoRenew).toBe(true)
+    expect(params.lockedBy).toMatch(/^regen-wiki01TEST-/)
+  })
+
+  it('returns 409 with documented body when CasLock contended', async () => {
+    mockDbSelect.mockReturnValueOnce(selectChainMock([makeWiki()]))
+    mockUsing.mockRejectedValueOnce(new Error('CasLock contended: wiki01TEST'))
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/regenerate', { method: 'POST' })
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.error).toBe('Regeneration already in progress')
+    expect(mockRegenerateWiki).not.toHaveBeenCalled()
+  })
+
+  it('400s on regenerate=false without acquiring the lock', async () => {
+    mockDbSelect.mockReturnValueOnce(selectChainMock([makeWiki({ regenerate: false })]))
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/regenerate', { method: 'POST' })
+    expect(res.status).toBe(400)
+    expect(mockUsing).not.toHaveBeenCalled()
+    expect(mockRegenerateWiki).not.toHaveBeenCalled()
+  })
+
+  it('404s on unknown wiki without acquiring the lock', async () => {
+    mockDbSelect.mockReturnValueOnce(selectChainMock([]))
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki99NONE/regenerate', { method: 'POST' })
+    expect(res.status).toBe(404)
+    expect(mockUsing).not.toHaveBeenCalled()
+  })
+
+  it('passes through non-contention errors as 500', async () => {
+    mockDbSelect.mockReturnValueOnce(selectChainMock([makeWiki()]))
+    mockUsing.mockRejectedValueOnce(new Error('boom'))
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST/regenerate', { method: 'POST' })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.error).toBe('Regeneration failed')
+    expect(body.detail).toBe('boom')
+  })
+})

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -13,6 +13,7 @@ import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
 import { nanoid24 } from '../lib/id.js'
 import { regenerateWiki } from '../lib/regen.js'
+import { wikiRegenLock } from '../db/locks.js'
 import { buildSidecar } from '../lib/wikiSidecar.js'
 import { makeSidecarDeps } from '../lib/wikiSidecarDeps.js'
 import { stripWikiContent } from '../lib/strip-wiki-content.js'
@@ -619,7 +620,7 @@ wikisRouter.post('/:id/unpublish', async (c) => {
   return c.json(publishWikiResponseSchema.parse(updated))
 })
 
-// POST /wikis/:id/regenerate — on-demand wiki regen
+// POST /wikis/:id/regenerate — on-demand wiki regen, serialized via wikiRegenLock (#audit-M5)
 wikisRouter.post('/:id/regenerate', async (c) => {
   const id = c.req.param('id')
   const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
@@ -629,22 +630,54 @@ wikisRouter.post('/:id/regenerate', async (c) => {
     return c.json({ error: 'Regeneration is disabled for this wiki' }, 400)
   }
 
+  // wikiRegenLock keys on lookup_key. Concurrent calls produce one 200 + one
+  // 409. successState/failureState both return the wiki to PENDING so the
+  // next regen can acquire. TTL-based stolen-lock recovery (90s) takes over
+  // a stale lock after a crashed regen.
+  const lockedBy = `regen-${id}-${crypto.randomUUID()}`
+  let result: Awaited<ReturnType<typeof regenerateWiki>> | null = null
+
   try {
-    const result = await regenerateWiki(db, id)
-    log.info({ wikiKey: id, ...result }, 'wiki regenerated via on-demand endpoint')
-    if (result.timing) {
-      const t = result.timing
-      c.header('Server-Timing', `classify;dur=${t.classify}, gather;dur=${t.gatherFragments}, llm;dur=${t.llmCall}, embed;dur=${t.embed}, total;dur=${t.total}`)
-    }
-    return c.json({ ok: true, lookupKey: id, fragmentCount: result.fragmentCount })
+    await wikiRegenLock.using(
+      {
+        key: id,
+        fromState: 'PENDING',
+        toState: 'LINKING',
+        successState: 'PENDING',
+        failureState: 'PENDING',
+        lockedBy,
+        autoRenew: true,
+      },
+      async () => {
+        result = await regenerateWiki(db, id)
+      }
+    )
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.startsWith('CasLock contended')) {
+      return c.json({ error: 'Regeneration already in progress' }, 409)
+    }
     if (err instanceof NoOpenRouterKeyError) {
       return c.json({ error: 'OpenRouter API key not configured' }, 500)
     }
-    const message = err instanceof Error ? err.message : String(err)
     log.error({ wikiKey: id, error: message }, 'wiki regen failed')
     return c.json({ error: 'Regeneration failed', detail: message }, 500)
   }
+
+  if (!result) {
+    log.error({ wikiKey: id }, 'wiki regen completed without result')
+    return c.json({ error: 'Regeneration failed', detail: 'no result' }, 500)
+  }
+
+  // TS sees `result` as never inside the closure due to control-flow analysis;
+  // rebind to a local with the correct type for the rest of the handler.
+  const regenResult: Awaited<ReturnType<typeof regenerateWiki>> = result
+  log.info({ wikiKey: id, ...regenResult }, 'wiki regenerated via on-demand endpoint')
+  if (regenResult.timing) {
+    const t = regenResult.timing
+    c.header('Server-Timing', `classify;dur=${t.classify}, gather;dur=${t.gatherFragments}, llm;dur=${t.llmCall}, embed;dur=${t.embed}, total;dur=${t.total}`)
+  }
+  return c.json({ ok: true, lookupKey: id, fragmentCount: regenResult.fragmentCount })
 })
 
 // PATCH /wikis/:id/regenerate — toggle regenerate boolean

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -559,6 +559,9 @@ wikisRouter.post('/:id/publish', async (c) => {
     return c.json({ error: 'Cannot publish a wiki with no content' }, 400)
   }
 
+  // Mint a fresh slug whenever publishedSlug IS NULL. Pairs with the
+  // unpublish handler which nulls the slug, so an unpublish/republish
+  // cycle always produces a new public URL (#audit-M2).
   const slug = wiki.publishedSlug ?? nanoid24()
   const [updated] = await db
     .update(wikis)
@@ -583,15 +586,24 @@ wikisRouter.post('/:id/publish', async (c) => {
   return c.json(publishWikiResponseSchema.parse(updated))
 })
 
-// POST /wikis/:id/unpublish — unpublish wiki (preserves slug for re-publish)
+// POST /wikis/:id/unpublish — unpublish wiki and rotate slug
 wikisRouter.post('/:id/unpublish', async (c) => {
   const id = c.req.param('id')
   const [wiki] = await db.select().from(wikis).where(eq(wikis.lookupKey, id))
   if (!wiki) return c.json({ error: 'Not found' }, 404)
 
+  // Rotate publishedSlug on unpublish (#audit-M2). Preserving the slug
+  // across an unpublish/republish cycle reuses the original public URL,
+  // defeating the user's intent that "unpublish" revoke the link they
+  // shared. publishedAt is preserved — it records the historical
+  // first-publish time and downstream audit views read it.
   const [updated] = await db
     .update(wikis)
-    .set({ published: false, updatedAt: new Date() })
+    .set({
+      published: false,
+      publishedSlug: null,
+      updatedAt: new Date(),
+    })
     .where(eq(wikis.lookupKey, id))
     .returning()
 

--- a/packages/shared/src/__tests__/identity.regex.test.ts
+++ b/packages/shared/src/__tests__/identity.regex.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { LK_REGEX, LK_REGEX_STRICT, safeRefToHref } from '../identity'
+
+// Covers the LOOKUP_KEY_RE → LK_REGEX rename, the new anchored variant
+// LK_REGEX_STRICT, and the safeRefToHref helper added for #audit-M9.
+
+const VALID_WIKI = 'wiki01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const VALID_FRAG = 'frag01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const VALID_ENTRY = 'entry01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const VALID_PERSON = 'person01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+describe('LK_REGEX (unanchored substring form, renamed from LOOKUP_KEY_RE)', () => {
+  it('matches a valid wiki key embedded in surrounding text', () => {
+    const text = `see ${VALID_WIKI} inline`
+    const match = text.match(LK_REGEX.wiki)
+    expect(match?.[0]).toBe(VALID_WIKI)
+  })
+
+  it('matches a valid fragment key embedded in surrounding text', () => {
+    const text = `cite ${VALID_FRAG} please`
+    const match = text.match(LK_REGEX.frag)
+    expect(match?.[0]).toBe(VALID_FRAG)
+  })
+
+  it('matches a valid entry key embedded in surrounding text', () => {
+    const text = `link ${VALID_ENTRY} here`
+    const match = text.match(LK_REGEX.entry)
+    expect(match?.[0]).toBe(VALID_ENTRY)
+  })
+
+  it('matches a valid person key embedded in surrounding text', () => {
+    const text = `meet ${VALID_PERSON} today`
+    const match = text.match(LK_REGEX.person)
+    expect(match?.[0]).toBe(VALID_PERSON)
+  })
+})
+
+describe('LK_REGEX_STRICT (anchored form for trust boundaries)', () => {
+  it('matches a bare valid wiki key', () => {
+    expect(LK_REGEX_STRICT.wiki.test(VALID_WIKI)).toBe(true)
+  })
+
+  it('rejects an absolute URL', () => {
+    expect(LK_REGEX_STRICT.wiki.test('https://evil.com')).toBe(false)
+  })
+
+  it('rejects a URL whose path contains a valid key (no embedding)', () => {
+    expect(LK_REGEX_STRICT.wiki.test(`https://evil.com/${VALID_WIKI}`)).toBe(false)
+  })
+
+  it('rejects a key with a leading prefix segment', () => {
+    expect(LK_REGEX_STRICT.wiki.test(`prefix ${VALID_WIKI}`)).toBe(false)
+  })
+
+  it('rejects a key with a trailing suffix segment', () => {
+    expect(LK_REGEX_STRICT.wiki.test(`${VALID_WIKI}/extra`)).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    expect(LK_REGEX_STRICT.wiki.test('')).toBe(false)
+  })
+
+  it('rejects a string that is one character too short', () => {
+    expect(LK_REGEX_STRICT.wiki.test(VALID_WIKI.slice(0, -1))).toBe(false)
+  })
+
+  it('rejects lowercase ULID body', () => {
+    expect(LK_REGEX_STRICT.wiki.test(VALID_WIKI.toLowerCase())).toBe(false)
+  })
+})
+
+describe('safeRefToHref', () => {
+  it('returns /wiki/<key> for a valid wiki key', () => {
+    expect(safeRefToHref(VALID_WIKI)).toBe(`/wiki/${VALID_WIKI}`)
+  })
+
+  it('returns /fragments/<key> for a valid fragment key', () => {
+    expect(safeRefToHref(VALID_FRAG)).toBe(`/fragments/${VALID_FRAG}`)
+  })
+
+  it('returns /entries/<key> for a valid entry key', () => {
+    expect(safeRefToHref(VALID_ENTRY)).toBe(`/entries/${VALID_ENTRY}`)
+  })
+
+  it('returns /people/<key> for a valid person key', () => {
+    expect(safeRefToHref(VALID_PERSON)).toBe(`/people/${VALID_PERSON}`)
+  })
+
+  it('returns null for an absolute URL', () => {
+    expect(safeRefToHref('https://evil.com')).toBeNull()
+  })
+
+  it('returns null for a URL whose path contains a valid key', () => {
+    expect(safeRefToHref(`https://evil.com/${VALID_WIKI}`)).toBeNull()
+  })
+
+  it('returns null for an unknown prefix', () => {
+    expect(safeRefToHref('vault01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBeNull()
+  })
+
+  it('returns null for the empty string', () => {
+    expect(safeRefToHref('')).toBeNull()
+  })
+
+  it('returns null for a path-traversal attempt', () => {
+    expect(safeRefToHref('../wiki/foo')).toBeNull()
+  })
+
+  it('returns null for a key with leading/trailing whitespace', () => {
+    expect(safeRefToHref(` ${VALID_WIKI} `)).toBeNull()
+  })
+})

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -18,27 +18,80 @@ export const TYPE_TO_DIR: Record<ObjectType, string> = {
 }
 
 /**
- * @summary Regex patterns for matching lookup keys by type.
+ * @summary Unanchored regex patterns for matching lookup keys by type.
  *
  * @remarks
  * Canonical format: `{prefix}[0-9A-Z]{26}` (Crockford Base32 ULID, no separator).
- * Use these for extraction from unstructured text (e.g. MCP response bodies, logs).
+ * Use these for substring extraction from unstructured text (e.g. MCP
+ * response bodies, log lines). For trust-boundary validation of a single
+ * input string, use {@link LK_REGEX_STRICT} instead — the unanchored form
+ * happily matches a valid key embedded in a malicious envelope (e.g.
+ * `https://evil.com/wiki01...`).
  *
  * @example
  * ```ts
- * const match = text.match(LOOKUP_KEY_RE.entry)
+ * const match = text.match(LK_REGEX.entry)
  * // match[0] === 'entry01KMJBYN40EK57JDH4RXWNKETV'
  * ```
  */
-export const LOOKUP_KEY_RE: Record<ObjectType, RegExp> = {
+export const LK_REGEX: Record<ObjectType, RegExp> = {
   entry: /entry[0-9A-Z]{26}/,
   frag: /frag[0-9A-Z]{26}/,
   wiki: /wiki[0-9A-Z]{26}/,
   person: /person[0-9A-Z]{26}/,
 }
 
-/** Match any lookup key regardless of type */
+/**
+ * @summary Anchored variant of {@link LK_REGEX} — for strict-match
+ * validation at trust boundaries (e.g. router.push, DB key writes).
+ *
+ * @remarks
+ * Unlike {@link LK_REGEX}, this set rejects strings that merely *contain*
+ * a valid key. Use it whenever an unsanitised string is about to become a
+ * route, file path, or DB primary key. (#audit-M9)
+ */
+export const LK_REGEX_STRICT: Record<ObjectType, RegExp> = {
+  entry: /^entry[0-9A-Z]{26}$/,
+  frag: /^frag[0-9A-Z]{26}$/,
+  wiki: /^wiki[0-9A-Z]{26}$/,
+  person: /^person[0-9A-Z]{26}$/,
+}
+
+/** Match any lookup key regardless of type (unanchored substring form). */
 export const ANY_LOOKUP_KEY_RE = /(?:entry|frag|wiki|person)[0-9A-Z]{26}/
+
+/** Map type prefix to canonical wiki path. */
+const PREFIX_TO_PATH: Record<ObjectType, (id: string) => string> = {
+  entry: (id) => `/entries/${id}`,
+  frag: (id) => `/fragments/${id}`,
+  wiki: (id) => `/wiki/${id}`,
+  person: (id) => `/people/${id}`,
+}
+
+/**
+ * Validate a lookup-key ref against {@link LK_REGEX_STRICT} and return the
+ * canonical wiki path on match, or null on mismatch.
+ *
+ * Use at any trust boundary that turns an unsanitised string into a
+ * client-side route (e.g. `router.push`). The strict regex prevents
+ * absolute URLs, scheme-relative URLs, and arbitrary path segments from
+ * leaking into navigation. (#audit-M9)
+ *
+ * @example
+ * ```ts
+ * safeRefToHref('wiki01ARZ3NDEKTSV4RRFFQ69G5FAV') // '/wiki/wiki01ARZ3NDEKTSV4RRFFQ69G5FAV'
+ * safeRefToHref('https://evil.com')               // null
+ * safeRefToHref('https://evil.com/wiki01ARZ...')  // null
+ * ```
+ */
+export function safeRefToHref(ref: string): string | null {
+  for (const prefix of Object.values(ObjectType)) {
+    if (LK_REGEX_STRICT[prefix].test(ref)) {
+      return PREFIX_TO_PATH[prefix](ref)
+    }
+  }
+  return null
+}
 
 const generateUlid = monotonicFactory()
 

--- a/wiki/src/components/graph/GraphDetailPanel.tsx
+++ b/wiki/src/components/graph/GraphDetailPanel.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
+import { safeRefToHref } from "@robin/shared";
 import { T, FONT } from "@/lib/typography";
-import { ROUTES } from "@/lib/routes";
 import type { GraphData, GraphNode, GraphNodeType } from "./graphSampleData";
 
 const TYPE_LABEL: Record<GraphNodeType, string> = {
@@ -192,17 +192,22 @@ export function GraphDetailPanel({
   if (connByType.fragment > 0) connParts.push(`${connByType.fragment} fragment${connByType.fragment !== 1 ? "s" : ""}`);
   if (connByType.person > 0) connParts.push(`${connByType.person} ${connByType.person !== 1 ? "people" : "person"}`);
 
-  // Navigation URL
-  const getNodeUrl = (node: GraphNode): string => {
-    const id = node.lookupKey ?? node.id;
-    switch (node.type) {
-      case "wiki":
-        return ROUTES.wiki(id);
-      case "fragment":
-        return ROUTES.fragment(id);
-      case "person":
-        return ROUTES.person(id);
+  // Navigation URL — guarded by safeRefToHref (#audit-M9). Treat
+  // node.lookupKey as untrusted at the navigation boundary; reject
+  // anything that does not match the canonical {prefix}[0-9A-Z]{26}
+  // shape so a forged node can't drive router.push to an arbitrary
+  // path or absolute URL.
+  const handleOpen = (node: GraphNode) => {
+    const ref = node.lookupKey ?? node.id;
+    const href = safeRefToHref(ref);
+    if (!href) {
+      console.warn(
+        "graph: refusing to navigate — invalid ref",
+        { lookupKey: node.lookupKey, id: node.id },
+      );
+      return;
     }
+    router.push(href);
   };
 
   return (
@@ -340,7 +345,7 @@ export function GraphDetailPanel({
       {/* Open button */}
       <button
         type="button"
-        onClick={() => router.push(getNodeUrl(selectedNode))}
+        onClick={() => handleOpen(selectedNode)}
         style={{
           width: "100%",
           padding: "8px 12px",


### PR DESCRIPTION
Closes #299.

## Summary

Phase 5 of the security remediation. Four independent fixes from the audit.

- **M-1 (5-01)**: Add unique partial index `users_singleton_uidx` on `users ((true))`. The JS pre-check stays as a fast path; the DB index is the authoritative gate. Two concurrent /sign-up/email requests now produce one 200 + one 500 (SQLSTATE 23505) — second cannot create a user.
- **M-2 (5-02)**: `/wikis/:id/unpublish` now nulls `publishedSlug`; `publishedAt` is preserved. The publish handler's existing `wiki.publishedSlug ?? nanoid24()` mints a fresh slug on republish, so the old public URL stays a 404.
- **M-5 (5-03)**: `/wikis/:id/regenerate` is now wrapped in `wikiRegenLock` (CasLock keyed on lookup_key, 90s TTL). Concurrent calls produce one 200 + one 409 Conflict. successState/failureState both return the wiki to PENDING. CasLock's TTL stale-lock recovery handles crashed regens.
- **M-9 (5-04)**: Rename `LOOKUP_KEY_RE` → `LK_REGEX` (substring form). Add `LK_REGEX_STRICT` (anchored). Add `safeRefToHref(ref)` in `@robin/shared` — validates against the anchored regex and returns the canonical wiki path or null. Wire `GraphDetailPanel` Open button through `safeRefToHref` so a forged `node.lookupKey` cannot drive `router.push` to an absolute URL.

## Verification

- `pnpm --filter @robin/core run typecheck` — passes
- `pnpm --filter @robin/shared run typecheck` — passes
- `cd wiki && npx tsc --noEmit` — passes
- New tests: `wikis.publish.test.ts` (4), `wikis.regen.lock.test.ts` (5), `identity.regex.test.ts` (22) — all pass (31 new tests).

## Test plan

- [x] Unit tests added for slug-rotation round-trip, regen-lock 409, and `safeRefToHref` rejecting absolute URLs / path-embedded keys.
- [ ] Manual: two concurrent `curl -X POST /sign-up/email` against an empty DB — expect one 200 + one 500, exactly one user row.
- [ ] Manual: publish a wiki, copy URL, unpublish, republish, hit original URL — expect 404.
- [ ] Manual: two concurrent `curl -X POST /wikis/:id/regenerate` — expect one 200 + one 409.
- [ ] Manual: in React devtools, edit a graph node's `lookupKey` to `https://evil.com`, click Open — expect no navigation, console warning.

## Locked decisions honored

- 5-01: DB uidx + JS pre-check, race-loser surfaces as 500. No better-auth adapter intercept.
- 5-02: `publishedSlug=NULL` on unpublish; `publishedAt` preserved.
- 5-03: `successState='PENDING'`, `failureState='PENDING'`. Inner optimistic UPDATE in `lib/regen.ts` preserved as defense-in-depth.
- 5-04: Repo-wide rename (only one consumer found: the JSDoc example in `identity.ts` itself). `safeRefToHref` lives in `@robin/shared`. No `ANCHORED` constant in `wiki/src/lib/routes.ts` (none existed).