### PR TITLE
feat(v1ag): account security wave 2 — forgot-password + force-reset (B1+B2)

### DIFF
--- a/core/src/__tests__/phase2-uat.integration.test.ts
+++ b/core/src/__tests__/phase2-uat.integration.test.ts
@@ -55,12 +55,22 @@ const dbExecuteImpl = vi.fn(async (q: unknown) => {
     else params.push(chunk)
   }
   dbExecuteCalls.push({ literal, params })
-  // SELECT returns a row; UPDATE doesn't read the result.
-  return [{ id: 'acct-test-1' }] as never
+  // SELECT returns the credential account row (id + user_id) so the recover
+  // route can re-set password_reset_required on the same user. UPDATEs ignore
+  // the return value.
+  return [{ id: 'acct-test-1', user_id: 'user-test-1' }] as never
 })
 
+// auth-recover wraps the password update + flag re-set in a transaction.
+// Proxy `tx.execute` straight to the same recorder so UAT assertions can
+// inspect every SQL fragment regardless of which call site issued it.
+const dbTransactionImpl = vi.fn(
+  async (cb: (tx: { execute: typeof dbExecuteImpl }) => Promise<unknown>) =>
+    cb({ execute: dbExecuteImpl }),
+)
+
 vi.mock('../db/client.js', () => ({
-  db: { execute: dbExecuteImpl },
+  db: { execute: dbExecuteImpl, transaction: dbTransactionImpl },
 }))
 
 // emitAuditEvent fires from inside the route. We capture every call so UAT 5
@@ -149,6 +159,7 @@ beforeEach(() => {
   auditCalls.length = 0
   emitAuditEventImpl.mockClear()
   dbExecuteImpl.mockClear()
+  dbTransactionImpl.mockClear()
 })
 
 afterEach(() => {
@@ -215,19 +226,35 @@ describe('UAT 2: POST /auth/recover { secretKey, newPassword }', () => {
     const body = (await res.json()) as { ok?: boolean }
     expect(body.ok).toBe(true)
 
-    // Two execute() calls: SELECT then UPDATE.
-    expect(dbExecuteImpl).toHaveBeenCalledTimes(2)
+    // Three execute() calls: SELECT, UPDATE accounts, UPDATE users
+    // (password_reset_required = true). The two UPDATEs run inside a
+    // single db.transaction() — see auth-recover.ts.
+    expect(dbExecuteImpl).toHaveBeenCalledTimes(3)
+    expect(dbTransactionImpl).toHaveBeenCalledTimes(1)
     const selectCall = dbExecuteCalls[0]
-    const updateCall = dbExecuteCalls[1]
-    expect(selectCall?.literal).toMatch(/SELECT id FROM accounts/i)
-    expect(updateCall?.literal).toMatch(/UPDATE accounts SET password/i)
+    const updateAccountsCall = dbExecuteCalls[1]
+    const updateUsersCall = dbExecuteCalls[2]
+    expect(selectCall?.literal).toMatch(/SELECT id, user_id FROM accounts/i)
+    expect(updateAccountsCall?.literal).toMatch(/UPDATE accounts SET password/i)
+    expect(updateUsersCall?.literal).toMatch(
+      /UPDATE users SET password_reset_required = true/i,
+    )
 
     // The UPDATE binds the hashed password as a parameter, never the cleartext.
-    const updateParams = updateCall!.params.filter((v): v is string => typeof v === 'string')
+    const updateParams = updateAccountsCall!.params.filter(
+      (v): v is string => typeof v === 'string',
+    )
     expect(updateParams.some((v) => v.length > 0)).toBe(true)
     expect(updateParams.some((v) => v === newPassword)).toBe(false)
     // Account id from the SELECT round-trip is bound in the UPDATE WHERE clause.
     expect(updateParams).toContain('acct-test-1')
+
+    // The user_id from the SELECT is bound in the users-table UPDATE so the
+    // flag re-set targets the same identity that just rotated its password.
+    const userUpdateParams = updateUsersCall!.params.filter(
+      (v): v is string => typeof v === 'string',
+    )
+    expect(userUpdateParams).toContain('user-test-1')
 
     // recover.success audit event fired.
     const successAudit = auditCalls.find(

--- a/core/src/auth.ts
+++ b/core/src/auth.ts
@@ -3,7 +3,7 @@ import { APIError } from 'better-auth/api'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { db } from './db/client.js'
 import * as schema from './db/schema.js'
-import { sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { producer } from './queue/producer.js'
 import { logger } from './lib/logger.js'
 import { ensureFirstUser } from './bootstrap/jit-provision.js'
@@ -28,6 +28,24 @@ export const auth = betterAuth({
   }),
 
   emailAndPassword: { enabled: true },
+
+  // Force-reset flag (#71). The boolean lives on users.password_reset_required
+  // and is JIT-set to true the first time a user is provisioned. Exposing it
+  // here as `mustResetPassword` makes it flow through every getSession call
+  // (including the one useSession() polls), so the wiki AuthGuard can gate
+  // protected routes on a single read. Cleared by POST /users/clear-reset-flag
+  // and re-set by /auth/recover.
+  user: {
+    additionalFields: {
+      mustResetPassword: {
+        type: 'boolean',
+        fieldName: 'password_reset_required',
+        required: false,
+        defaultValue: false,
+        input: false,
+      },
+    },
+  },
 
   // Single-user mode: no social providers. Use INITIAL_USERNAME/INITIAL_PASSWORD
   // env vars + the boot seed script to create the one-and-only user.
@@ -83,6 +101,31 @@ export const auth = betterAuth({
 
     after: async (rawCtx) => {
       const ctx = rawCtx as Record<string, unknown>
+
+      // Force-reset gate (#71). On every successful /sign-in/email, read the
+      // flag and log its value. The user model's additionalFields config
+      // (mustResetPassword → password_reset_required) is what actually exposes
+      // it on session.user; this hook exists for observability and to keep
+      // the integration point explicit.
+      if (ctx.path === '/sign-in/email') {
+        const c = ctx.context as Record<string, unknown> | undefined
+        const newSession = c?.newSession as Record<string, unknown> | undefined
+        const sess = c?.session as Record<string, unknown> | undefined
+        const user = ((newSession?.user as Record<string, unknown>) ??
+          (sess?.user as Record<string, unknown>) ??
+          undefined) as Record<string, unknown> | undefined
+        const userId = user?.id as string | undefined
+        if (userId) {
+          const [row] = await db
+            .select({ flag: schema.users.passwordResetRequired })
+            .from(schema.users)
+            .where(eq(schema.users.id, userId))
+          const mustResetPassword = row?.flag === true
+          log.debug({ userId, mustResetPassword }, 'sign-in/email after hook')
+        }
+        return { response: null, headers: null }
+      }
+
       if (ctx.path !== '/sign-up/email') return { response: null, headers: null }
 
       const c = ctx.context as Record<string, unknown> | undefined

--- a/core/src/auth.ts
+++ b/core/src/auth.ts
@@ -39,7 +39,12 @@ export const auth = betterAuth({
     additionalFields: {
       mustResetPassword: {
         type: 'boolean',
-        fieldName: 'password_reset_required',
+        // The drizzle schema's JS property is `passwordResetRequired` and the
+        // adapter looks up schema[model][fieldName] to find the column. Setting
+        // fieldName to the drizzle key (not the snake_case DB column) is what
+        // the better-auth drizzle adapter expects — see node_modules/@better-
+        // auth/drizzle-adapter/dist/index.mjs `getFieldName`.
+        fieldName: 'passwordResetRequired',
         required: false,
         defaultValue: false,
         input: false,

--- a/core/src/routes/auth-recover.ts
+++ b/core/src/routes/auth-recover.ts
@@ -126,8 +126,8 @@ authRecoverRoutes.post('/recover', async (c) => {
 
   const hashed = await hashPassword(body.newPassword)
 
-  const rows = await db.execute<{ id: string }>(
-    sql`SELECT id FROM accounts WHERE provider_id = 'credential' LIMIT 1`
+  const rows = await db.execute<{ id: string; user_id: string }>(
+    sql`SELECT id, user_id FROM accounts WHERE provider_id = 'credential' LIMIT 1`
   )
   const account = rows[0]
   if (!account) {
@@ -143,9 +143,18 @@ authRecoverRoutes.post('/recover', async (c) => {
     return c.json({ error: 'No account found' }, 404)
   }
 
-  await db.execute(
-    sql`UPDATE accounts SET password = ${hashed} WHERE id = ${account.id}`
-  )
+  // Re-set password_reset_required = true (#71). The user just used the
+  // server-secret recovery channel, which means a deployment-side process
+  // chose this password — the human must pick their own on next sign-in.
+  // Same transaction as the password update so the two states stay aligned.
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`UPDATE accounts SET password = ${hashed} WHERE id = ${account.id}`
+    )
+    await tx.execute(
+      sql`UPDATE users SET password_reset_required = true WHERE id = ${account.user_id}`
+    )
+  })
 
   log.info({ accountId: account.id, ip }, 'password recovery succeeded')
   await emitAuditEvent(db, {

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -120,6 +120,19 @@ usersRouter.patch('/onboard', async (c) => {
   return c.json(okResponseSchema.parse({ ok: true }))
 })
 
+// POST /users/clear-reset-flag — clear the JIT-set initial-password flag
+// after the user has chosen their own password. Auth-gated, no body.
+// Companion to the after-hook in auth.ts and the /account/initial-password-reset
+// page in the wiki. Returns 204 on success.
+usersRouter.post('/clear-reset-flag', async (c) => {
+  const userId = c.get('userId') as string
+  await db
+    .update(users)
+    .set({ passwordResetRequired: false })
+    .where(eq(users.id, userId))
+  return c.body(null, 204)
+})
+
 // GET /users/keypair — metadata only (no privateKey). The decrypted key is
 // only ever returned via POST /users/keypair/reveal after a password proof.
 usersRouter.get('/keypair', async (c) => {

--- a/wiki/src/app/(public)/login/page.tsx
+++ b/wiki/src/app/(public)/login/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { authClient } from '@/lib/auth-client'
 import { useSession } from '@/hooks/useSession'
@@ -183,6 +184,15 @@ export default function LoginPage() {
             {loading ? 'Signing in...' : 'Sign in'}
           </button>
         </form>
+
+        <p style={{ ...T.bodySmall, textAlign: 'center', marginTop: 16 }}>
+          <Link
+            href="/recover"
+            style={{ color: 'var(--wiki-link)', textDecoration: 'none' }}
+          >
+            Forgot password?
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/wiki/src/app/account/initial-password-reset/page.tsx
+++ b/wiki/src/app/account/initial-password-reset/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { type CSSProperties } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth-client";
+import { AuthGuard } from "@/components/AuthGuard";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { T, FONT } from "@/lib/typography";
+
+const sectionLabel: CSSProperties = {
+  ...T.micro,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "var(--wiki-count)",
+  margin: 0,
+};
+
+const bodySmallText: CSSProperties = {
+  ...T.micro,
+  color: "var(--heading-secondary)",
+  margin: 0,
+};
+
+const titleText: CSSProperties = {
+  ...T.body,
+  fontWeight: 500,
+  color: "var(--heading-color)",
+  margin: 0,
+};
+
+// Mirrors the change-password section on /profile (page.tsx:599-691) so the
+// flow looks like the rest of the app even though it sits at its own route.
+//
+// Why a current-password field exists here even though the user "just signed
+// in": better-auth's /change-password requires currentPassword, and we don't
+// store the seeded password client-side. Asking again is a one-keystroke ask
+// and keeps the flow on the standard auth API.
+export default function InitialPasswordResetPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [confirmPw, setConfirmPw] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (newPw !== confirmPw) return;
+    if (newPw.length < 12) {
+      setError("Password must be at least 12 characters.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const { error: changeError } = await authClient.changePassword({
+        currentPassword: currentPw,
+        newPassword: newPw,
+      });
+      if (changeError) {
+        setError(changeError.message ?? "Could not change password.");
+        return;
+      }
+
+      const res = await fetch("/api/users/clear-reset-flag", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        setError("Password changed but the reset flag could not be cleared. Refresh and try again.");
+        return;
+      }
+
+      // Drop the cached profile + session so the AuthGuard re-reads the
+      // cleared flag instead of bouncing this page again.
+      await queryClient.invalidateQueries({ queryKey: ["profile"] });
+      await authClient.getSession({ query: { disableCookieCache: true } });
+      router.replace("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not change password.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submitDisabled =
+    submitting || !currentPw || !newPw || !confirmPw || newPw !== confirmPw;
+
+  return (
+    <AuthGuard>
+      <div
+        className="min-h-screen overflow-y-auto"
+        style={{ background: "var(--background)", color: "var(--foreground)" }}
+      >
+        <div className="mx-auto max-w-[560px] px-10 pt-16 pb-20">
+          <h1 style={{ ...T.h1, fontFamily: FONT.SERIF, color: "var(--heading-color)", margin: 0 }}>
+            Set your password
+          </h1>
+          <p style={{ ...T.bodySmall, color: "var(--heading-secondary)", marginTop: 4 }}>
+            Robin provisioned your account with a one-time password. Choose your own
+            before continuing.
+          </p>
+
+          <section className="mt-8" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <p style={sectionLabel}>Security</p>
+            <Card size="sm" className="rounded-none">
+              <CardContent className="space-y-4">
+                <div>
+                  <p style={titleText}>Change password</p>
+                  <p style={{ ...bodySmallText, marginTop: 2 }}>
+                    Pick something you&apos;ll remember — 12+ characters with letters and digits.
+                  </p>
+                </div>
+                <form className="space-y-3" onSubmit={handleSubmit}>
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="current-password"
+                      style={{ ...T.micro, color: "var(--heading-secondary)" }}
+                    >
+                      Current password
+                    </Label>
+                    <Input
+                      id="current-password"
+                      type="password"
+                      autoComplete="current-password"
+                      value={currentPw}
+                      onChange={(e) => setCurrentPw(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="new-password"
+                      style={{ ...T.micro, color: "var(--heading-secondary)" }}
+                    >
+                      New password
+                    </Label>
+                    <Input
+                      id="new-password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={newPw}
+                      onChange={(e) => setNewPw(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="confirm-password"
+                      style={{ ...T.micro, color: "var(--heading-secondary)" }}
+                    >
+                      Confirm new password
+                    </Label>
+                    <Input
+                      id="confirm-password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={confirmPw}
+                      onChange={(e) => setConfirmPw(e.target.value)}
+                    />
+                  </div>
+                  {newPw.length > 0 && confirmPw.length > 0 && newPw !== confirmPw && (
+                    <p style={{ ...T.micro, color: "var(--destructive)", margin: 0 }}>
+                      Passwords do not match.
+                    </p>
+                  )}
+                  {error && (
+                    <p style={{ ...T.micro, color: "var(--destructive)", margin: 0 }}>
+                      {error}
+                    </p>
+                  )}
+                  <Button type="submit" size="sm" disabled={submitDisabled}>
+                    <span style={T.buttonSmall}>
+                      {submitting ? "Saving..." : "Save and continue"}
+                    </span>
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          </section>
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/wiki/src/components/AuthGuard.tsx
+++ b/wiki/src/components/AuthGuard.tsx
@@ -5,15 +5,24 @@ import { useEffect } from 'react'
 import { useSession } from '@/hooks/useSession'
 import { useProfile } from '@/hooks/useProfile'
 
+const RESET_PATH = '/account/initial-password-reset'
+
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const pathname = usePathname()
-  const { isAuthenticated, isLoading } = useSession()
+  const { session, isAuthenticated, isLoading } = useSession()
   const { data: profile, isLoading: profileLoading } = useProfile({
     enabled: isAuthenticated,
   })
 
   const isPublicPath = pathname === '/login' || pathname === '/recover'
+  const isResetPath = pathname === RESET_PATH
+  // mustResetPassword flows through better-auth's user.additionalFields
+  // (mapped to users.password_reset_required). The field is not in the
+  // generated Session type yet, so widen the user object to read it.
+  const mustResetPassword =
+    (session?.user as { mustResetPassword?: boolean } | undefined)
+      ?.mustResetPassword === true
 
   // Redirect unauthenticated users to login
   useEffect(() => {
@@ -22,17 +31,53 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     }
   }, [isLoading, isAuthenticated, isPublicPath, router])
 
+  // Force-reset gate (#71). Runs above the onboarding redirect so a freshly
+  // provisioned user lands on the password-reset page before anything else.
+  // No deep-link bypass: every protected path falls through to RESET_PATH
+  // until /users/clear-reset-flag flips the flag.
+  useEffect(() => {
+    if (
+      isAuthenticated &&
+      mustResetPassword &&
+      !isPublicPath &&
+      !isResetPath
+    ) {
+      router.replace(RESET_PATH)
+    }
+  }, [isAuthenticated, mustResetPassword, isPublicPath, isResetPath, router])
+
   // Redirect authenticated but un-onboarded users to onboarding wizard
   useEffect(() => {
-    if (isAuthenticated && !profileLoading && !profile?.onboardedAt && !isPublicPath) {
+    if (
+      isAuthenticated &&
+      !mustResetPassword &&
+      !profileLoading &&
+      !profile?.onboardedAt &&
+      !isPublicPath
+    ) {
       router.replace('/')
     }
-  }, [isAuthenticated, profileLoading, profile, isPublicPath, router])
+  }, [
+    isAuthenticated,
+    mustResetPassword,
+    profileLoading,
+    profile,
+    isPublicPath,
+    router,
+  ])
 
   if (isLoading) return null
   if (!isAuthenticated && !isPublicPath) return null
+  if (isAuthenticated && mustResetPassword && !isResetPath && !isPublicPath)
+    return null
   if (isAuthenticated && profileLoading) return null
-  if (isAuthenticated && !profile?.onboardedAt && !isPublicPath) return null
+  if (
+    isAuthenticated &&
+    !mustResetPassword &&
+    !profile?.onboardedAt &&
+    !isPublicPath
+  )
+    return null
 
   return <>{children}</>
 }


### PR DESCRIPTION
## Summary

Stream B account-security phases 1 and 2 from the v1 A-game workstream. Closes the self-serve recovery and credentials-leak-via-deploy-template gaps end-to-end.

Plan: `.planning/v1-a-game/streams/B-account-security/PLAN.md` (phases 1 + 2). Tracker: #282.

Closes #71.

## What ships

**B1 — Forgot-password link on `/login`**
- One `<Link href="/recover">Forgot password?</Link>` below the password field. Mirrors `/recover`'s "Back to sign in" typography.

**B2 — Finish force-reset on first login**
- `additionalFields.passwordResetRequired` on better-auth's user model — surfaces `mustResetPassword` on every `getSession`.
- `after`-hook on `/sign-in/email` (observability log; the `additionalFields` wiring is what carries the value).
- `wiki/src/components/AuthGuard.tsx` — render gate: `mustResetPassword === true` redirects to `/account/initial-password-reset` and refuses to render protected children. Gated above onboarding/public-path checks; no deep-link bypass.
- `wiki/src/app/account/initial-password-reset/page.tsx` (new) — Current / New / Confirm fields. Submits via `authClient.changePassword`, clears flag via `POST /api/users/clear-reset-flag`, redirects to `/`.
- `POST /users/clear-reset-flag` — auth-gated, sets `password_reset_required = false` on the calling user, returns 204.
- `/auth/recover` — re-sets `password_reset_required = true` in the same transaction as the password update. Recovery via `RECOVERY_SECRET` is now treated as a credential rotation that demands a follow-up user-chosen password.

No new migration — `users.password_reset_required` column was already plumbed (schema.ts + jit-provision.ts).

## Deviation from PLAN.md

PLAN said: "no current-password field — they just signed in with the seeded one; that's evidence enough."
Shipped: a current-password field on the reset page.

Reason: better-auth's `/change-password` requires `currentPassword` and we don't store the seeded password client-side. The plan's literal `authClient.changePassword({ currentPassword: <seeded>, newPassword })` isn't possible without either (a) a server bypass route or (b) re-prompting. Approved approach (b) — better-auth already enforces password policy and length, re-typing 30 seconds after sign-in is a one-keystroke ask, and we avoid adding a new privileged server surface.

Documented inline at `wiki/src/app/account/initial-password-reset/page.tsx:37-43`.

## Minor deviations (justified)

- `additionalFields.fieldName` had to point at the drizzle JS key (`passwordResetRequired`), not the snake-case DB column. Fixed mid-stream after live test surfaced the better-auth drizzle adapter behaviour.
- The `after`-hook is observability-only; `additionalFields` is the actual session-payload mechanism.

## Test plan

- [ ] CI pre-merge.yml green (depends on #314 first run)
- [ ] Fresh deploy first-sign-in → AuthGuard redirects to `/account/initial-password-reset`
- [ ] Submit new password → flag clears → redirected to `/` → subsequent navigation no redirect
- [ ] Sign out + sign back in with new password → no prompt
- [ ] Hit `/auth/recover` with valid `RECOVERY_SECRET` → flag re-set → next sign-in redirects again
- [ ] Existing user with flag=false lands on `/` directly
- [ ] Deep-link to a protected route with `mustResetPassword=true` → AuthGuard blocks + redirects (verified in code; live browser walkthrough during merge UAT)
- [ ] Click "Forgot password?" on `/login` → lands on `/recover`; "Back to sign in" returns to `/login`

## Notes for reviewer

- Wave 2 was rebased onto current `origin/main` after #313 (sec/phase-6-cleanup) merged — clean rebase, no conflicts. Some commit SHAs differ from earlier internal refs.
- `additionalFields` is the canonical mechanism for surfacing custom user fields through every `getSession` call. The `after`-hook is kept for log observability, not session writes.