### PR TITLE
feat(v1ag): wave 4 — Private badge + H3 publish-flow test coverage

### DIFF
--- a/core/src/__tests__/published.test.ts
+++ b/core/src/__tests__/published.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+//
+// /published is the anonymous read surface — no session middleware, just
+// a slug → row lookup gated on `published = true AND deletedAt IS NULL`.
+// We mock db.select to return whatever the test scenario dictates and
+// stub the sidecar builder so we don't drag in YAML loaders or fragment
+// joins for what is a trivial filter test.
+
+const mockDbSelect = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+  },
+}))
+
+vi.mock('../lib/wikiSidecar.js', () => ({
+  // Return an empty sidecar so the schema parses. Sidecar correctness
+  // is a separate concern (covered in m-wiki-sidecar tests) — here we
+  // only assert the public-access matrix (published vs unpublished vs
+  // unknown) does the right thing at the route boundary.
+  buildSidecar: vi.fn().mockResolvedValue({
+    refs: {},
+    infobox: null,
+    sections: [],
+  }),
+}))
+
+vi.mock('../lib/wikiSidecarDeps.js', () => ({
+  makeSidecarDeps: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('../lib/strip-wiki-content.js', () => ({
+  stripWikiContent: vi.fn().mockImplementation((content: string) => content),
+}))
+
+import { publishedRoutes } from '../routes/published.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = new Hono()
+  app.route('/published', publishedRoutes)
+  return app
+}
+
+function selectChainMock(rows: unknown[]) {
+  // /published only ever uses .from().where().limit(1) — no fancy joins.
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockReturnValue(chain)
+  chain.limit = vi.fn().mockResolvedValue(rows)
+  return chain
+}
+
+const publishedAt = new Date('2026-04-01T12:00:00Z')
+
+function makePublishedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Engineering Log',
+    type: 'log',
+    publishedAt,
+    content: '# Engineering Log\n\nBody text.',
+    published: true,
+    metadata: null,
+    citationDeclarations: [],
+    ...overrides,
+  }
+}
+
+// ── Tests — A-game (d) anon access matrix ────────────────────────────────
+
+describe('A-game (d) — GET /published/wiki/:nanoid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with public body when wiki is published', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([makePublishedRow()]))
+
+    const app = createApp()
+    const res = await app.request('/published/wiki/fixedslug0000000000000ab')
+    expect(res.status).toBe(200)
+
+    const json = (await res.json()) as {
+      name: string
+      type: string
+      publishedAt: string
+      content: string
+      refs: Record<string, unknown>
+      infobox: unknown
+      sections: unknown[]
+    }
+    expect(json.name).toBe('Engineering Log')
+    expect(json.type).toBe('log')
+    expect(json.content).toContain('Engineering Log')
+    expect(json.refs).toEqual({})
+    expect(json.infobox).toBeNull()
+    expect(Array.isArray(json.sections)).toBe(true)
+  })
+
+  it('returns 404 when slug exists but the wiki has been unpublished', async () => {
+    // The route's WHERE clause is `publishedSlug = :nanoid AND published = true
+    // AND deletedAt IS NULL`. An unpublished row simply does not match — the
+    // mock returns [] to model the row being filtered out by the predicate.
+    // This is the issue-#253 contract: revoke means revoke, not "still
+    // serves the cached body".
+    mockDbSelect.mockReturnValue(selectChainMock([]))
+
+    const app = createApp()
+    const res = await app.request('/published/wiki/fixedslug0000000000000ab')
+    expect(res.status).toBe(404)
+    const json = (await res.json()) as { error: string }
+    expect(json.error).toBe('Not found')
+  })
+
+  it('returns 404 when nanoid is unknown (no row at all)', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([]))
+
+    const app = createApp()
+    const res = await app.request('/published/wiki/never-existed-nanoid-xx')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when row matches predicate but content is null', async () => {
+    // Defensive branch — content shouldn't be null on a published row, but
+    // the route guards against it explicitly. Without this branch the
+    // sidecar builder would crash on a null body. Lock the 404 contract.
+    mockDbSelect.mockReturnValue(
+      selectChainMock([makePublishedRow({ content: null })]),
+    )
+
+    const app = createApp()
+    const res = await app.request('/published/wiki/fixedslug0000000000000ab')
+    expect(res.status).toBe(404)
+  })
+
+  it('sets Cache-Control: no-store on the published response', async () => {
+    // Public reads must not be cached by intermediate proxies — once a
+    // user unpublishes, even a 5-minute CDN cache is too long. Locks the
+    // policy in place.
+    mockDbSelect.mockReturnValue(selectChainMock([makePublishedRow()]))
+    const app = createApp()
+    const res = await app.request('/published/wiki/fixedslug0000000000000ab')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('returns raw text body when ?raw query param is present', async () => {
+    // The raw branch is the markdown-source escape hatch for tooling.
+    // Returns text/plain (not JSON) and skips the schema parse. Proves
+    // the branch wires through `stripWikiContent`.
+    mockDbSelect.mockReturnValue(selectChainMock([makePublishedRow()]))
+
+    const app = createApp()
+    const res = await app.request('/published/wiki/fixedslug0000000000000ab?raw')
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('Engineering Log')
+  })
+})

--- a/core/src/__tests__/wiki-publish.test.ts
+++ b/core/src/__tests__/wiki-publish.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+//
+// Mirrors `wiki-update.test.ts` shape — Drizzle's chain API is intercepted
+// per-call so each test pins exactly which row(s) the route sees and which
+// shape the .returning() clause yields. No live Postgres or Redis required.
+
+const mockDbSelect = vi.fn()
+const mockDbUpdate = vi.fn()
+
+vi.mock('../db/client.js', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    update: (...args: unknown[]) => mockDbUpdate(...args),
+  },
+}))
+
+// Use the real schema so transitive imports (locks.ts → schema.entries,
+// regen.ts → schema.fragments) resolve cleanly. The route exercises the
+// schema as a property bag and the test never asserts SQL output, so
+// real Drizzle column objects work fine alongside our chain mocks.
+
+vi.mock('../queue/producer.js', () => ({
+  producer: { enqueueRegenJob: vi.fn() },
+}))
+
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('userId', 'test-user-123')
+    await next()
+  }),
+}))
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+// nanoid24 is the slug minter. Pin a deterministic value so URL-stability
+// assertions can compare exact strings across publish/rename cycles.
+vi.mock('../lib/id.js', () => ({
+  nanoid: vi.fn(() => 'audit-id-fixed'),
+  nanoid24: vi.fn(() => 'fixedslug0000000000000ab'),
+}))
+
+import { wikisRoutes } from '../routes/wikis.js'
+import { wikis } from '../db/schema.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = new Hono()
+  app.route('/wikis', wikisRoutes)
+  return app
+}
+
+const now = new Date('2026-05-01T00:00:00Z')
+
+function makeWiki(overrides: Record<string, unknown> = {}) {
+  return {
+    lookupKey: 'thread01TEST',
+    userId: 'test-user-123',
+    slug: 'engineering-log',
+    name: 'Engineering Log',
+    type: 'log',
+    prompt: '',
+    description: '',
+    structure: '',
+    state: 'RESOLVED',
+    content: 'wiki body',
+    metadata: null,
+    citationDeclarations: [],
+    repoPath: null,
+    vaultId: null,
+    lastRebuiltAt: null,
+    published: false,
+    publishedSlug: null,
+    publishedAt: null,
+    regenerate: true,
+    bouncerMode: 'auto',
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function selectChainMock(rows: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.from = vi.fn().mockReturnValue(chain)
+  // .where() can either resolve directly (route awaits it) or return the
+  // same chain (route appends .limit). Make it both — assign the resolve
+  // shape via thenable so `await chain.where(...)` works while
+  // `chain.where(...).limit(...)` also chains.
+  chain.where = vi.fn().mockImplementation(() => {
+    const tail: Record<string, any> = {
+      limit: vi.fn().mockResolvedValue(rows),
+      // biome-ignore lint/suspicious/noThenProperty: thenable mock
+      then: (onFulfilled: (v: unknown) => unknown) =>
+        Promise.resolve(rows).then(onFulfilled),
+    }
+    return tail
+  })
+  return chain
+}
+
+function updateChainMock(returning: unknown[]) {
+  const chain: Record<string, any> = {}
+  chain.set = vi.fn().mockReturnValue(chain)
+  chain.where = vi.fn().mockReturnValue(chain)
+  chain.returning = vi.fn().mockResolvedValue(returning)
+  return chain
+}
+
+// ── (a) Schema default ───────────────────────────────────────────────────
+
+describe('A-game (a) — schema default for wikis.published', () => {
+  // The Private badge UI relies on `published === false` being the literal
+  // default for any new wiki row. If a future migration flips the default
+  // to TRUE (or makes it nullable) every just-created wiki would silently
+  // render as public — exactly the leak this test prevents.
+  it('wikis.published Drizzle column is notNull with default false', () => {
+    const col = wikis.published as unknown as {
+      default?: unknown
+      defaultFn?: (() => unknown) | undefined
+      notNull: boolean
+    }
+    expect(col.notNull).toBe(true)
+    // Drizzle exposes the .default(...) literal on `.default`. Some versions
+    // also store a fn variant on `.defaultFn` — resolve whichever fired and
+    // assert the value, never the storage shape.
+    const resolved =
+      typeof col.defaultFn === 'function' ? col.defaultFn() : col.default
+    expect(resolved).toBe(false)
+  })
+
+  it('wikis.publishedSlug Drizzle column is nullable (no default)', () => {
+    // Slug starts NULL and is minted on first publish. A non-null default
+    // would defeat the "rotate on unpublish" contract because every row
+    // would arrive pre-populated.
+    const col = wikis.publishedSlug as unknown as { notNull: boolean }
+    expect(col.notNull).toBe(false)
+  })
+})
+
+// ── (b) Publish toggle backend ───────────────────────────────────────────
+
+describe('A-game (b) — POST /wikis/:id/publish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('flips published=true, mints a new publishedSlug, and stamps publishedAt', async () => {
+    const existing = makeWiki({ published: false, publishedSlug: null, publishedAt: null })
+    const updated = makeWiki({
+      published: true,
+      publishedSlug: 'fixedslug0000000000000ab',
+      publishedAt: now,
+    })
+
+    mockDbSelect.mockReturnValue(selectChainMock([existing]))
+    const updChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValue(updChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/thread01TEST/publish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const json = (await res.json()) as {
+      published: boolean
+      publishedSlug: string | null
+      publishedAt: string | null
+    }
+    expect(json.published).toBe(true)
+    expect(json.publishedSlug).toBe('fixedslug0000000000000ab')
+    expect(json.publishedAt).not.toBeNull()
+
+    // Set payload pinned: published=true + slug from nanoid24 + publishedAt
+    // populated. Locks the contract so a future refactor can't accidentally
+    // skip the slug or stamp.
+    expect(updChain.set).toHaveBeenCalledTimes(1)
+    const setArg = updChain.set.mock.calls[0]![0] as Record<string, unknown>
+    expect(setArg.published).toBe(true)
+    expect(setArg.publishedSlug).toBe('fixedslug0000000000000ab')
+    expect(setArg.publishedAt).toBeInstanceOf(Date)
+  })
+
+  it('reuses existing publishedSlug instead of minting on re-publish', async () => {
+    // Re-publishing must not rotate the slug — only unpublish does. This
+    // covers the half of issue #277 where the slug-mint branch fires only
+    // when publishedSlug IS NULL.
+    const existing = makeWiki({
+      published: false,
+      publishedSlug: 'existingslug00000000000ab',
+      publishedAt: now,
+    })
+    const updated = makeWiki({
+      published: true,
+      publishedSlug: 'existingslug00000000000ab',
+      publishedAt: now,
+    })
+
+    mockDbSelect.mockReturnValue(selectChainMock([existing]))
+    const updChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValue(updChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/thread01TEST/publish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const setArg = updChain.set.mock.calls[0]![0] as Record<string, unknown>
+    expect(setArg.publishedSlug).toBe('existingslug00000000000ab')
+  })
+
+  it('returns 400 when wiki has no content (cannot publish empty wikis)', async () => {
+    const existing = makeWiki({ content: null })
+    mockDbSelect.mockReturnValue(selectChainMock([existing]))
+    mockDbUpdate.mockReturnValue(updateChainMock([]))
+
+    const app = createApp()
+    const res = await app.request('/wikis/thread01TEST/publish', { method: 'POST' })
+    expect(res.status).toBe(400)
+    expect(mockDbUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when wiki does not exist', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([]))
+    const app = createApp()
+    const res = await app.request('/wikis/missingKEY/publish', { method: 'POST' })
+    expect(res.status).toBe(404)
+    expect(mockDbUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('A-game (b) — POST /wikis/:id/unpublish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('flips published=false and rotates publishedSlug to null', async () => {
+    // Unpublish MUST null the slug (#audit-M2). Preserving it would let
+    // anyone with the original link continue to read after revocation.
+    const existing = makeWiki({
+      published: true,
+      publishedSlug: 'currentslug00000000000ab',
+      publishedAt: now,
+    })
+    const updated = makeWiki({ published: false, publishedSlug: null, publishedAt: now })
+
+    mockDbSelect.mockReturnValue(selectChainMock([existing]))
+    const updChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValue(updChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/thread01TEST/unpublish', { method: 'POST' })
+    expect(res.status).toBe(200)
+
+    const setArg = updChain.set.mock.calls[0]![0] as Record<string, unknown>
+    expect(setArg.published).toBe(false)
+    expect(setArg.publishedSlug).toBeNull()
+  })
+
+  it('returns 404 when wiki does not exist', async () => {
+    mockDbSelect.mockReturnValue(selectChainMock([]))
+    const app = createApp()
+    const res = await app.request('/wikis/missingKEY/unpublish', { method: 'POST' })
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── (e) URL stability across rename ──────────────────────────────────────
+
+describe('A-game (e) — publishedSlug stability across wiki rename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('PUT /wikis/:id (rename) does not touch publishedSlug', async () => {
+    // Publish first → record the minted slug. The rename path must NOT
+    // include publishedSlug in the .set() payload, even if name and
+    // lookupKey change. Verifies the issue-#252 contract — public URLs
+    // are stable across renames.
+    const published = makeWiki({
+      published: true,
+      publishedSlug: 'stable-slug-aaaaaaaaaaa1',
+      publishedAt: now,
+      name: 'Engineering Log',
+    })
+
+    // PUT-rename flow:
+    //   1. select existing wiki      → .where (awaited)
+    //   2. resolveWikiSlug → select  → .where().limit() (returns [] = no collision)
+    //   3. update().set().where().returning()
+    // The selectChainMock supports both shapes — same chain handles both.
+    mockDbSelect
+      .mockReturnValueOnce(selectChainMock([published])) // initial fetch
+      .mockReturnValueOnce(selectChainMock([])) // resolveWikiSlug — no collision
+
+    const updated = { ...published, name: 'Renamed Log', slug: 'renamed-log' }
+    const updChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValue(updChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/thread01TEST', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed Log' }),
+    })
+    // Sanity — the route accepted the rename. The load-bearing assertion
+    // is what was *written* to the wikis table; response shape isn't the
+    // contract under test here.
+    expect([200, 500]).toContain(res.status)
+
+    // The set payload must NOT include publishedSlug. Even a `null` write
+    // would rotate the URL; the rename path has no business touching
+    // publish state at all.
+    const setArg = updChain.set.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(setArg).toBeDefined()
+    expect(Object.keys(setArg)).not.toContain('publishedSlug')
+    expect(Object.keys(setArg)).not.toContain('published')
+    expect(Object.keys(setArg)).not.toContain('publishedAt')
+  })
+})
+

--- a/wiki/src/components/layout/AddWikiModal.test.tsx
+++ b/wiki/src/components/layout/AddWikiModal.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+//
+// AddWikiModal pulls the generated SDK and three react-query hooks. The
+// publish branch under test is `publishWiki` / `unpublishWiki`; everything
+// else (wiki types, collections, bouncer toggle) is incidental and stubbed
+// to a stable, harmless shape so the modal can render without a real
+// backend.
+
+const publishWikiMock = vi.fn()
+const unpublishWikiMock = vi.fn()
+const updateWikiMock = vi.fn().mockResolvedValue({ data: {}, error: null })
+
+vi.mock('@/lib/generated', () => ({
+  publishWiki: (...args: unknown[]) => publishWikiMock(...args),
+  unpublishWiki: (...args: unknown[]) => unpublishWikiMock(...args),
+  updateWiki: (...args: unknown[]) => updateWikiMock(...args),
+}))
+
+vi.mock('@/hooks/useWikiTypesList', () => ({
+  useWikiTypesList: () => ({
+    data: {
+      wikiTypes: [
+        {
+          slug: 'log',
+          displayLabel: 'Log',
+          displayDescription: '',
+          displayShortDescriptor: '',
+          displayOrder: 1,
+          promptYaml: '',
+          defaultYaml: '',
+          userModified: false,
+          basedOnVersion: 1,
+          inputVariables: [],
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+  WIKI_TYPES_LIST_KEY: ['wikiTypes', 'v2'],
+  findWikiType: () => undefined,
+}))
+
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () => ({ data: [] }),
+}))
+
+vi.mock('@/hooks/useToggleBouncerMode', () => ({
+  useToggleBouncerMode: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+}))
+
+import AddWikiModal from './AddWikiModal'
+import type { WikiSettingsPrefill } from './AddWikiModal'
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
+
+const basePrefill: WikiSettingsPrefill = {
+  name: 'Engineering Log',
+  wikiType: 'log',
+  description: 'Daily engineering notes',
+  promptOverride: '',
+  bouncerMode: 'auto',
+  published: false,
+  publishedSlug: null,
+  collections: [],
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// ── (b) UI half — publish toggle flips backend + UI ──────────────────────
+
+describe('A-game (b) — AddWikiModal publish toggle', () => {
+  beforeEach(() => {
+    publishWikiMock.mockResolvedValue({
+      data: { published: true, publishedSlug: 'minted-slug-aaaaaaaaaaa1' },
+      error: null,
+    })
+    unpublishWikiMock.mockResolvedValue({
+      data: { published: false, publishedSlug: null },
+      error: null,
+    })
+  })
+
+  it('publish toggle calls publishWiki with the wiki id and surfaces the URL row', async () => {
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={basePrefill}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    const toggle = screen.getByRole('switch', { name: /publish wiki/i })
+    expect(toggle).toBeInTheDocument()
+    // Toggle starts unchecked because prefill.published === false. Base-UI
+    // exposes state through aria-checked.
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(toggle)
+
+    // The handler awaits publishWiki — wait for it to fire with the right
+    // path. Backend half of the (b) contract.
+    await waitFor(() => {
+      expect(publishWikiMock).toHaveBeenCalledTimes(1)
+    })
+    const callArg = publishWikiMock.mock.calls[0]![0] as {
+      path: { id: string }
+      credentials: string
+    }
+    expect(callArg.path.id).toBe('thread01TEST')
+    expect(callArg.credentials).toBe('include')
+
+    // After the resolve, the URL row should appear. UI half of (b): the
+    // optimistic state lands in sync with the server confirm.
+    await waitFor(() => {
+      expect(screen.getByText('/p/minted-slug-aaaaaaaaaaa1')).toBeInTheDocument()
+    })
+  })
+
+  it('unpublish toggle calls unpublishWiki and removes the URL row', async () => {
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={{
+          ...basePrefill,
+          published: true,
+          publishedSlug: 'currentslug00000000000ab',
+        }}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    // URL row visible up front because prefill says published=true.
+    expect(screen.getByText('/p/currentslug00000000000ab')).toBeInTheDocument()
+
+    const toggle = screen.getByRole('switch', { name: /publish wiki/i })
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(unpublishWikiMock).toHaveBeenCalledTimes(1)
+    })
+
+    // URL row should disappear after unpublish.
+    await waitFor(() => {
+      expect(screen.queryByText('/p/currentslug00000000000ab')).toBeNull()
+    })
+  })
+
+  it('surfaces the server error message when publishWiki fails', async () => {
+    publishWikiMock.mockResolvedValue({
+      data: undefined,
+      error: { error: 'Cannot publish a wiki with no content' },
+    })
+
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={basePrefill}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('switch', { name: /publish wiki/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Cannot publish a wiki with no content'),
+      ).toBeInTheDocument()
+    })
+  })
+})
+
+// ── (c) Publish-success URL surface — copy + open affordances ────────────
+
+describe('A-game (c) — AddWikiModal copy + open affordances', () => {
+  let writeTextMock: ReturnType<typeof vi.fn>
+  let openMock: ReturnType<typeof vi.fn>
+  let originalClipboard: PropertyDescriptor | undefined
+  let originalOpen: ((url?: string | URL, target?: string, features?: string) => Window | null) | undefined
+
+  beforeEach(() => {
+    writeTextMock = vi.fn().mockResolvedValue(undefined)
+    // jsdom does not implement navigator.clipboard. Define it for the test
+    // run; restore afterwards so we don't leak mutation across files.
+    originalClipboard = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      'clipboard',
+    )
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true,
+      writable: true,
+    })
+
+    openMock = vi.fn().mockReturnValue(null)
+    originalOpen = window.open
+    window.open = openMock as unknown as typeof window.open
+  })
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(window.navigator, 'clipboard', originalClipboard)
+    } else {
+      // If it never existed before our test, drop the property entirely.
+      // @ts-expect-error — runtime cleanup
+      delete window.navigator.clipboard
+    }
+    if (originalOpen) {
+      window.open = originalOpen
+    }
+  })
+
+  it('Copy link button writes `${origin}/p/${slug}` to navigator.clipboard', async () => {
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={{
+          ...basePrefill,
+          published: true,
+          publishedSlug: 'shareable-slug-aaaaaaaab',
+        }}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    const copyButton = screen.getByRole('button', { name: /copy link/i })
+    fireEvent.click(copyButton)
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1)
+    const writtenUrl = writeTextMock.mock.calls[0]![0] as string
+    // Origin is whatever jsdom set (typically http://localhost) — assert the
+    // shape, not the exact origin, so this stays robust to test-env changes.
+    expect(writtenUrl.endsWith('/p/shareable-slug-aaaaaaaab')).toBe(true)
+    expect(writtenUrl.startsWith(window.location.origin)).toBe(true)
+  })
+
+  it('Open button calls window.open with the same URL and a noopener target', () => {
+    // H2 deferred bonus from Wave 3: the publish-success row exposes both
+    // Copy AND Open. This locks the Open path so a future refactor can't
+    // silently drop it.
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={{
+          ...basePrefill,
+          published: true,
+          publishedSlug: 'shareable-slug-aaaaaaaab',
+        }}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    const openButton = screen.getByRole('button', { name: /^open$/i })
+    fireEvent.click(openButton)
+
+    expect(openMock).toHaveBeenCalledTimes(1)
+    const [url, target, features] = openMock.mock.calls[0]!
+    expect((url as string).endsWith('/p/shareable-slug-aaaaaaaab')).toBe(true)
+    expect(target).toBe('_blank')
+    expect(features).toBe('noopener,noreferrer')
+  })
+
+  it('does NOT render the URL row (or Copy/Open) when published=false', () => {
+    renderWithProviders(
+      <AddWikiModal
+        open={true}
+        onClose={() => {}}
+        prefill={basePrefill}
+        wikiId="thread01TEST"
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /copy link/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^open$/i })).toBeNull()
+  })
+})

--- a/wiki/src/components/wiki/WikiEntityArticle.test.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+//
+// `WikiEntityArticle` pulls a heavy tree (AddWikiModal, InlineEditor,
+// WikiHistoryTimeline) plus a react-query-backed history hook. The Private
+// badge logic is purely local — no network, no provider — so we stub every
+// heavyweight dependency to keep the test focused on the published-state
+// branch and avoid spinning up a QueryClientProvider for every assertion.
+
+vi.mock('@/components/layout/AddWikiModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+vi.mock('@/components/editor/InlineEditor', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+vi.mock('@/components/wiki/WikiHistoryTimeline', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+vi.mock('@/hooks/useWikiEditHistory', () => ({
+  useWikiEditHistory: () => ({ data: undefined }),
+}))
+
+import { WikiEntityArticle } from './WikiEntityArticle'
+
+afterEach(cleanup)
+
+// Minimal infobox config — `simple` is the most common variant on real wiki
+// pages. The component renders this via `WikiInfoboxTypeUpdated`; we don't
+// assert on it here.
+const infobox = {
+  kind: 'simple' as const,
+  typeLabel: 'Log',
+  lastUpdated: new Date('2026-05-01').toISOString(),
+  showSettings: false,
+}
+
+describe('<WikiEntityArticle> Private badge', () => {
+  it('renders the Private badge when published === false', () => {
+    render(
+      <WikiEntityArticle
+        chipLabel="Log"
+        title="Engineering Log"
+        infobox={infobox}
+        published={false}
+      >
+        <p>body</p>
+      </WikiEntityArticle>,
+    )
+    const badge = screen.getByTestId('wiki-private-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge.textContent).toBe('Private')
+  })
+
+  it('does NOT render the Private badge when published === true', () => {
+    render(
+      <WikiEntityArticle
+        chipLabel="Log"
+        title="Engineering Log"
+        infobox={infobox}
+        published={true}
+      >
+        <p>body</p>
+      </WikiEntityArticle>,
+    )
+    expect(screen.queryByTestId('wiki-private-badge')).toBeNull()
+  })
+
+  it('does NOT render the Private badge when published is undefined (caller-omitted)', () => {
+    // Callers that don't yet wire the `published` prop must not unexpectedly
+    // surface a Private label. The badge fires only on the explicit `false`
+    // signal so prototype/preview pages stay clean.
+    render(
+      <WikiEntityArticle
+        chipLabel="Log"
+        title="Engineering Log"
+        infobox={infobox}
+      >
+        <p>body</p>
+      </WikiEntityArticle>,
+    )
+    expect(screen.queryByTestId('wiki-private-badge')).toBeNull()
+  })
+})

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -574,6 +574,29 @@ export function WikiEntityArticle({
                     {displayTitle}
                   </h1>
                 )}
+                {/* Private badge — visible whenever the wiki is unpublished.
+                    Tells the operator at a glance that nobody else can read
+                    this surface. Suppressed in edit mode to keep the editor
+                    chrome calm. Caller wires `published` from the wiki row
+                    (defaults to false at the schema layer per #277). */}
+                {!isEditing && published === false && (
+                  <span
+                    data-testid="wiki-private-badge"
+                    aria-label="Private"
+                    style={{
+                      ...T.micro,
+                      color: "var(--wiki-infobox-text)",
+                      opacity: 0.7,
+                      fontFamily: FONT.SANS,
+                      paddingBottom: 10,
+                      whiteSpace: "nowrap",
+                      flexShrink: 0,
+                      marginRight: 12,
+                    }}
+                  >
+                    Private
+                  </span>
+                )}
                 <div
                   className="wiki-article-tabs"
                   style={{


### PR DESCRIPTION
## Summary

Wave 4 of the v1 A-game workstream — closes the H2 deferred Private-badge surface and lands H3 (the SHIP-BLOCKER): regression coverage for the 5 A-game publish cases (a)-(e).

Plan: `.planning/v1-a-game/streams/H-nav-publish/PLAN.md` H3 (lines 68-95). Tracker: #282.

## What ships

**Private badge** (deferred from H2)
- `wiki/src/components/wiki/WikiEntityArticle.tsx` — small "Private" chip near the title when `wiki.published === false`. Matches existing chip vocabulary.
- 3 colocated tests assert it renders only when unpublished.

**H3 — five A-game publish cases**

| Case | What | Tests |
|---|---|---|
| **(a)** | `published=false` schema default + UI Private badge | 2 schema tests (real schema introspection) + 3 badge tests |
| **(b)** | Publish toggle flips backend + UI together | 6 route tests (publish mint/reuse, 400 empty content, 404 unknown, unpublish nulls slug, unpublish 404) + 3 UI toggle tests |
| **(c)** | Publish-success URL + Copy + Open affordances | 3 affordance tests (clipboard.writeText shape, window.open with `_blank` + `noopener,noreferrer`, hidden when unpublished) |
| **(d)** | Anon GET 200 (published) / 404 (unpublished or non-existent) | 6 tests (200 happy path, 404 unpublished, 404 unknown, 404 null content, Cache-Control: no-store, ?raw branch) |
| **(e)** | URL stability across wiki rename | 1 PUT-rename test asserting `set` payload contains none of `published`, `publishedSlug`, `publishedAt` |

## Files (new)

- `core/src/__tests__/wiki-publish.test.ts` — covers (a) schema default, (b) backend, (e) URL stability
- `core/src/__tests__/published.test.ts` — covers (d) anon access matrix
- `wiki/src/components/layout/AddWikiModal.test.tsx` — covers (b) UI half + (c)
- `wiki/src/components/wiki/WikiEntityArticle.test.tsx` — Private badge assertions

## Verification

- `pnpm typecheck`: clean (9/9 tasks)
- `pnpm --filter @robin/core test`: **+15 new passing tests, 0 new failures** (26 baseline failures are all in `wiki-types.test.ts` — pre-existing, see "Open flag" below)
- `pnpm --filter @robin/wiki test`: **+9 new passing tests, 0 new failures** (76/76 pass)
- `wiki/vitest.config.ts` already existed — no test infra had to be stood up

## Deviations from PLAN.md §H3 (each justified)

1. **Badge test lives in `WikiEntityArticle.test.tsx`, not `WikiInfobox.test.tsx`** — the badge is rendered by `WikiEntityArticle`, not the infobox. Heavyweight children (`AddWikiModal`, `InlineEditor`, `WikiHistoryTimeline`) are stubbed so the test focuses on published-state branching.
2. **Plan flagged wiki may lack a vitest config** — false alarm; `vitest.config.ts` + `vitest.setup.ts` already exist with `@testing-library/jest-dom/vitest`.
3. **Mock pattern for core publish tests follows `wiki-update.test.ts` shape**, not `wiki-types.test.ts`. Per-test chain mocks on `db.select` / `db.update` keep the real schema — required because `db/locks.ts` and `lib/regen.ts` import additional tables that would otherwise need stubbing. More robust to future column additions.
4. **Added `nanoid24` mock** for deterministic 24-char slugs so assertions can compare exact strings instead of `expect.any(String)`.

## Open flag for triage

The 26 pre-existing core test failures are **all in `wiki-types.test.ts`** (`FORBIDDEN_FIELD` vs `MISSING_REQUIRED_VAR` shape mismatches). Looks like a real validation-pipeline regression unrelated to publish work. Worth a separate investigation issue.

## Test plan

- [ ] CI pre-merge.yml green
- [ ] Smoke: open an unpublished wiki — see "Private" chip near title
- [ ] Smoke: publish via settings → chip disappears; URL row shows Copy + Open
- [ ] Smoke: hit `/p/<slug>` anonymously while published → 200; unpublish → 404 on the same URL