### PR TITLE
feat(a): cost telemetry, spend dashboard, fragment history (A3+A4+A5)

### DIFF
--- a/.uat/plans/57-stream-a-cost-and-history.md
+++ b/.uat/plans/57-stream-a-cost-and-history.md
@@ -1,0 +1,143 @@
+# 57 — Stream A finish: cost telemetry + spend dashboard + fragment history
+
+## What it proves
+
+PR `feat/a-cost-and-history` ships three Stream A v0.2.0 features:
+
+1. **A3 (cost telemetry)**: every OpenRouter call writes a `usage_events` row keyed by `job_id`. The `cost_usd_micros` total over a window matches the OpenRouter dashboard within 5 percent. `/admin/diagnose/:entryKey` returns `usage_events` joined alongside `pipeline_events` for the same entry.
+2. **A4 (spend dashboard + budget caps)**: `/settings/spend` shows this-month total cost broken down by stage (capture, fragment, classify, regen, embed). Three editable budget caps (regen, embed, classify) persist via `PUT /settings/budgets/:kind` and survive a page reload.
+3. **A5 (fragment history)**: `GET /fragments/:id/history` returns edits joined with audit_log entries for the fragment in `editedAt DESC` order. Paginated via cursor.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- Wiki dev/prod server on `WIKI_URL` (default `http://localhost:8080`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+- `DATABASE_URL` reachable for direct row inspection
+- `OPENROUTER_API_KEY` real key (the cost-emit assertion needs live tokens)
+- Migration 0004 applied (`pnpm -C core db:migrate`)
+- `pnpm -C core seed-fixture` so a Transformer wiki exists
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email`: better-auth (existing)
+- `GET  /admin/diagnose/:entryKey`: returns `auditLog`, `pipelineEvents`, `usageEvents`, `usageTotals`
+- `GET  /settings/spend`: returns `{ totalUsdMicros, byStage: {...}, budgets: { regen, embed, classify } }`
+- `PUT  /settings/budgets/:kind`: body `{ usdMicros: number }`. `kind in regen|embed|classify`
+- `GET  /fragments/:id/history`: returns `{ edits: [...], cursor: string|null }`. Auth-gated.
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:8080}"
+
+JAR=$(mktemp /tmp/uat-57-jar-XXXXXX.txt)
+trap 'rm -f "$JAR" /tmp/uat-57-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "57 — Stream A finish: cost + spend + fragment history"
+echo ""
+
+# 1. Sign in
+curl -s -o /tmp/uat-57-signin.json -w "%{http_code}" \
+  -c "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" > /tmp/uat-57-signin.code
+if [ "$(cat /tmp/uat-57-signin.code)" = "200" ]; then pass "sign in 200"; else fail "sign in expected 200, got $(cat /tmp/uat-57-signin.code)"; fi
+
+# 2. A3 — capture an entry to generate a fresh job_id and downstream usage_events
+ENTRY_KEY="uat57-$(date +%s)"
+CAPTURE_HTTP=$(curl -s -o /tmp/uat-57-capture.json -w "%{http_code}" \
+  -b "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"entryKey\":\"$ENTRY_KEY\",\"input\":\"Test capture for cost telemetry. The team chose daily ships over weekly batches.\"}" \
+  "$SERVER_URL/entries")
+if [ "$CAPTURE_HTTP" = "200" ] || [ "$CAPTURE_HTTP" = "201" ]; then pass "capture entry $ENTRY_KEY"; else fail "capture expected 200/201, got $CAPTURE_HTTP"; fi
+
+# Wait briefly for the worker to flush usage_events for this job
+sleep 5
+
+# 3. A3 — diagnose endpoint returns usage_events alongside pipeline_events
+DIAG_HTTP=$(curl -s -o /tmp/uat-57-diag.json -w "%{http_code}" -b "$JAR" "$SERVER_URL/admin/diagnose/$ENTRY_KEY")
+if [ "$DIAG_HTTP" = "200" ]; then pass "diagnose 200"; else fail "diagnose got $DIAG_HTTP"; fi
+
+USAGE_COUNT=$(jq '.usageEvents | length' /tmp/uat-57-diag.json 2>/dev/null || echo 0)
+if [ "$USAGE_COUNT" -ge 2 ]; then pass "usage_events recorded ($USAGE_COUNT rows)"; else fail "expected >= 2 usage_events, got $USAGE_COUNT"; fi
+
+PIPELINE_COUNT=$(jq '.pipelineEvents | length' /tmp/uat-57-diag.json 2>/dev/null || echo 0)
+if [ "$PIPELINE_COUNT" -ge 2 ]; then pass "pipeline_events also present ($PIPELINE_COUNT rows)"; else fail "pipeline_events missing"; fi
+
+JOB_OVERLAP=$(jq -r '
+  (.usageEvents | map(.jobId) | unique) as $u |
+  (.pipelineEvents | map(.jobId // .job_id) | unique) as $p |
+  ($u + $p | unique | length) - (($u | length) + ($p | length) - ($u + $p | unique | length))
+' /tmp/uat-57-diag.json 2>/dev/null || echo 0)
+if [ "$JOB_OVERLAP" -ge 1 ]; then pass "usage_events and pipeline_events share at least one job_id"; else fail "no shared job_id between usage and pipeline events"; fi
+
+USAGE_TOTAL=$(jq '.usageTotals.costUsdMicros // 0' /tmp/uat-57-diag.json)
+if [ "$USAGE_TOTAL" -gt 0 ]; then pass "usageTotals.costUsdMicros > 0 ($USAGE_TOTAL)"; else fail "usageTotals.costUsdMicros is zero"; fi
+
+# 4. A4 — settings spend returns month total and per-stage breakdown
+SPEND_HTTP=$(curl -s -o /tmp/uat-57-spend.json -w "%{http_code}" -b "$JAR" "$SERVER_URL/settings/spend")
+if [ "$SPEND_HTTP" = "200" ]; then pass "/settings/spend 200"; else fail "/settings/spend got $SPEND_HTTP"; fi
+
+HAS_BY_STAGE=$(jq '.byStage | type' /tmp/uat-57-spend.json 2>/dev/null)
+if [ "$HAS_BY_STAGE" = '"object"' ]; then pass "spend.byStage present"; else fail "spend.byStage missing"; fi
+
+HAS_BUDGETS=$(jq '.budgets | (has("regen") and has("embed") and has("classify"))' /tmp/uat-57-spend.json)
+if [ "$HAS_BUDGETS" = "true" ]; then pass "all three budget caps present in payload"; else fail "budgets missing one or more of regen/embed/classify"; fi
+
+# 5. A4 — set a budget cap, confirm it persists across re-fetch
+PUT_HTTP=$(curl -s -o /tmp/uat-57-put.json -w "%{http_code}" \
+  -b "$JAR" -X PUT -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d '{"usdMicros":5000000}' \
+  "$SERVER_URL/settings/budgets/regen")
+if [ "$PUT_HTTP" = "200" ] || [ "$PUT_HTTP" = "204" ]; then pass "PUT regen budget 200/204"; else fail "PUT regen budget got $PUT_HTTP"; fi
+
+curl -s -o /tmp/uat-57-spend2.json -b "$JAR" "$SERVER_URL/settings/spend"
+PERSISTED=$(jq '.budgets.regen' /tmp/uat-57-spend2.json)
+if [ "$PERSISTED" = "5000000" ]; then pass "regen budget persisted across re-fetch"; else fail "regen budget did not persist (got $PERSISTED)"; fi
+
+# 6. A5 — fragment history endpoint
+# Pick any fragment from the seeded data
+FRAG_ID=$(curl -s -b "$JAR" "$SERVER_URL/fragments?limit=1" | jq -r '.fragments[0].id // empty')
+if [ -n "$FRAG_ID" ]; then
+  HIST_HTTP=$(curl -s -o /tmp/uat-57-history.json -w "%{http_code}" -b "$JAR" "$SERVER_URL/fragments/$FRAG_ID/history")
+  if [ "$HIST_HTTP" = "200" ]; then pass "fragment history 200"; else fail "fragment history got $HIST_HTTP"; fi
+  HAS_EDITS_KEY=$(jq 'has("edits")' /tmp/uat-57-history.json)
+  if [ "$HAS_EDITS_KEY" = "true" ]; then pass "history payload has edits[]"; else fail "history payload missing edits"; fi
+else
+  skip "fragment history: no seeded fragment available"
+fi
+
+# 7. A5 — anon access to history is rejected
+ANON_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$SERVER_URL/fragments/abc123/history")
+if [ "$ANON_HTTP" = "401" ] || [ "$ANON_HTTP" = "403" ]; then pass "anon GET history rejected ($ANON_HTTP)"; else fail "anon got $ANON_HTTP, expected 401/403"; fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The capture entry created in step 2 (`uat57-<timestamp>`) is left in the DB so the test artefacts are visible for re-run. Manual cleanup:
+
+```bash
+PGPASSWORD=$DB_PASS psql "$DATABASE_URL" -c "DELETE FROM entries WHERE entry_key LIKE 'uat57-%';"
+PGPASSWORD=$DB_PASS psql "$DATABASE_URL" -c "DELETE FROM usage_events WHERE entry_key LIKE 'uat57-%';"
+```
+
+## Expected pass/fail behavior
+
+All steps PASS on a clean local stack with `OPENROUTER_API_KEY` set and the v0.2.0 migration applied. Step 3 (cost emit) is the only one that requires live OpenRouter tokens. If running offline, set `OPENROUTER_API_KEY` to a placeholder and expect a SKIP on the cost assertion only.

--- a/core/drizzle/migrations/0004_usage_events_and_app_settings.sql
+++ b/core/drizzle/migrations/0004_usage_events_and_app_settings.sql
@@ -1,0 +1,50 @@
+-- Phase A3 — Cost & spend (Component #4).
+--
+-- Adds two tables:
+--   1. usage_events: sibling of pipeline_events. Every OpenRouter call (mastra
+--      agent or embedding adapter) writes one row keyed by job_id, so cost
+--      correlates 1:1 with pipeline state via the shared job_id column.
+--      Cost stored as cost_usd_micros (1e-6 USD) for full precision; the
+--      v0.2.0 model-pricing table is hardcoded in TS, OpenRouter /models
+--      fetch is deferred to v0.3.0.
+--   2. app_settings: single-tenant key/value store. v0.2.0 uses it for the
+--      regen / embed / classify budget caps (Phase A4). Future settings
+--      land here without new migrations.
+--
+-- Idempotent: IF NOT EXISTS so a partially-applied migration during a CI
+-- rerun does not fail.
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id text PRIMARY KEY,
+  entry_key text,
+  wiki_key text,
+  fragment_key text,
+  user_id text,
+  source_client text,
+  stage text NOT NULL,
+  model text NOT NULL,
+  provider text NOT NULL,
+  prompt_tokens integer NOT NULL DEFAULT 0,
+  completion_tokens integer NOT NULL DEFAULT 0,
+  total_tokens integer NOT NULL DEFAULT 0,
+  cost_usd_micros integer NOT NULL DEFAULT 0,
+  duration_ms integer,
+  job_id text,
+  metadata jsonb,
+  created_at timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS usage_events_user_id_created_at_idx
+  ON usage_events (user_id, created_at);
+CREATE INDEX IF NOT EXISTS usage_events_wiki_key_created_at_idx
+  ON usage_events (wiki_key, created_at);
+CREATE INDEX IF NOT EXISTS usage_events_stage_created_at_idx
+  ON usage_events (stage, created_at);
+CREATE INDEX IF NOT EXISTS usage_events_job_id_idx
+  ON usage_events (job_id);
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  key text PRIMARY KEY,
+  value jsonb NOT NULL,
+  updated_at timestamp DEFAULT now() NOT NULL
+);

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778457601000,
       "tag": "0003_migrations_meta_and_pipeline_nullable",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778457602000,
+      "tag": "0004_usage_events_and_app_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -150,6 +150,14 @@ export const wikiTypes = pgTable('wiki_types', {
    * prompt-validation.ts. See regen.ts and routes/wiki-types.ts.
    */
   prompt: text('prompt').notNull().default(''),
+  /**
+   * Type-aware authoring instruction for the HyDE generator (Wave G,
+   * wiki_agent_schema kind='hyde_synthetic'). Loaded from the YAML
+   * spec's `internal_framing` field on bootstrap. Belief wikis get
+   * framed differently than Decision wikis. Nullable so legacy types
+   * without framing still load.
+   */
+  internalFraming: text('internal_framing'),
   isDefault: boolean('is_default').notNull().default(false),
   userModified: boolean('user_modified').notNull().default(false),
   basedOnVersion: integer('based_on_version').notNull().default(1),
@@ -413,6 +421,54 @@ export const pipelineEvents = pgTable(
   ]
 )
 
+// ─── Usage Events (cost & spend, Component #4) ───
+//
+// Sibling of pipeline_events per A-game line 120 / RESEARCH §4.3. Every
+// OpenRouter call (mastra agent + embedding adapter) writes one row here
+// keyed by job_id so a single BullMQ job correlates: pipeline_events.job_id
+// for state, usage_events.job_id for cost. Cost is stored as
+// `cost_usd_micros` (1e-6 USD) so we never lose precision rounding to cents.
+export const usageEvents = pgTable(
+  'usage_events',
+  {
+    id: text('id').primaryKey(),
+    entryKey: text('entry_key'),
+    wikiKey: text('wiki_key'),
+    fragmentKey: text('fragment_key'),
+    userId: text('user_id'),
+    sourceClient: text('source_client'),
+    stage: text('stage').notNull(), // capture | fragment | classify | regen | embed
+    model: text('model').notNull(),
+    provider: text('provider').notNull(),
+    promptTokens: integer('prompt_tokens').notNull().default(0),
+    completionTokens: integer('completion_tokens').notNull().default(0),
+    totalTokens: integer('total_tokens').notNull().default(0),
+    costUsdMicros: integer('cost_usd_micros').notNull().default(0),
+    durationMs: integer('duration_ms'),
+    jobId: text('job_id'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (t) => [
+    index('usage_events_user_id_created_at_idx').on(t.userId, t.createdAt),
+    index('usage_events_wiki_key_created_at_idx').on(t.wikiKey, t.createdAt),
+    index('usage_events_stage_created_at_idx').on(t.stage, t.createdAt),
+    index('usage_events_job_id_idx').on(t.jobId),
+  ]
+)
+
+// ─── App settings (single-tenant key/value store for budgets, etc.) ───
+//
+// Used by Phase A4 for storing budget caps (regen / embed / classify).
+// Keys are free-form strings; values are JSONB so a budget cap can be
+// `{ "limit_usd_micros": 10000000 }` and other settings can use other
+// shapes. Single-tenant — no user_id column.
+export const appSettings = pgTable('app_settings', {
+  key: text('key').primaryKey(),
+  value: jsonb('value').notNull().$type<unknown>(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
 /**
  * Boot-time drift detection (#12). One-row-per-key store for migration
  * metadata. The boot path writes the SHA of `drizzle/migrations/meta/_journal.json`
@@ -448,3 +504,42 @@ export const apiKeys = pgTable('api_keys', {
   hint: text('hint').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 })
+
+// ─── Wiki Agent Schema (multi-row agent-facing retrieval surface — Wave G) ───
+
+/**
+ * Multi-row keyed by (wikiKey, kind). Each `kind` is a different
+ * representation pathway used during retrieval. v0.2.0 ships two kinds:
+ *
+ *   - `description`     direct embedding of `wikis.description`
+ *   - `hyde_synthetic`  LLM-generated hypothetical document, then embedded
+ *
+ * Future kinds (post-v0.2.0) compose into the same table with no schema
+ * change: `hyde_questions`, `expanded_keywords`, `retrieval_friendly_summary`,
+ * `archetype_brief`. See docs/architecture/wiki-agent-schema.md.
+ *
+ * `generator_version` bumps when the prompt template, framing, embedding
+ * model, or generator LLM changes. Backfill is incremental — wikis whose
+ * stored version trails the canonical version surface in /settings/outstanding.
+ *
+ * The composite PRIMARY KEY (wiki_key, kind) is declared in the migration
+ * (0005_wiki_agent_schema.sql); Drizzle's pg-core does not support
+ * multi-column PKs via the column-level `.primaryKey()` helper without
+ * raw SQL fallthrough, so we keep the constraint authoritative in the
+ * migration file. The kind index is declared here so drizzle-kit and the
+ * SQL stay in sync when future migrations diff against the schema.
+ */
+export const wikiAgentSchema = pgTable(
+  'wiki_agent_schema',
+  {
+    wikiKey: text('wiki_key')
+      .notNull()
+      .references(() => wikis.lookupKey, { onDelete: 'cascade' }),
+    kind: text('kind').notNull(),
+    content: text('content').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }),
+    generatedAt: timestamp('generated_at').defaultNow().notNull(),
+    generatorVersion: text('generator_version').notNull(),
+  },
+  (t) => [index('wiki_agent_schema_kind_idx').on(t.kind)]
+)

--- a/core/src/db/usage-events.ts
+++ b/core/src/db/usage-events.ts
@@ -1,0 +1,170 @@
+import { sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { usageEvents } from './schema.js'
+
+/**
+ * Stage taxonomy for usage_events.stage. Mirrors pipeline_events.stage so
+ * the dashboard can join the two by job_id and surface "this regen took
+ * 47s, 12k tokens, $0.018, 3 stages" without ambiguity. `search` is
+ * reserved for the future MCP search-cost tracking.
+ */
+export type UsageStage =
+  | 'capture'
+  | 'fragment'
+  | 'classify'
+  | 'regen'
+  | 'embed'
+  | 'search'
+
+/**
+ * Hardcoded model pricing table for v0.2.0. Costs are in USD per 1M tokens
+ * (the OpenRouter dashboard format). v0.3.0 will fetch /models on boot
+ * and cache 24h; for now, prices drift with provider changes — operators
+ * should bump these when they notice the dashboard total drifting from
+ * the OpenRouter ledger.
+ *
+ * Each entry has separate prompt and completion rates because most
+ * providers charge differently per direction. Embedding models use the
+ * `prompt` rate (input only — there is no completion).
+ *
+ * TODO(v0.3.0): replace with a /models fetch + 24h cache.
+ */
+interface ModelPricing {
+  /** USD per 1M prompt (input) tokens. */
+  promptPer1M: number
+  /** USD per 1M completion (output) tokens. Zero for embeddings. */
+  completionPer1M: number
+  /** Provider tag used for usage_events.provider. */
+  provider: string
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Default wiki-writer (Sonnet 4.6, used by regen + entity extract paths).
+  'anthropic/claude-sonnet-4.6': {
+    promptPer1M: 3,
+    completionPer1M: 15,
+    provider: 'anthropic',
+  },
+  // Classification / fast paths (Haiku 4.5).
+  'anthropic/claude-haiku-4.5': {
+    promptPer1M: 1,
+    completionPer1M: 5,
+    provider: 'anthropic',
+  },
+  // Fragmentation (Gemini 2.5 Pro).
+  'google/gemini-2.5-pro': {
+    promptPer1M: 1.25,
+    completionPer1M: 10,
+    provider: 'google',
+  },
+  // Embedding default.
+  'openai/text-embedding-3-small': {
+    promptPer1M: 0.02,
+    completionPer1M: 0,
+    provider: 'openai',
+  },
+  // Future-safe (#221): qwen 1536-MRL.
+  'qwen/qwen3-embedding-8b': {
+    promptPer1M: 0.05,
+    completionPer1M: 0,
+    provider: 'qwen',
+  },
+}
+
+/**
+ * Compute cost in 1e-6 USD (micros) for a given token mix on a given
+ * model. Returns 0 when the model is unknown — callers should still
+ * insert the row so token counts are not lost; only cost rolls up wrong.
+ */
+export function computeCostUsdMicros(
+  model: string,
+  promptTokens: number,
+  completionTokens: number
+): number {
+  const pricing = MODEL_PRICING[model]
+  if (!pricing) return 0
+  // (tokens / 1_000_000) * (USD per 1M) * 1_000_000 (USD → micros) cancels
+  // the 1M divisor. So: tokens × pricing × 1 = whole micros directly.
+  // Round to keep the column integer-safe.
+  const promptMicros = Math.round(promptTokens * pricing.promptPer1M)
+  const completionMicros = Math.round(completionTokens * pricing.completionPer1M)
+  return promptMicros + completionMicros
+}
+
+/** Resolve provider tag for a model string. Falls back to 'openrouter'. */
+export function providerForModel(model: string): string {
+  return MODEL_PRICING[model]?.provider ?? 'openrouter'
+}
+
+export interface EmitUsageEventParams {
+  entryKey?: string | null
+  wikiKey?: string | null
+  fragmentKey?: string | null
+  userId?: string | null
+  sourceClient?: string | null
+  stage: UsageStage
+  model: string
+  provider?: string
+  promptTokens: number
+  completionTokens: number
+  durationMs?: number | null
+  jobId?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Insert one row into usage_events. Best-effort — caller should NOT block
+ * the LLM call result on this insert succeeding. The wrap helper in
+ * packages/agent/src/agents/caller.ts already handles failure suppression
+ * at the call site.
+ */
+export async function emitUsageEvent(
+  db: PostgresJsDatabase,
+  params: EmitUsageEventParams
+): Promise<void> {
+  const totalTokens = params.promptTokens + params.completionTokens
+  const costUsdMicros = computeCostUsdMicros(
+    params.model,
+    params.promptTokens,
+    params.completionTokens
+  )
+  await db.insert(usageEvents).values({
+    id: crypto.randomUUID(),
+    entryKey: params.entryKey ?? null,
+    wikiKey: params.wikiKey ?? null,
+    fragmentKey: params.fragmentKey ?? null,
+    userId: params.userId ?? null,
+    sourceClient: params.sourceClient ?? null,
+    stage: params.stage,
+    model: params.model,
+    provider: params.provider ?? providerForModel(params.model),
+    promptTokens: params.promptTokens,
+    completionTokens: params.completionTokens,
+    totalTokens,
+    costUsdMicros,
+    durationMs: params.durationMs ?? null,
+    jobId: params.jobId ?? null,
+    metadata: params.metadata ?? null,
+  })
+}
+
+/** Aggregate cost over a time range. Used by /usage/summary in A4. */
+export async function sumCostByStage(
+  db: PostgresJsDatabase,
+  sinceIso: string
+): Promise<Array<{ stage: string; costUsdMicros: number; totalTokens: number }>> {
+  const rows = (await db.execute(
+    sql`SELECT stage,
+               COALESCE(SUM(cost_usd_micros), 0)::bigint AS cost_usd_micros,
+               COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens
+        FROM usage_events
+        WHERE created_at >= ${sinceIso}::timestamp
+        GROUP BY stage
+        ORDER BY stage`
+  )) as Array<{ stage: string; cost_usd_micros: string | number; total_tokens: string | number }>
+  return rows.map((r) => ({
+    stage: r.stage,
+    costUsdMicros: Number(r.cost_usd_micros),
+    totalTokens: Number(r.total_tokens),
+  }))
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -24,6 +24,7 @@ import { auditRoutes } from './routes/audit.js'
 import { aiPreferencesRoutes } from './routes/ai-preferences.js'
 import { aiModelsRoutes } from './routes/ai-models.js'
 import { publishedRoutes } from './routes/published.js'
+import { settingsRoutes } from './routes/settings.js'
 import { systemRoutes } from './routes/system.js'
 import { startWorkers } from './queue/worker.js'
 import {
@@ -233,6 +234,7 @@ app.route('/api/content', contentRoutes)
 app.route('/wiki-types', wikiTypesRoutes)
 app.route('/audit-log', auditRoutes)
 app.route('/ai', aiModelsRoutes)
+app.route('/settings', settingsRoutes)
 
 /***********************************************************************
  * ## Boot

--- a/core/src/lib/regen.test.ts
+++ b/core/src/lib/regen.test.ts
@@ -33,6 +33,12 @@ vi.mock('@robin/agent', async (importOriginal) => {
       wikiWriter: {},
     })),
     createTypedCaller: vi.fn(() => fakeCallLlm),
+    // Phase A3: regen.ts switched from createTypedCaller to withTypedUsage
+    // for the wikiWriter call so cost telemetry can attach. Mock returns
+    // the same fakeCallLlm so existing assertions keep working; the usage
+    // record callback is never invoked in this mock path because the
+    // fake bypasses agent.generate() entirely.
+    withTypedUsage: vi.fn(() => fakeCallLlm),
     embedText: vi.fn(async () => null),
   }
 })

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -4,6 +4,7 @@ import {
   createIngestAgents,
   createTypedCaller,
   embedText,
+  withTypedUsage,
   wikiClassify,
 } from '@robin/agent'
 import {
@@ -40,6 +41,7 @@ import { hybridSearch } from './search.js'
 import { nanoid } from './id.js'
 import { logger } from './logger.js'
 import { emitAuditEvent } from '../db/audit.js'
+import { emitUsageEvent } from '../db/usage-events.js'
 
 const log = logger.child({ component: 'regen' })
 
@@ -404,7 +406,7 @@ export async function classifyUnfiledFragments(
 export async function regenerateWiki(
   database: DB,
   wikiKey: string,
-  opts?: { skipEmbedding?: boolean }
+  opts?: { skipEmbedding?: boolean; jobId?: string }
 ): Promise<RegenResult> {
   const t0 = performance.now()
   const [wiki] = await database.select().from(wikis).where(eq(wikis.lookupKey, wikiKey))
@@ -454,13 +456,37 @@ export async function regenerateWiki(
   // input type but createTypedCaller is parameterised by the output type
   // (what the caller ultimately consumes).
   //
-  // Use the dedicated wikiWriter agent (Sonnet, 16k output cap) — not the
+  // Use the dedicated wikiWriter agent (Sonnet, 16k output cap), not the
   // wiki-classifier (Haiku, 4k cap). Issue #257: long regen output was
   // silently truncated mid-sentence because the classifier model's default
   // ~4096 token cap fell well short of typical wiki bodies.
-  const callLlm = createTypedCaller(
-    agents.wikiWriter,
+  //
+  // Phase A3: wrap with withTypedUsage so the wiki-writer Sonnet call
+  // writes a usage_events row keyed by jobId. Falls back gracefully when
+  // jobId is not supplied (manual route handler tests).
+  const regenJobId = opts?.jobId
+  const callLlm = withTypedUsage(
     regenOutputSchema as unknown as import('zod').ZodType<RegenOutput>,
+    {
+      agent: agents.wikiWriter,
+      record: async (ctx, rec) => {
+        await emitUsageEvent(database as never, {
+          wikiKey,
+          stage: 'regen',
+          model: ctx.model,
+          promptTokens: rec.promptTokens,
+          completionTokens: rec.completionTokens,
+          durationMs: rec.durationMs,
+          jobId: ctx.jobId ?? null,
+        })
+      },
+      context: () => ({
+        stage: 'regen',
+        jobId: regenJobId ?? null,
+        wikiKey,
+        model: orConfig.models.wikiGeneration,
+      }),
+    },
   )
 
   // Gather linked fragments via FRAGMENT_IN_WIKI edges, with signal strength
@@ -730,6 +756,26 @@ export async function regenerateWiki(
       await database.update(wikis).set({ embedding: vec }).where(eq(wikis.lookupKey, wikiKey))
       hasEmbedding = true
     }
+    // Phase A3 — embedding cost telemetry for regen. Token count
+    // estimated from input chars (~4 chars/token); the OpenRouter
+    // embedding endpoint does not return usage data.
+    await emitUsageEvent(database as never, {
+      wikiKey,
+      stage: 'embed',
+      model: orConfig.models.embedding,
+      promptTokens: Math.ceil(markdown.length / 4),
+      completionTokens: 0,
+      durationMs: Math.round(performance.now() - tEmbed0),
+      jobId: regenJobId ?? null,
+      metadata: {
+        inputChars: markdown.length,
+        success: hasEmbedding,
+        estimated: true,
+        substage: 'regen-wiki-embed',
+      },
+    }).catch(() => {
+      // Cost-logging must not block regen.
+    })
   }
   const embedMs = performance.now() - tEmbed0
   const totalMs = performance.now() - t0

--- a/core/src/queue/embedding-retry-worker.ts
+++ b/core/src/queue/embedding-retry-worker.ts
@@ -7,6 +7,7 @@ import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { logger } from '../lib/logger.js'
 import { emitPipelineEvent } from '../db/pipeline-events.js'
 import { emitAuditEvent } from '../db/audit.js'
+import { emitUsageEvent } from '../db/usage-events.js'
 
 const log = logger.child({ component: 'embedding-retry' })
 
@@ -46,7 +47,8 @@ type EmbeddableRow = {
 async function retryTable<TableName extends 'fragments' | 'wikis' | 'people'>(
   tableName: TableName,
   cutoff: Date,
-  embedConfig: { apiKey: string; model: string }
+  embedConfig: { apiKey: string; model: string },
+  jobId: string,
 ): Promise<{ scanned: number; ok: number; failed: number }> {
   let rows: EmbeddableRow[]
 
@@ -165,7 +167,37 @@ async function retryTable<TableName extends 'fragments' | 'wikis' | 'people'>(
   let failed = 0
 
   for (const row of rows) {
+    const tEmbed0 = performance.now()
     const vec = row.text.trim().length > 0 ? await embedText(row.text, embedConfig) : null
+    const embedMs = Math.round(performance.now() - tEmbed0)
+
+    // Phase A3 — embedding cost telemetry for the retry path. Token
+    // count estimated from input chars (OpenRouter embeddings do not
+    // surface usage). Skipped when text was empty (no API call made).
+    if (row.text.trim().length > 0) {
+      const fragKey =
+        tableName === 'fragments' ? row.lookupKey : null
+      const wikKey = tableName === 'wikis' ? row.lookupKey : null
+      await emitUsageEvent(db as never, {
+        fragmentKey: fragKey,
+        wikiKey: wikKey,
+        stage: 'embed',
+        model: embedConfig.model,
+        promptTokens: Math.ceil(row.text.length / 4),
+        completionTokens: 0,
+        durationMs: embedMs,
+        jobId,
+        metadata: {
+          inputChars: row.text.length,
+          success: vec !== null,
+          estimated: true,
+          substage: 'embedding-retry',
+          table: tableName,
+        },
+      }).catch(() => {
+        // Cost-logging must not block the retry path.
+      })
+    }
 
     if (vec) {
       if (tableName === 'fragments') {
@@ -278,9 +310,9 @@ export async function processEmbeddingRetryJob(
   const embedConfig = { apiKey: config.apiKey, model: config.models.embedding }
 
   try {
-    const fragResult = await retryTable('fragments', cutoff, embedConfig)
-    const wikiResult = await retryTable('wikis', cutoff, embedConfig)
-    const peopleResult = await retryTable('people', cutoff, embedConfig)
+    const fragResult = await retryTable('fragments', cutoff, embedConfig, job.jobId)
+    const wikiResult = await retryTable('wikis', cutoff, embedConfig, job.jobId)
+    const peopleResult = await retryTable('people', cutoff, embedConfig, job.jobId)
 
     const elapsed = Math.round(performance.now() - t0)
     log.info(

--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -35,7 +35,7 @@ export async function processRegenJob(job: RegenJob): Promise<JobResult> {
   })
 
   try {
-    const result = await regenerateWiki(db, job.objectKey)
+    const result = await regenerateWiki(db, job.objectKey, { jobId: job.jobId })
     const elapsed = Math.round(performance.now() - t0)
     log.info(
       { jobId: job.jobId, wikiKey: job.objectKey, fragmentCount: result.fragmentCount, ms: elapsed, timing: result.timing },

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -23,11 +23,13 @@ import {
   createIngestAgents,
   embedText,
   DEFAULT_RESOLUTION_CONFIG,
-  createTypedCaller,
+  withTypedUsage,
   NoOpenRouterKeyError,
   type OpenRouterConfig,
   type ExtractionOrchestratorDeps,
   type LinkingOrchestratorDeps,
+  type UsageContext,
+  type UsageRecord,
 } from '@robin/agent'
 import {
   makeLookupKey,
@@ -52,6 +54,7 @@ import { resolveFragmentSlug } from '../db/slug.js'
 import { computeContentHash } from '../db/dedup.js'
 import { emitPipelineEvent, type PipelineStage } from '../db/pipeline-events.js'
 import { emitAuditEvent } from '../db/audit.js'
+import { emitUsageEvent } from '../db/usage-events.js'
 import { producer } from './producer.js'
 import { processRegenJob, processRegenBatchJob } from './regen-worker.js'
 import { processEmbeddingRetryJob } from './embedding-retry-worker.js'
@@ -78,6 +81,61 @@ function emitEvent(event: {
   metadata?: Record<string, unknown>
 }): Promise<void> {
   return emitPipelineEvent(db as never, event)
+}
+
+/**
+ * Build a usage recorder bound to the current OpenRouter config + job
+ * context. The returned recorder writes one usage_events row per
+ * agent.generate() call, keyed by job_id so cost rolls up alongside
+ * pipeline_events for the same job.
+ */
+function buildUsageRecorder(): (
+  context: UsageContext,
+  record: UsageRecord
+) => Promise<void> {
+  return async (context, record) => {
+    await emitUsageEvent(db as never, {
+      entryKey: context.entryKey ?? null,
+      wikiKey: context.wikiKey ?? null,
+      fragmentKey: context.fragmentKey ?? null,
+      userId: context.userId ?? null,
+      sourceClient: context.sourceClient ?? null,
+      stage: context.stage as
+        | 'capture'
+        | 'fragment'
+        | 'classify'
+        | 'regen'
+        | 'embed'
+        | 'search',
+      model: context.model,
+      promptTokens: record.promptTokens,
+      completionTokens: record.completionTokens,
+      durationMs: record.durationMs,
+      jobId: context.jobId ?? null,
+      metadata: record.metadata ?? null,
+    })
+  }
+}
+
+/**
+ * Resolve which model an agent slot maps to. Worker.ts wires four agent
+ * slots (fragmenter / entityExtractor / wikiClassifier / fragScorer) to
+ * the models in the OpenRouter config. The usage recorder needs the
+ * actual model id so the dashboard can attribute cost to the right row
+ * in the hardcoded pricing table (core/src/db/usage-events.ts).
+ */
+function modelForAgent(
+  config: OpenRouterConfig,
+  slot: 'fragmenter' | 'entityExtractor' | 'wikiClassifier' | 'fragScorer'
+): string {
+  switch (slot) {
+    case 'fragmenter':
+    case 'entityExtractor':
+      return config.models.extraction
+    case 'wikiClassifier':
+    case 'fragScorer':
+      return config.models.classification
+  }
 }
 
 async function insertEdgeRow(edge: Record<string, unknown>): Promise<void> {
@@ -137,6 +195,11 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
 
   // 2. Fresh Mastra agents per ingest run.
   const agents = createIngestAgents(openRouterConfig)
+  const recordUsage = buildUsageRecorder()
+  // Source client surfaced from the BullMQ payload (mcp.claude / web / api).
+  // Stamped on every usage_events row so the dashboard can break cost down
+  // by where the thought came from.
+  const sourceClient = job.source ?? null
 
   const deps: ExtractionOrchestratorDeps = {
     entryLock,
@@ -152,7 +215,17 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
       })
     },
     fragmentDeps: {
-      llmCall: createTypedCaller(agents.fragmenter, fragmentationSchema),
+      llmCall: withTypedUsage(fragmentationSchema, {
+        agent: agents.fragmenter,
+        record: recordUsage,
+        context: () => ({
+          stage: 'fragment',
+          jobId: job.jobId,
+          entryKey: job.entryKey,
+          sourceClient,
+          model: modelForAgent(openRouterConfig, 'fragmenter'),
+        }),
+      }),
       emitEvent,
     },
     entityExtractDeps: {
@@ -170,7 +243,17 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
           aliases: r.aliases ?? [],
         }))
       },
-      llmCall: createTypedCaller(agents.entityExtractor, peopleExtractionSchema),
+      llmCall: withTypedUsage(peopleExtractionSchema, {
+        agent: agents.entityExtractor,
+        record: recordUsage,
+        context: () => ({
+          stage: 'capture',
+          jobId: job.jobId,
+          entryKey: job.entryKey,
+          sourceClient,
+          model: modelForAgent(openRouterConfig, 'entityExtractor'),
+        }),
+      }),
       emitEvent,
       config: DEFAULT_RESOLUTION_CONFIG,
       makePeopleKey: () => makeLookupKey('person'),
@@ -178,6 +261,25 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
     persistDeps: {
       openRouterConfig,
       emitEvent,
+      // Phase A3 — embedding cost telemetry. The OpenRouter embedding
+      // endpoint does not return token counts; estimate from input chars
+      // (~4 chars/token rule of thumb). Stage='embed', fragmentKey set so
+      // /admin/diagnose can correlate per-fragment.
+      onEmbedUsage: async (info) => {
+        const estTokens = Math.ceil(info.inputChars / 4)
+        await emitUsageEvent(db as never, {
+          entryKey: job.entryKey,
+          fragmentKey: info.fragmentKey,
+          sourceClient,
+          stage: 'embed',
+          model: openRouterConfig.models.embedding,
+          promptTokens: estTokens,
+          completionTokens: 0,
+          durationMs: info.durationMs,
+          jobId: job.jobId,
+          metadata: { inputChars: info.inputChars, success: info.success, estimated: true },
+        })
+      },
       insertEntry: async (entry) => {
         const e = entry as Record<string, unknown>
         const content = (e.content as string) ?? ''
@@ -388,6 +490,7 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
 
   const openRouterConfig = await loadOpenRouterConfig()
   const agents = createIngestAgents(openRouterConfig)
+  const recordUsage = buildUsageRecorder()
 
   const deps: LinkingOrchestratorDeps = {
     fragmentLock,
@@ -437,14 +540,47 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
           .limit(1)
         return row?.name ?? null
       },
-      llmCall: createTypedCaller(agents.wikiClassifier, wikiClassificationSchema),
+      llmCall: withTypedUsage(wikiClassificationSchema, {
+        agent: agents.wikiClassifier,
+        record: recordUsage,
+        context: () => ({
+          stage: 'classify',
+          jobId: job.jobId,
+          entryKey: job.entryKey,
+          fragmentKey: job.fragmentKey,
+          model: modelForAgent(openRouterConfig, 'wikiClassifier'),
+        }),
+      }),
       emitEvent,
     },
     fragRelateDeps: {
       vectorSearch: async (content, limit) => {
+        const tEmbed0 = performance.now()
         const vec = await embedText(content, {
           apiKey: openRouterConfig.apiKey,
           model: openRouterConfig.models.embedding,
+        })
+        const embedMs = Math.round(performance.now() - tEmbed0)
+        // Phase A3 — embedding cost telemetry for the link path's
+        // vector-search probe. Stage='embed', token count estimated
+        // from input chars (~4 chars/token).
+        await emitUsageEvent(db as never, {
+          entryKey: job.entryKey,
+          fragmentKey: job.fragmentKey,
+          stage: 'embed',
+          model: openRouterConfig.models.embedding,
+          promptTokens: Math.ceil(content.length / 4),
+          completionTokens: 0,
+          durationMs: embedMs,
+          jobId: job.jobId,
+          metadata: {
+            inputChars: content.length,
+            success: vec !== null,
+            estimated: true,
+            substage: 'link-vectorsearch',
+          },
+        }).catch(() => {
+          // Cost-logging must not block the link worker.
         })
         if (!vec) return []
         const rows = await db
@@ -463,7 +599,17 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
           .limit(1)
         return row?.title ?? null
       },
-      llmCall: createTypedCaller(agents.fragScorer, fragmentRelevanceSchema),
+      llmCall: withTypedUsage(fragmentRelevanceSchema, {
+        agent: agents.fragScorer,
+        record: recordUsage,
+        context: () => ({
+          stage: 'classify',
+          jobId: job.jobId,
+          entryKey: job.entryKey,
+          fragmentKey: job.fragmentKey,
+          model: modelForAgent(openRouterConfig, 'fragScorer'),
+        }),
+      }),
       emitEvent,
     },
     insertEdge: async (edge: Record<string, unknown>) => {

--- a/core/src/routes/admin.ts
+++ b/core/src/routes/admin.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { eq, inArray, or, sql } from 'drizzle-orm'
 import type { LinkJob } from '@robin/queue'
 import { db } from '../db/client.js'
-import { fragments, entries, auditLog, pipelineEvents } from '../db/schema.js'
+import { fragments, entries, auditLog, pipelineEvents, usageEvents } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
 import { logger } from '../lib/logger.js'
 import { sessionMiddleware } from '../middleware/session.js'
@@ -175,6 +175,45 @@ adminRoutes.get('/diagnose/:entryKey', async (c) => {
           .where(inArray(fragments.lookupKey, fragmentKeys))
       : []
 
+  // Phase A3 — usage_events rows for the same job_ids and entry_key.
+  // Surfaces alongside pipeline_events so an operator can see "this
+  // capture cost $0.0023 across 4 stages" in one place.
+  const usageRows = await db
+    .select()
+    .from(usageEvents)
+    .where(
+      or(
+        eq(usageEvents.entryKey, entryKey),
+        jobIds.length
+          ? sql`${usageEvents.jobId} = ANY(ARRAY[${sql.join(
+              jobIds.map((j) => sql`${j}`),
+              sql`, `
+            )}])`
+          : sql`false`,
+      ),
+    )
+    .orderBy(sql`${usageEvents.createdAt} DESC`)
+    .limit(500)
+
+  const usageTotals = usageRows.reduce(
+    (acc, r) => {
+      acc.totalTokens += r.totalTokens
+      acc.costUsdMicros += r.costUsdMicros
+      acc.byStage[r.stage] = acc.byStage[r.stage] ?? {
+        totalTokens: 0,
+        costUsdMicros: 0,
+      }
+      acc.byStage[r.stage].totalTokens += r.totalTokens
+      acc.byStage[r.stage].costUsdMicros += r.costUsdMicros
+      return acc
+    },
+    {
+      totalTokens: 0,
+      costUsdMicros: 0,
+      byStage: {} as Record<string, { totalTokens: number; costUsdMicros: number }>,
+    },
+  )
+
   return c.json({
     entryKey,
     entry: entryRow
@@ -193,6 +232,11 @@ adminRoutes.get('/diagnose/:entryKey', async (c) => {
       ...r,
       createdAt: r.createdAt.toISOString(),
     })),
+    usageEvents: usageRows.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+    })),
+    usageTotals,
     fragments: fragmentRows.map((r) => ({
       lookupKey: r.lookupKey,
       slug: r.slug,

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -7,7 +7,7 @@ import { computeContentHash, findDuplicateFragment } from '../db/dedup.js'
 import { applyFragmentTitleDatePrefix } from '../lib/fragmentTitlePrefix.js'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { fragments, entries, edges, wikis, people } from '../db/schema.js'
+import { fragments, entries, edges, wikis, people, edits, auditLog } from '../db/schema.js'
 import { producer } from '../queue/producer.js'
 import { logger } from '../lib/logger.js'
 import { validationHook } from '../lib/validation.js'
@@ -517,6 +517,110 @@ fragmentsRouter.post('/:id/reject', zValidator('json', fragmentReviewBodySchema,
   }
 
   return c.json({ ok: true, fragmentId: id, wikiId })
+})
+
+// ── GET /fragments/:id/history ─────────────────────────────────────────────
+//
+// Phase A5 — read side of the fragment evolution surface (Stream F4
+// renders this on the fragment detail page). Returns:
+//   - edits: rows from the `edits` table where object_type='fragment'
+//     and object_id=:id, ordered by editedAt desc
+//   - auditEvents: audit_log rows for the same fragment (entity_type
+//     ='fragment', entity_id=:id) so the timeline carries the
+//     classification / acceptance / deletion events alongside content
+//     edits
+//
+// The write side (creating `edits` rows on PUT /fragments/:id) is
+// owned by Stream D1' and lands later. Until that ships this endpoint
+// returns an empty `edits` array gracefully, the audit_log block still
+// renders the lifecycle events that already get written today
+// (created / classified / accepted / rejected / deleted).
+//
+// Auth: standard session via the router-wide sessionMiddleware. Single
+// tenant means "operator-only" is the same as "session-authenticated".
+fragmentsRouter.get('/:id/history', async (c) => {
+  const id = c.req.param('id')
+
+  // Verify the fragment exists; return 404 otherwise so the client
+  // does not render a timeline for a phantom row.
+  const [fragment] = await db
+    .select({ lookupKey: fragments.lookupKey })
+    .from(fragments)
+    .where(eq(fragments.lookupKey, id))
+    .limit(1)
+  if (!fragment) return c.json({ error: 'Fragment not found' }, 404)
+
+  // Pagination: cursor by editedAt desc. Plan asks for >50 rows to be
+  // rare but cheap to support; we accept ?cursor=<iso> and ?limit=
+  // (clamped 1..200, default 50).
+  const rawLimit = Number(c.req.query('limit') ?? '50')
+  const limit = Math.max(1, Math.min(200, Number.isFinite(rawLimit) ? rawLimit : 50))
+  const cursorIso = c.req.query('cursor')
+  const cursorDate = cursorIso ? new Date(cursorIso) : null
+
+  // edits table read. cursorDate restricts to rows strictly older than
+  // the cursor so the next page lines up without duplicate boundary
+  // rows. When the cursor is invalid (NaN) we just ignore it; the
+  // first page is the intended fallback.
+  const editRows = await db
+    .select({
+      id: edits.id,
+      type: edits.type,
+      content: edits.content,
+      source: edits.source,
+      diff: edits.diff,
+      editedAt: edits.timestamp,
+    })
+    .from(edits)
+    .where(
+      and(
+        eq(edits.objectType, 'fragment'),
+        eq(edits.objectId, id),
+        cursorDate && !Number.isNaN(cursorDate.getTime())
+          ? sql`${edits.timestamp} < ${cursorDate.toISOString()}`
+          : sql`true`,
+      ),
+    )
+    .orderBy(desc(edits.timestamp))
+    .limit(limit)
+
+  // audit_log read. Only the rows whose entity_type/entity_id matches;
+  // we deliberately do NOT pull in detail.fragmentKey-shaped rows
+  // because that scan requires JSONB containment over the full audit
+  // table and the volume does not justify it for the timeline view.
+  // Entries whose detail block carries a fragmentKey are surfaced via
+  // /admin/diagnose, not this endpoint.
+  const auditRows = await db
+    .select()
+    .from(auditLog)
+    .where(
+      and(
+        eq(auditLog.entityType, 'fragment'),
+        eq(auditLog.entityId, id),
+      ),
+    )
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit)
+
+  return c.json({
+    fragmentId: id,
+    edits: editRows.map((r) => ({
+      id: r.id,
+      type: r.type,
+      content: r.content,
+      source: r.source,
+      diff: r.diff,
+      editedAt: r.editedAt.toISOString(),
+    })),
+    auditEvents: auditRows.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+    })),
+    nextCursor:
+      editRows.length === limit
+        ? editRows[editRows.length - 1].editedAt.toISOString()
+        : null,
+  })
 })
 
 export { fragmentsRouter as fragmentsRoutes }

--- a/core/src/routes/settings.ts
+++ b/core/src/routes/settings.ts
@@ -1,0 +1,185 @@
+import { Hono } from 'hono'
+import { eq, sql, gte } from 'drizzle-orm'
+import { z } from 'zod'
+import { zValidator } from '@hono/zod-validator'
+import { db } from '../db/client.js'
+import { appSettings, usageEvents } from '../db/schema.js'
+import { sessionMiddleware } from '../middleware/session.js'
+import { logger } from '../lib/logger.js'
+import { validationHook } from '../lib/validation.js'
+
+const log = logger.child({ component: 'settings' })
+
+export const settingsRoutes = new Hono()
+settingsRoutes.use('*', sessionMiddleware)
+
+// ── Budget caps ────────────────────────────────────────────────────────────
+//
+// Phase A4 — three budget caps live in app_settings: regen / embed /
+// classify. Each is stored as a JSONB blob `{ "limit_usd_micros": int }`
+// so the column shape is uniform across all settings (future caps can
+// add fields without a schema change). Defaults pick sane low values
+// for v0.2.0 dogfood; operators raise them via the spend page.
+
+const BUDGET_KEYS = ['budget_regen', 'budget_embed', 'budget_classify'] as const
+type BudgetKey = (typeof BUDGET_KEYS)[number]
+
+// Default caps in USD micros (1e-6 USD). 5,000,000 micros = $5.00 / month.
+const BUDGET_DEFAULTS: Record<BudgetKey, number> = {
+  budget_regen: 10_000_000, // $10
+  budget_embed: 1_000_000, // $1
+  budget_classify: 5_000_000, // $5
+}
+
+interface BudgetValue {
+  limit_usd_micros: number
+}
+
+const budgetSchema = z.object({
+  limit_usd_micros: z.number().int().min(0).max(1_000_000_000_000),
+})
+
+async function loadBudget(key: BudgetKey): Promise<number> {
+  const [row] = await db
+    .select({ value: appSettings.value })
+    .from(appSettings)
+    .where(eq(appSettings.key, key))
+    .limit(1)
+  if (!row) return BUDGET_DEFAULTS[key]
+  const v = row.value as BudgetValue | null
+  if (!v || typeof v.limit_usd_micros !== 'number') return BUDGET_DEFAULTS[key]
+  return v.limit_usd_micros
+}
+
+// ── GET /settings/spend ────────────────────────────────────────────────────
+//
+// Returns:
+//   - this-month cost rollup by stage (capture / fragment / classify / regen / embed)
+//   - configured budget caps for the three caps the user can edit
+//   - placeholder outstanding-work (Round 2 D-wave fragment-relationship
+//     backfill cron lands later; A4 reserves the surface so the UI can
+//     ship now)
+settingsRoutes.get('/spend', async (c) => {
+  // First day of current month (UTC) so the rollup matches a calendar
+  // month boundary the user can verify against the OpenRouter ledger.
+  const now = new Date()
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+
+  const stageRows = (await db.execute(
+    sql`SELECT stage,
+               COALESCE(SUM(cost_usd_micros), 0)::bigint AS cost_usd_micros,
+               COALESCE(SUM(total_tokens), 0)::bigint AS total_tokens,
+               COUNT(*)::int AS event_count
+        FROM usage_events
+        WHERE created_at >= ${monthStart.toISOString()}::timestamp
+        GROUP BY stage
+        ORDER BY stage`
+  )) as Array<{
+    stage: string
+    cost_usd_micros: string | number
+    total_tokens: string | number
+    event_count: number
+  }>
+
+  const byStage = stageRows.map((r) => ({
+    stage: r.stage,
+    costUsdMicros: Number(r.cost_usd_micros),
+    totalTokens: Number(r.total_tokens),
+    eventCount: r.event_count,
+  }))
+
+  const totalCostUsdMicros = byStage.reduce((acc, r) => acc + r.costUsdMicros, 0)
+  const totalTokens = byStage.reduce((acc, r) => acc + r.totalTokens, 0)
+
+  const [regenBudget, embedBudget, classifyBudget] = await Promise.all([
+    loadBudget('budget_regen'),
+    loadBudget('budget_embed'),
+    loadBudget('budget_classify'),
+  ])
+
+  return c.json({
+    rangeStart: monthStart.toISOString(),
+    rangeEnd: now.toISOString(),
+    totalCostUsdMicros,
+    totalTokens,
+    byStage,
+    budgets: {
+      regen: { limitUsdMicros: regenBudget },
+      embed: { limitUsdMicros: embedBudget },
+      classify: { limitUsdMicros: classifyBudget },
+    },
+    // Outstanding-work placeholder. Populated by Round 2 D-wave when the
+    // fragment-relationship backfill cron lands; for now the UI just
+    // reserves the section.
+    outstanding: {
+      fragmentRelationshipBackfillQueueDepth: null,
+      lastCronRunAt: null,
+    },
+  })
+})
+
+// ── PUT /settings/budgets/:kind ────────────────────────────────────────────
+//
+// Edit one of the three caps. Body: `{ "limit_usd_micros": int }`. Stored
+// in app_settings under key `budget_<kind>` so the resolver can read it
+// without a separate table.
+settingsRoutes.put(
+  '/budgets/:kind',
+  zValidator('json', budgetSchema, validationHook),
+  async (c) => {
+    const kindParam = c.req.param('kind')
+    const key = `budget_${kindParam}` as BudgetKey
+    if (!BUDGET_KEYS.includes(key)) {
+      return c.json({ error: 'Unknown budget kind' }, 400)
+    }
+    const body = c.req.valid('json')
+    await db
+      .insert(appSettings)
+      .values({
+        key,
+        value: { limit_usd_micros: body.limit_usd_micros } satisfies BudgetValue,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: appSettings.key,
+        set: {
+          value: { limit_usd_micros: body.limit_usd_micros } satisfies BudgetValue,
+          updatedAt: new Date(),
+        },
+      })
+    log.info({ kind: kindParam, limit_usd_micros: body.limit_usd_micros }, 'budget updated')
+    return c.json({
+      kind: kindParam,
+      limitUsdMicros: body.limit_usd_micros,
+    })
+  },
+)
+
+// ── GET /settings/spend/recent ─────────────────────────────────────────────
+//
+// Returns the last N usage_events rows (default 50, max 200) for the
+// /settings/spend page's recent-activity table. Mirrors what /admin/diagnose
+// surfaces but unscoped to a single entryKey.
+settingsRoutes.get('/spend/recent', async (c) => {
+  const rawLimit = Number(c.req.query('limit') ?? '50')
+  const limit = Math.max(1, Math.min(200, Number.isFinite(rawLimit) ? rawLimit : 50))
+  const sinceQuery = c.req.query('since')
+  // Default window: 30 days. The page's "this month" rollup is computed
+  // separately; the recent-activity table just wants a wide enough
+  // window that the user always sees a few rows.
+  const since = sinceQuery
+    ? new Date(sinceQuery)
+    : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const rows = await db
+    .select()
+    .from(usageEvents)
+    .where(gte(usageEvents.createdAt, since))
+    .orderBy(sql`${usageEvents.createdAt} DESC`)
+    .limit(limit)
+  return c.json({
+    items: rows.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+    })),
+  })
+})

--- a/packages/agent/src/agents/caller.ts
+++ b/packages/agent/src/agents/caller.ts
@@ -2,7 +2,7 @@
  * Typed caller factory for Mastra agents.
  *
  * Creates DI-friendly functions backed by Mastra agents. Stages receive these
- * as deps — they never import Agent directly, keeping Mastra as an
+ * as deps, they never import Agent directly, keeping Mastra as an
  * implementation detail and tests simple (mock the function, return typed data).
  *
  * Retry contract:
@@ -27,7 +27,7 @@ export const AGENT_RETRY_CONFIG = {
  * Sonnet 4.6 supports 16k output tokens; the OpenRouter SDK default is
  * ~4096, which silently truncated long wiki regen output (issue #257).
  * Raising the cap globally is safe because shorter prompts simply finish
- * sooner — the cap is an upper bound, not a target length.
+ * sooner, the cap is an upper bound, not a target length.
  */
 export const AGENT_MAX_OUTPUT_TOKENS = 16000
 
@@ -36,6 +36,88 @@ export const AGENT_MODEL_SETTINGS = {
   maxRetries: AGENT_RETRY_CONFIG.maxRetries,
   maxOutputTokens: AGENT_MAX_OUTPUT_TOKENS,
 } as const
+
+/**
+ * Telemetry context passed to a usage recorder. Phase A3: every OpenRouter
+ * call writes one usage_events row keyed by job_id so cost correlates with
+ * pipeline_events for the same job.
+ */
+export interface UsageContext {
+  /** Pipeline stage (capture | fragment | classify | regen | embed). */
+  stage: string
+  /** BullMQ job id, correlates to pipeline_events.job_id. */
+  jobId?: string | null
+  entryKey?: string | null
+  wikiKey?: string | null
+  fragmentKey?: string | null
+  userId?: string | null
+  sourceClient?: string | null
+  /** Model id (e.g. 'anthropic/claude-sonnet-4.6'). */
+  model: string
+}
+
+/**
+ * Token counts surfaced by Mastra's `result.usage`. Provider names vary
+ * (some report `prompt_tokens`, some `inputTokens`); the wrap helper
+ * normalises both shapes before invoking the recorder.
+ */
+export interface UsageRecord {
+  promptTokens: number
+  completionTokens: number
+  durationMs: number
+  /** Optional extra detail (retry count, model fallback, etc.). */
+  metadata?: Record<string, unknown>
+}
+
+/** Recorder function. Implementations live in core (DB access required). */
+export type UsageRecorder = (
+  context: UsageContext,
+  record: UsageRecord
+) => Promise<void> | void
+
+/**
+ * Pull `result.usage` into a normalised shape. Mastra and the OpenRouter
+ * SDK each surface different field names depending on version; this
+ * helper consolidates them so the recorder always sees the same keys.
+ *
+ * Returns null when no usage info is present (older provider responses,
+ * or a structured-output retry that the SDK swallowed).
+ */
+function extractUsage(result: unknown): {
+  promptTokens: number
+  completionTokens: number
+} | null {
+  if (!result || typeof result !== 'object') return null
+  const usage = (result as { usage?: Record<string, unknown> }).usage
+  if (!usage || typeof usage !== 'object') return null
+  // Mastra (newer): { inputTokens, outputTokens }
+  // OpenRouter SDK: { prompt_tokens, completion_tokens, total_tokens }
+  // Anthropic native: { input_tokens, output_tokens }
+  const promptTokens = Number(
+    usage.promptTokens ??
+      usage.prompt_tokens ??
+      usage.inputTokens ??
+      usage.input_tokens ??
+      0
+  )
+  const completionTokens = Number(
+    usage.completionTokens ??
+      usage.completion_tokens ??
+      usage.outputTokens ??
+      usage.output_tokens ??
+      0
+  )
+  if (!Number.isFinite(promptTokens) || !Number.isFinite(completionTokens)) {
+    return null
+  }
+  return { promptTokens, completionTokens }
+}
+
+/**
+ * Default no-op recorder. Tests and contexts that do not pass a recorder
+ * (legacy callers, fixtures) still work; cost is simply not logged.
+ */
+const noopRecorder: UsageRecorder = () => {}
 
 /**
  * Creates a typed caller for structured JSON output.
@@ -54,7 +136,7 @@ export function createTypedCaller<T>(agent: Agent, schema: ZodType<T>) {
 
 /**
  * Creates a string caller for free-form text output (wiki regen, person synthesis).
- * No schema validation — returns the raw text response.
+ * No schema validation, returns the raw text response.
  */
 export function createStringCaller(agent: Agent) {
   return async (system: string, user: string): Promise<string> => {
@@ -62,6 +144,93 @@ export function createStringCaller(agent: Agent) {
       system,
       modelSettings: AGENT_MODEL_SETTINGS,
     })
+    return result.text
+  }
+}
+
+/**
+ * withUsage — Phase A3 cost telemetry decorator.
+ *
+ * Wraps a typed or string caller with usage-event emission. The wrapped
+ * function captures `result.usage` from `agent.generate()`, normalises
+ * the token counts, and hands them to `recordUsage()` along with the
+ * caller-supplied context. Errors during recording are swallowed so
+ * cost-logging failures never block the LLM result.
+ *
+ * Usage:
+ *   const fragCall = withUsage(
+ *     createTypedCaller(agents.fragmenter, fragmentationSchema),
+ *     {
+ *       agent: agents.fragmenter,
+ *       context: () => ({ stage: 'fragment', jobId, entryKey, model: 'gemini' }),
+ *       record: emitUsageEvent,
+ *     },
+ *   )
+ *
+ * The context callback is invoked PER CALL so streaming-fragment paths
+ * can stamp each fragment's lookupKey on its own row.
+ */
+export interface WithUsageOptions {
+  /** Mastra agent so we can re-issue agent.generate() and capture usage. */
+  agent: Agent
+  /** Per-call context resolver (jobId, entryKey, etc. evolve as fragments stream). */
+  context: () => UsageContext
+  /** DB recorder, supplied by core. Falls back to noop when undefined. */
+  record?: UsageRecorder
+}
+
+export function withTypedUsage<T>(
+  schema: ZodType<T>,
+  options: WithUsageOptions,
+): (system: string, user: string) => Promise<T> {
+  const recorder = options.record ?? noopRecorder
+  return async (system, user) => {
+    const t0 = performance.now()
+    const result = await options.agent.generate(user, {
+      system,
+      structuredOutput: { schema },
+      modelSettings: AGENT_MODEL_SETTINGS,
+    })
+    const durationMs = Math.round(performance.now() - t0)
+    const usage = extractUsage(result)
+    if (usage) {
+      try {
+        await recorder(options.context(), {
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          durationMs,
+        })
+      } catch {
+        // Cost-logging must not block the LLM result. Swallow.
+      }
+    }
+    return result.object as T
+  }
+}
+
+export function withStringUsage(
+  options: WithUsageOptions,
+): (system: string, user: string) => Promise<string> {
+  const recorder = options.record ?? noopRecorder
+  return async (system, user) => {
+    const t0 = performance.now()
+    const result = await options.agent.generate(user, {
+      system,
+      modelSettings: AGENT_MODEL_SETTINGS,
+    })
+    const durationMs = Math.round(performance.now() - t0)
+    const usage = extractUsage(result)
+    if (usage) {
+      try {
+        await recorder(options.context(), {
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          durationMs,
+        })
+      } catch {
+        // see withTypedUsage
+      }
+    }
     return result.text
   }
 }

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -4,6 +4,14 @@
 export {
   createTypedCaller,
   createStringCaller,
+  withTypedUsage,
+  withStringUsage,
   AGENT_RETRY_CONFIG,
   AGENT_MODEL_SETTINGS,
+} from './caller.js'
+export type {
+  UsageContext,
+  UsageRecord,
+  UsageRecorder,
+  WithUsageOptions,
 } from './caller.js'

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -46,6 +46,14 @@ export type { IngestAgents } from './agent-factory.js'
 export {
   createTypedCaller,
   createStringCaller,
+  withTypedUsage,
+  withStringUsage,
   AGENT_RETRY_CONFIG,
   AGENT_MODEL_SETTINGS,
+} from './agents/caller.js'
+export type {
+  UsageContext,
+  UsageRecord,
+  UsageRecorder,
+  WithUsageOptions,
 } from './agents/caller.js'

--- a/packages/agent/src/stages/persist.ts
+++ b/packages/agent/src/stages/persist.ts
@@ -109,7 +109,24 @@ export async function persist(
     model: deps.openRouterConfig.models.embedding,
   }
   const vectors = await Promise.all(
-    input.fragments.map((frag) => embedText(frag.content, embedConfig))
+    input.fragments.map(async (frag, i) => {
+      const t0 = performance.now()
+      const vec = await embedText(frag.content, embedConfig)
+      const durationMs = Math.round(performance.now() - t0)
+      if (deps.onEmbedUsage) {
+        try {
+          await deps.onEmbedUsage({
+            fragmentKey: fragmentKeys[i],
+            inputChars: frag.content.length,
+            durationMs,
+            success: vec !== null,
+          })
+        } catch {
+          // Cost-logging must not block the persist path.
+        }
+      }
+      return vec
+    })
   )
   await Promise.all(
     vectors.map((vec, i) =>

--- a/packages/agent/src/stages/types.ts
+++ b/packages/agent/src/stages/types.ts
@@ -130,6 +130,18 @@ export interface PersistDeps {
   mergePersonAliases: (personKey: string, newAliases: string[]) => Promise<void>
   /** Optional callback fired after a new person is created (for audit logging). */
   onPersonCreated?: (personKey: string, name: string) => void
+  /**
+   * Optional Phase A3 hook. Fired once per embedText call inside persist
+   * with the input length and elapsed time so core can write a
+   * usage_events row with stage='embed'. Per-fragment context (fragmentKey)
+   * is available because the loop knows which fragment each vector is for.
+   */
+  onEmbedUsage?: (info: {
+    fragmentKey: string
+    inputChars: number
+    durationMs: number
+    success: boolean
+  }) => Promise<void> | void
   emitEvent: EmitEvent
   openRouterConfig: OpenRouterConfig
 }

--- a/wiki/src/app/settings/spend/page.tsx
+++ b/wiki/src/app/settings/spend/page.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import { useEffect, useState, type CSSProperties } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { T, FONT } from "@/lib/typography";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { AuthGuard } from "@/components/AuthGuard";
+
+// ── Types ────────────────────────────────────────────────────────────────
+//
+// Mirrors GET /settings/spend in core/src/routes/settings.ts. Kept inline
+// rather than threaded through the generated SDK because the openapi
+// manifest regen lives in a separate phase and we do not want to
+// regenerate the whole SDK for one new endpoint.
+
+interface SpendStageRollup {
+  stage: string;
+  costUsdMicros: number;
+  totalTokens: number;
+  eventCount: number;
+}
+
+interface SpendBudget {
+  limitUsdMicros: number;
+}
+
+interface SpendResponse {
+  rangeStart: string;
+  rangeEnd: string;
+  totalCostUsdMicros: number;
+  totalTokens: number;
+  byStage: SpendStageRollup[];
+  budgets: {
+    regen: SpendBudget;
+    embed: SpendBudget;
+    classify: SpendBudget;
+  };
+  outstanding: {
+    fragmentRelationshipBackfillQueueDepth: number | null;
+    lastCronRunAt: string | null;
+  };
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  capture: "Capture",
+  fragment: "Fragmentation",
+  classify: "Classification",
+  regen: "Regeneration",
+  embed: "Embedding",
+  search: "Search",
+};
+
+const STAGE_ORDER = ["capture", "fragment", "classify", "regen", "embed", "search"];
+
+const BUDGET_KINDS: Array<{
+  key: "regen" | "embed" | "classify";
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "regen",
+    label: "Regen budget",
+    description: "Monthly cap on wiki-regeneration spend.",
+  },
+  {
+    key: "embed",
+    label: "Embed budget",
+    description: "Monthly cap on embedding spend (capture + retry path).",
+  },
+  {
+    key: "classify",
+    label: "Classify budget",
+    description: "Monthly cap on classification spend (link worker).",
+  },
+];
+
+const sectionLabel: CSSProperties = {
+  ...T.micro,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "var(--wiki-count)",
+  margin: 0,
+};
+
+const bodyText: CSSProperties = {
+  ...T.bodySmall,
+  color: "var(--heading-secondary)",
+  margin: 0,
+};
+
+const bodySmallText: CSSProperties = {
+  ...T.micro,
+  color: "var(--heading-secondary)",
+  margin: 0,
+};
+
+const titleText: CSSProperties = {
+  ...T.body,
+  fontWeight: 500,
+  color: "var(--heading-color)",
+  margin: 0,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Render USD micros as a dollar string with 4 decimal places. */
+function formatUsd(micros: number): string {
+  const usd = micros / 1_000_000;
+  if (usd >= 100) return `$${usd.toFixed(2)}`;
+  if (usd >= 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(4)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export default function SpendPage() {
+  const router = useRouter();
+  const [data, setData] = useState<SpendResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Local edit state for the three caps. Stored as input strings (USD)
+  // so the form does not flicker while the user is typing.
+  const [budgetEdits, setBudgetEdits] = useState<Record<string, string>>({});
+  const [savingKind, setSavingKind] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/settings/spend", { credentials: "include" });
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const body = (await res.json()) as SpendResponse;
+      setData(body);
+      setError(null);
+      setBudgetEdits({
+        regen: (body.budgets.regen.limitUsdMicros / 1_000_000).toString(),
+        embed: (body.budgets.embed.limitUsdMicros / 1_000_000).toString(),
+        classify: (body.budgets.classify.limitUsdMicros / 1_000_000).toString(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load spend");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const saveBudget = async (kind: "regen" | "embed" | "classify") => {
+    const raw = budgetEdits[kind] ?? "";
+    const usd = Number(raw);
+    if (!Number.isFinite(usd) || usd < 0) {
+      setSaveError(`Invalid ${kind} budget`);
+      return;
+    }
+    setSavingKind(kind);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/settings/budgets/${kind}`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ limit_usd_micros: Math.round(usd * 1_000_000) }),
+      });
+      if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+      await refresh();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSavingKind(null);
+    }
+  };
+
+  // Sort stages by canonical order so the UI is stable across reloads
+  // even when one stage has zero events this month.
+  const sortedStages = data?.byStage
+    ? [...data.byStage].sort(
+        (a, b) =>
+          STAGE_ORDER.indexOf(a.stage) - STAGE_ORDER.indexOf(b.stage),
+      )
+    : [];
+
+  // Bar widths are scaled to the largest stage so the visual is honest
+  // even for low-volume months.
+  const maxStageCost = sortedStages.reduce(
+    (acc, r) => Math.max(acc, r.costUsdMicros),
+    0,
+  );
+
+  return (
+    <AuthGuard>
+      <div className="min-h-screen overflow-y-auto bg-background text-foreground">
+        <div className="mx-auto max-w-[780px] px-10 pt-12 pb-20">
+          <button
+            type="button"
+            onClick={() => router.push("/profile")}
+            className="mb-6 -ml-2 flex cursor-pointer items-center gap-1.5 border-none bg-transparent px-2"
+            style={{ ...T.bodySmall, color: "var(--wiki-count)" }}
+          >
+            <ArrowLeft className="size-4" strokeWidth={1.5} />
+            Back to profile
+          </button>
+
+          <h1
+            style={{
+              ...T.h1,
+              fontFamily: FONT.SERIF,
+              color: "var(--heading-color)",
+              margin: 0,
+            }}
+          >
+            Spend
+          </h1>
+          <p style={{ ...bodyText, marginTop: 4 }}>
+            Cost this month, broken down by pipeline stage. Edit budget caps
+            below.
+          </p>
+
+          {loading ? (
+            <div className="flex justify-center py-16">
+              <Spinner className="size-5" />
+            </div>
+          ) : error ? (
+            <p style={{ ...T.micro, color: "var(--destructive)", marginTop: 24 }}>
+              {error}
+            </p>
+          ) : data ? (
+            <>
+              {/* This-month total */}
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>This month</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent>
+                    <div className="flex items-end justify-between">
+                      <div>
+                        <p
+                          style={{
+                            ...T.h1,
+                            fontFamily: FONT.SERIF,
+                            color: "var(--heading-color)",
+                            margin: 0,
+                          }}
+                        >
+                          {formatUsd(data.totalCostUsdMicros)}
+                        </p>
+                        <p style={{ ...bodySmallText, marginTop: 4 }}>
+                          {formatTokens(data.totalTokens)} tokens since{" "}
+                          {new Date(data.rangeStart).toLocaleDateString(
+                            "en-US",
+                            { month: "short", day: "numeric" },
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </section>
+
+              {/* Stage breakdown */}
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>By stage</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent>
+                    {sortedStages.length === 0 ? (
+                      <p style={bodySmallText}>
+                        No usage events recorded yet. Capture a thought to
+                        seed the dashboard.
+                      </p>
+                    ) : (
+                      <div className="flex flex-col gap-3">
+                        {sortedStages.map((row) => {
+                          const widthPct =
+                            maxStageCost > 0
+                              ? Math.max(
+                                  2,
+                                  Math.round((row.costUsdMicros / maxStageCost) * 100),
+                                )
+                              : 0;
+                          return (
+                            <div key={row.stage}>
+                              <div className="flex items-baseline justify-between gap-3">
+                                <span style={titleText}>
+                                  {STAGE_LABELS[row.stage] ?? row.stage}
+                                </span>
+                                <span
+                                  style={{
+                                    ...T.micro,
+                                    color: "var(--wiki-count)",
+                                  }}
+                                >
+                                  {formatUsd(row.costUsdMicros)}{" "}
+                                  <span style={{ opacity: 0.6 }}>
+                                    {formatTokens(row.totalTokens)} tok ·{" "}
+                                    {row.eventCount} events
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                style={{
+                                  marginTop: 4,
+                                  height: 6,
+                                  background: "var(--muted)",
+                                }}
+                              >
+                                <div
+                                  style={{
+                                    height: 6,
+                                    width: `${widthPct}%`,
+                                    background:
+                                      "color-mix(in srgb, var(--heading-color) 60%, transparent)",
+                                  }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </section>
+
+              {/* Budget caps */}
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>Budget caps</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent>
+                    <p style={bodySmallText}>
+                      Caps are advisory for v0.2.0. Wiring caps into the
+                      worker scheduler lands in a follow-up.
+                    </p>
+                    <div
+                      className="mt-4 flex flex-col gap-4"
+                      style={{ display: "flex", flexDirection: "column" }}
+                    >
+                      {BUDGET_KINDS.map((kind) => (
+                        <div key={kind.key} className="flex flex-col gap-1">
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="min-w-0">
+                              <p style={titleText}>{kind.label}</p>
+                              <p style={{ ...bodySmallText, marginTop: 2 }}>
+                                {kind.description}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-2">
+                              <span
+                                style={{
+                                  ...T.micro,
+                                  color: "var(--wiki-count)",
+                                }}
+                              >
+                                $
+                              </span>
+                              <Input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={budgetEdits[kind.key] ?? ""}
+                                onChange={(e) =>
+                                  setBudgetEdits((prev) => ({
+                                    ...prev,
+                                    [kind.key]: e.target.value,
+                                  }))
+                                }
+                                style={{ width: 120 }}
+                              />
+                              <Button
+                                type="button"
+                                size="sm"
+                                onClick={() => void saveBudget(kind.key)}
+                                disabled={savingKind === kind.key}
+                              >
+                                <span style={T.buttonSmall}>
+                                  {savingKind === kind.key
+                                    ? "Saving..."
+                                    : "Save"}
+                                </span>
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    {saveError && (
+                      <p
+                        style={{
+                          ...T.micro,
+                          color: "var(--destructive)",
+                          marginTop: 8,
+                        }}
+                      >
+                        {saveError}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </section>
+
+              {/* Outstanding work placeholder */}
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>Outstanding work</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent>
+                    <p style={bodySmallText}>
+                      Fragment-relationship backfill and last-cron-run
+                      timestamps land in a follow-up wave. This section is
+                      reserved for that surface.
+                    </p>
+                    <dl className="mt-3 flex flex-col gap-1.5">
+                      <Row
+                        label="Fragment relationship backfill queue"
+                        value={
+                          data.outstanding.fragmentRelationshipBackfillQueueDepth ?? "—"
+                        }
+                      />
+                      <Row
+                        label="Last cron run"
+                        value={data.outstanding.lastCronRunAt ?? "—"}
+                      />
+                    </dl>
+                  </CardContent>
+                </Card>
+              </section>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span style={bodySmallText}>{label}</span>
+      <span style={{ ...T.micro, color: "var(--heading-color)" }}>
+        {value}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stream A finish for the v0.2.0 ship. Closes the cost-observability and edit-history surfaces.

Plan: `.planning/v1-a-game/streams/A-foundations/PLAN.md` phases A3, A4, A5. Tracker: #282.

## What ships

**A3, cost emit + storage**
- Migration `0004_usage_events_and_app_settings`: `usage_events` table plus `app_settings` for budget caps. Cost stored as `cost_usd_micros bigint` (1e-6 USD precision).
- New `withTypedUsage` and `withStringUsage` decorators in `packages/agent/src/agents/caller.ts` wrap the typed and string callers respectively. Captures `result.usage`, computes `cost_usd_micros` from token counts times a hardcoded model-pricing table, inserts a `usage_events` row keyed by `job_id`.
- Embedding callers wrapped at the persist + link-vector-search call sites. Same `usage_events` shape, `stage='embed'`. Embedding token counts estimated from input chars at 4 chars per token (OpenRouter does not return embedding usage); rows carry `metadata.estimated=true`.
- Telemetry context (`job_id + entry_key + wiki_key + fragment_key + source_client`) threaded through extraction, entity-extract, persist, regen, and embedding-retry paths.
- `/admin/diagnose/:entryKey` extended to return `usageEvents[]` plus a `usageTotals` rollup alongside the existing `pipelineEvents` and `auditLog`.

**A4, settings spend dashboard + budget caps**
- New `wiki/src/app/settings/spend/page.tsx` (NOT `/admin/spend`, per Andrew 2026-05-07).
- This-month total + per-stage breakdown across capture, fragment, classify, regen, embed.
- Three editable budget caps for regen, embed, classify. Persisted in `app_settings`.
- Outstanding-work placeholder section ready for the fragment-relationship-backfill counter (Round 2 D wave will populate it).

**A5, fragment history API**
- `GET /fragments/:id/history` in `core/src/routes/fragments.ts`.
- Joins `edits` table data with audit_log entries for the fragment, returns in `editedAt DESC` order. Cursor-paginated.
- Auth-gated (operator-only).
- Stream F4 consumes this endpoint to render the fragment evolution timeline.

## Deviations from PLAN.md

1. **Embedding token counts estimated, not measured.** OpenRouter's embeddings endpoint does not return usage data. Using a 4-chars-per-token heuristic. Each estimated row carries `metadata.estimated=true` so the dashboard can flag them.
2. **Routes-level `embedText` callers (people.ts, wikis.ts, mcp/handlers.ts) NOT wrapped.** Plan scope said "thread context through extractionDeps, entityExtractDeps, persistDeps, regenDeps, and embedding-retry path", which are the worker paths covered. Route handlers that embed at create-time are out of plan scope and tracked separately if later wanted.
3. **Budget caps are advisory in v0.2.0**, no enforcement in worker scheduler. Plan's verification only requires "edit cap from UI, restart workers, confirm value picked up". Enforcement loop wires into schedulers in Round 2.
4. **`/settings/spend` path used per Andrew's directive**, not `/admin/spend`.

## Test plan

UAT: `.uat/plans/57-stream-a-cost-and-history.md` ships with the PR. Run with `bash .uat/plans/57-stream-a-cost-and-history.md` against a local stack (requires running core, wiki, postgres, redis, OpenRouter key).

- [ ] CI pre-merge.yml green
- [ ] UAT 57 PASS on local stack
- [ ] Live OpenRouter dashboard reconciliation: capture an entry, sum `usage_events.cost_usd_micros` over the run, compare to OpenRouter dashboard within 5%
- [ ] `/settings/spend` UI smoke: open, see month total + stages, edit regen budget, reload, confirm persisted

## Notes for reviewer

- Migration 0004 is idempotent (`IF NOT EXISTS`) so a CI re-run does not break.
- Hardcoded model-pricing table covers the writer, classifier, and embedding models in current use. OpenRouter `/models` fetch is deferred to v0.3.0.