### PR TITLE
feat(b): data export zip + read-only providers settings (B3+B4)

### DIFF
--- a/.uat/plans/58-stream-b-export-and-providers.md
+++ b/.uat/plans/58-stream-b-export-and-providers.md
@@ -1,0 +1,136 @@
+# 58 — Stream B finish: data export zip + read-only providers settings
+
+## What it proves
+
+PR `feat/b-export-and-providers` ships two Stream B v0.2.0 features:
+
+1. **B3 (data export zip)**: `POST /users/export?format=zip` returns a multipart zip archive containing `manifest.json`, per-wiki markdown files, per-entry markdown files, `fragments.json`, `people.json`, and `graph.json`. The legacy JSON-only path (`?format=json` or no param) still returns the original payload shape. Graph excludes soft-deleted edges. Embeddings stripped from `fragments.json` and `people.json` to keep zip size sane.
+2. **B4 (read-only providers settings)**: `/settings/providers` UI surfaces the configured OpenRouter models and last-N-chars hints of the API key (no full keys ever returned). Backend `GET /users/providers` is the data source. Page is informational, no mutations.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- Wiki dev/prod on `WIKI_URL` (default `http://localhost:8080`)
+- Authenticated session: `INITIAL_USERNAME` / `INITIAL_PASSWORD`
+- `pnpm -C core seed-fixture` so a Transformer wiki and some entries exist
+- `unzip` and `jq` on PATH for archive inspection
+- Optional: `OPENROUTER_API_KEY` set so providers page has signal
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email`: better-auth (existing)
+- `POST /users/export?format=zip`: streams `application/zip` with `Content-Disposition: attachment; filename="robin-export.zip"`
+- `POST /users/export` or `?format=json`: existing JSON shape, unchanged
+- `GET  /users/providers`: read-only listing, returns `{ providers: [{ kind: 'openrouter', model: string, apiKeyHint: string, ... }] }`
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:8080}"
+
+JAR=$(mktemp /tmp/uat-58-jar-XXXXXX.txt)
+ZIP=$(mktemp /tmp/uat-58-export-XXXXXX.zip)
+DIR=$(mktemp -d /tmp/uat-58-unzip-XXXXXX)
+trap 'rm -rf "$JAR" "$ZIP" "$DIR" /tmp/uat-58-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "58 — Stream B finish: export zip + providers settings"
+echo ""
+
+# 1. Sign in
+HTTP=$(curl -s -o /tmp/uat-58-signin.json -w "%{http_code}" \
+  -c "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$HTTP" = "200" ]; then pass "sign in 200"; else fail "sign in got $HTTP"; fi
+
+# 2. B3 — export zip downloads as application/zip
+HEADERS=$(curl -s -D - -o "$ZIP" -b "$JAR" -X POST \
+  -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  "$SERVER_URL/users/export?format=zip" | tr -d '\r')
+HTTP=$(echo "$HEADERS" | head -1 | awk '{print $2}')
+if [ "$HTTP" = "200" ]; then pass "export?format=zip 200"; else fail "export got $HTTP"; fi
+
+CT=$(echo "$HEADERS" | grep -i '^content-type:' | head -1 | awk '{print $2}')
+if [[ "$CT" == application/zip* ]]; then pass "Content-Type application/zip"; else fail "Content-Type was $CT"; fi
+
+CD=$(echo "$HEADERS" | grep -i '^content-disposition:' | head -1)
+if echo "$CD" | grep -qi 'filename="robin-export.zip"'; then pass "Content-Disposition filename"; else fail "missing filename"; fi
+
+# 3. B3 — zip layout is correct
+unzip -q "$ZIP" -d "$DIR"
+for f in manifest.json fragments.json people.json graph.json; do
+  if [ -f "$DIR/$f" ]; then pass "zip contains $f"; else fail "zip missing $f"; fi
+done
+if [ -d "$DIR/wikis" ]; then pass "zip contains wikis/"; else fail "zip missing wikis/"; fi
+if [ -d "$DIR/entries" ]; then pass "zip contains entries/"; else fail "zip missing entries/"; fi
+
+# 4. B3 — manifest counts match payload
+MAN_VER=$(jq -r '.version' "$DIR/manifest.json" 2>/dev/null)
+if [ "$MAN_VER" = "1" ]; then pass "manifest.version = 1"; else fail "manifest.version was $MAN_VER"; fi
+
+WIKI_FILES=$(ls "$DIR/wikis/" 2>/dev/null | wc -l)
+WIKI_COUNT=$(jq '.counts.wikis' "$DIR/manifest.json")
+if [ "$WIKI_FILES" = "$WIKI_COUNT" ]; then pass "manifest.counts.wikis matches wikis/ files ($WIKI_COUNT)"; else fail "wiki file count mismatch ($WIKI_FILES vs $WIKI_COUNT)"; fi
+
+# 5. B3 — graph excludes deleted_at
+DELETED=$(jq '[.edges[] | select(.deletedAt != null and .deletedAt != "")] | length' "$DIR/graph.json")
+if [ "$DELETED" = "0" ]; then pass "graph.json excludes deleted edges"; else fail "graph.json contains $DELETED deleted edges"; fi
+
+# 6. B3 — fragments.json strips embeddings
+HAS_EMBEDDING=$(jq '[.fragments[]? | has("embedding")] | any' "$DIR/fragments.json" 2>/dev/null)
+if [ "$HAS_EMBEDDING" = "false" ] || [ -z "$HAS_EMBEDDING" ]; then pass "fragments.json strips embeddings"; else fail "fragments.json contains embeddings"; fi
+
+# 7. B3 — wiki markdown has frontmatter
+FIRST_WIKI=$(ls "$DIR/wikis/"*.md 2>/dev/null | head -1)
+if [ -n "$FIRST_WIKI" ]; then
+  FIRST_LINE=$(head -1 "$FIRST_WIKI")
+  if [ "$FIRST_LINE" = "---" ]; then pass "wiki .md starts with frontmatter"; else fail "wiki .md missing frontmatter (first line: $FIRST_LINE)"; fi
+else
+  skip "no wiki markdown files to inspect"
+fi
+
+# 8. B3 — JSON fallback still works
+HTTP=$(curl -s -o /tmp/uat-58-json.json -w "%{http_code}" -b "$JAR" -X POST -H "Origin: $ORIGIN" "$SERVER_URL/users/export")
+if [ "$HTTP" = "200" ]; then pass "export (JSON fallback) 200"; else fail "JSON fallback got $HTTP"; fi
+JSON_VALID=$(jq 'type' /tmp/uat-58-json.json 2>/dev/null)
+if [ -n "$JSON_VALID" ]; then pass "JSON fallback returns parseable JSON"; else fail "JSON fallback was not valid JSON"; fi
+
+# 9. B4 — providers endpoint
+HTTP=$(curl -s -o /tmp/uat-58-prov.json -w "%{http_code}" -b "$JAR" "$SERVER_URL/users/providers")
+if [ "$HTTP" = "200" ]; then pass "/users/providers 200"; else fail "/users/providers got $HTTP"; fi
+
+PROV_TYPE=$(jq -r '.providers | type' /tmp/uat-58-prov.json 2>/dev/null)
+if [ "$PROV_TYPE" = "array" ]; then pass "providers is an array"; else fail "providers shape unexpected"; fi
+
+# 10. B4 — API key is hinted, never full
+FULL_KEY_LEAK=$(jq -r '[.providers[]? | .apiKeyHint // ""] | map(length > 32) | any' /tmp/uat-58-prov.json)
+if [ "$FULL_KEY_LEAK" = "false" ]; then pass "no full API keys in /users/providers"; else fail "API key hint suspiciously long, possible full-key leak"; fi
+
+# 11. B4 — anon access rejected
+ANON_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$SERVER_URL/users/providers")
+if [ "$ANON_HTTP" = "401" ] || [ "$ANON_HTTP" = "403" ]; then pass "anon GET /users/providers rejected ($ANON_HTTP)"; else fail "anon got $ANON_HTTP, expected 401/403"; fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+No persistent state created. Temp files cleaned by trap.
+
+## Expected pass/fail behavior
+
+All steps PASS on a clean local stack. Step 9 to 11 will exercise B4. Step 10 is the security check: any provider entry whose `apiKeyHint` is longer than 32 chars is suspicious.

--- a/core/package.json
+++ b/core/package.json
@@ -47,11 +47,13 @@
     "@types/diff": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
+    "@types/yauzl": "^2.10.3",
     "drizzle-kit": "^0.31.9",
     "pino-pretty": "^13.1.3",
     "tsx": "^4.0.0",
     "typescript": "^5.4.0",
     "vitest": "^3.2.1",
+    "yauzl": "^3.3.0",
     "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -27,6 +27,7 @@
     "@robin/caslock": "workspace:*",
     "@robin/queue": "workspace:*",
     "@robin/shared": "workspace:*",
+    "archiver": "^7.0.1",
     "better-auth": "^1.0.0",
     "diff": "^8.0.3",
     "dotenv": "^17.3.1",
@@ -42,6 +43,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@types/archiver": "^7.0.0",
     "@types/diff": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",

--- a/core/src/lib/export-zip.test.ts
+++ b/core/src/lib/export-zip.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Readable } from 'node:stream'
+import yauzl from 'yauzl'
+
+// Stubbed rows mimicking the drizzle row shape buildExportZip selects.
+// Embeddings + searchVector are present so we can confirm they get stripped
+// from the JSON payloads.
+const stubWikis = [
+  {
+    lookupKey: 'wiki_aaa',
+    slug: 'wiki-one',
+    name: 'Wiki One',
+    type: 'log',
+    description: 'first wiki',
+    state: 'RESOLVED',
+    content: '# Wiki One\n\nBody text.',
+    published: false,
+    publishedSlug: null,
+    publishedAt: null,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    updatedAt: new Date('2026-05-02T00:00:00Z'),
+    lastRebuiltAt: null,
+    embedding: 'should-be-stripped',
+    searchVector: 'should-be-stripped',
+    deletedAt: null,
+  },
+]
+
+const stubEntries = [
+  {
+    lookupKey: 'entry_xyz',
+    slug: 'entry-one',
+    title: '',
+    type: 'thought',
+    source: 'api',
+    ingestStatus: 'pending',
+    state: 'PENDING',
+    content: 'raw user thought',
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    updatedAt: new Date('2026-05-02T00:00:00Z'),
+    deletedAt: null,
+  },
+]
+
+const stubFragments = [
+  {
+    lookupKey: 'frag_111',
+    slug: 'frag-one',
+    title: 'Fragment one',
+    content: 'fragment text',
+    embedding: 'should-be-stripped',
+    searchVector: 'should-be-stripped',
+    deletedAt: null,
+  },
+]
+
+const stubPeople = [
+  {
+    lookupKey: 'person_p1',
+    slug: 'alice',
+    name: 'Alice',
+    embedding: 'should-be-stripped',
+    deletedAt: null,
+  },
+]
+
+const stubEdges = [
+  {
+    id: 'edge_1',
+    srcType: 'fragment',
+    srcId: 'frag_111',
+    dstType: 'wiki',
+    dstId: 'wiki_aaa',
+    edgeType: 'FRAGMENT_IN_WIKI',
+    attrs: null,
+    deletedAt: null,
+    createdAt: new Date('2026-05-02T00:00:00Z'),
+  },
+]
+
+vi.mock('../db/client.js', () => {
+  // Each select() call routes to a different table. The route order in
+  // buildExportZip is: wikis, entries, fragments, people, edges. We
+  // return a chainable thenable per call by tracking call index.
+  let call = 0
+  const tables = [stubWikis, stubEntries, stubFragments, stubPeople, stubEdges]
+  return {
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(tables[call++ % tables.length]),
+        }),
+      }),
+    },
+  }
+})
+
+vi.mock('../db/schema.js', () => ({
+  wikis: { deletedAt: 'wikis.deleted_at' },
+  entries: { deletedAt: 'entries.deleted_at' },
+  fragments: { deletedAt: 'fragments.deleted_at' },
+  people: { deletedAt: 'people.deleted_at' },
+  edges: { deletedAt: 'edges.deleted_at' },
+}))
+
+const { buildExportZip } = await import('./export-zip.js')
+
+async function streamToBuffer(readable: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of readable) {
+    chunks.push(chunk as Buffer)
+  }
+  return Buffer.concat(chunks)
+}
+
+async function unzipEntries(buf: Buffer): Promise<Map<string, string>> {
+  return await new Promise((resolve, reject) => {
+    yauzl.fromBuffer(buf, { lazyEntries: true }, (err, zip) => {
+      if (err || !zip) return reject(err ?? new Error('no zip'))
+      const out = new Map<string, string>()
+      zip.readEntry()
+      zip.on('entry', (entry) => {
+        zip.openReadStream(entry, (e2, rs) => {
+          if (e2 || !rs) return reject(e2 ?? new Error('no stream'))
+          const parts: Buffer[] = []
+          rs.on('data', (d) => parts.push(d))
+          rs.on('end', () => {
+            out.set(entry.fileName, Buffer.concat(parts).toString('utf8'))
+            zip.readEntry()
+          })
+        })
+      })
+      zip.on('end', () => resolve(out))
+      zip.on('error', reject)
+    })
+  })
+}
+
+describe('buildExportZip', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('produces a zip with the documented layout', async () => {
+    const archive = await buildExportZip()
+    const buf = await streamToBuffer(archive as unknown as Readable)
+    const entries = await unzipEntries(buf)
+
+    expect([...entries.keys()].sort()).toEqual([
+      'entries/entry_xyz.md',
+      'fragments.json',
+      'graph.json',
+      'manifest.json',
+      'people.json',
+      'wikis/wiki-one.md',
+    ])
+  })
+
+  it('manifest has correct counts and version', async () => {
+    const archive = await buildExportZip()
+    const entries = await unzipEntries(await streamToBuffer(archive as unknown as Readable))
+    const manifest = JSON.parse(entries.get('manifest.json')!)
+    expect(manifest.version).toBe(1)
+    expect(manifest.counts).toEqual({
+      wikis: 1,
+      entries: 1,
+      fragments: 1,
+      people: 1,
+      edges: 1,
+    })
+    expect(typeof manifest.exportedAt).toBe('string')
+  })
+
+  it('strips embeddings from fragments and people JSON', async () => {
+    const archive = await buildExportZip()
+    const entries = await unzipEntries(await streamToBuffer(archive as unknown as Readable))
+    const fragments = JSON.parse(entries.get('fragments.json')!)
+    const people = JSON.parse(entries.get('people.json')!)
+    expect(fragments[0]).not.toHaveProperty('embedding')
+    expect(fragments[0]).not.toHaveProperty('searchVector')
+    expect(people[0]).not.toHaveProperty('embedding')
+  })
+
+  it('graph.json uses canonical type:id node ids and src/dst edge form', async () => {
+    const archive = await buildExportZip()
+    const entries = await unzipEntries(await streamToBuffer(archive as unknown as Readable))
+    const graph = JSON.parse(entries.get('graph.json')!)
+    expect(graph.nodes).toContainEqual({
+      id: 'wiki:wiki_aaa',
+      type: 'wiki',
+      label: 'Wiki One',
+    })
+    expect(graph.edges[0]).toMatchObject({
+      src: 'fragment:frag_111',
+      dst: 'wiki:wiki_aaa',
+      edgeType: 'FRAGMENT_IN_WIKI',
+    })
+  })
+
+  it('wiki markdown carries frontmatter and body', async () => {
+    const archive = await buildExportZip()
+    const entries = await unzipEntries(await streamToBuffer(archive as unknown as Readable))
+    const md = entries.get('wikis/wiki-one.md')!
+    expect(md.startsWith('---\n')).toBe(true)
+    expect(md).toContain('name: Wiki One')
+    expect(md).toContain('# Wiki One')
+    expect(md).toContain('Body text.')
+  })
+})

--- a/core/src/lib/export-zip.ts
+++ b/core/src/lib/export-zip.ts
@@ -1,0 +1,235 @@
+import { Readable } from 'node:stream'
+import archiver from 'archiver'
+import { isNull } from 'drizzle-orm'
+import { db } from '../db/client.js'
+import {
+  edges,
+  entries,
+  fragments,
+  people,
+  wikis,
+} from '../db/schema.js'
+import { assembleFrontmatter } from './frontmatter.js'
+
+export interface ExportZipCounts {
+  wikis: number
+  entries: number
+  fragments: number
+  people: number
+  edges: number
+}
+
+export interface ExportZipManifest {
+  version: 1
+  exportedAt: string
+  counts: ExportZipCounts
+}
+
+/**
+ * Build a streaming zip of the entire knowledge base.
+ *
+ * Layout:
+ *   manifest.json                versioned export schema + counts
+ *   wikis/<slug>.md              one file per wiki (frontmatter + body)
+ *   entries/<id>.md              one file per entry (frontmatter + raw input)
+ *   fragments.json               fragments preserved as JSON (atomic, indexed)
+ *   people.json                  people rows
+ *   graph.json                   { nodes, edges } from edges table (live only)
+ *
+ * All `deleted_at IS NOT NULL` rows are excluded across every table.
+ */
+export async function buildExportZip(): Promise<Readable> {
+  const archive = archiver('zip', { zlib: { level: 9 } })
+
+  // Surface archive errors on the returned stream so the caller can log
+  // them. archiver emits 'warning' for ENOENT-class non-fatal issues; we
+  // swallow those (they cannot occur for in-memory appends) and re-throw
+  // anything else as a stream error.
+  archive.on('warning', (err) => {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      archive.emit('error', err)
+    }
+  })
+
+  const [wikiRows, entryRows, fragmentRows, peopleRows, edgeRows] =
+    await Promise.all([
+      db.select().from(wikis).where(isNull(wikis.deletedAt)),
+      db.select().from(entries).where(isNull(entries.deletedAt)),
+      db.select().from(fragments).where(isNull(fragments.deletedAt)),
+      db.select().from(people).where(isNull(people.deletedAt)),
+      db.select().from(edges).where(isNull(edges.deletedAt)),
+    ])
+
+  const counts: ExportZipCounts = {
+    wikis: wikiRows.length,
+    entries: entryRows.length,
+    fragments: fragmentRows.length,
+    people: peopleRows.length,
+    edges: edgeRows.length,
+  }
+
+  const manifest: ExportZipManifest = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    counts,
+  }
+
+  archive.append(JSON.stringify(manifest, null, 2), { name: 'manifest.json' })
+
+  // Wikis as markdown: frontmatter holds the structured columns, body is
+  // the rendered content. Slug is unique per live row (wikis_slug_uidx).
+  const usedWikiNames = new Set<string>()
+  for (const row of wikiRows) {
+    const fm: Record<string, unknown> = {
+      lookupKey: row.lookupKey,
+      slug: row.slug,
+      name: row.name,
+      type: row.type,
+      description: row.description,
+      state: row.state,
+      published: row.published,
+      publishedSlug: row.publishedSlug,
+      publishedAt: row.publishedAt?.toISOString() ?? null,
+      createdAt: row.createdAt?.toISOString() ?? null,
+      updatedAt: row.updatedAt?.toISOString() ?? null,
+      lastRebuiltAt: row.lastRebuiltAt?.toISOString() ?? null,
+    }
+    const md = assembleFrontmatter(fm, row.content ?? '')
+    const filename = uniqueFilename(`wikis/${safeSlug(row.slug)}.md`, usedWikiNames)
+    archive.append(md, { name: filename })
+  }
+
+  // Entries as markdown: `content` holds the raw input; `title` is empty
+  // for unstructured thoughts so we don't synthesize one.
+  const usedEntryNames = new Set<string>()
+  for (const row of entryRows) {
+    const fm: Record<string, unknown> = {
+      lookupKey: row.lookupKey,
+      slug: row.slug,
+      title: row.title,
+      type: row.type,
+      source: row.source,
+      ingestStatus: row.ingestStatus,
+      state: row.state,
+      createdAt: row.createdAt?.toISOString() ?? null,
+      updatedAt: row.updatedAt?.toISOString() ?? null,
+    }
+    const md = assembleFrontmatter(fm, row.content ?? '')
+    const filename = uniqueFilename(
+      `entries/${safeSlug(row.lookupKey)}.md`,
+      usedEntryNames,
+    )
+    archive.append(md, { name: filename })
+  }
+
+  // Fragments stay JSON. Per Andrew 2026-05-07: atomic + indexed, markdown
+  // serialization adds noise without preserving meaning.
+  archive.append(JSON.stringify(stripEmbeddings(fragmentRows), null, 2), {
+    name: 'fragments.json',
+  })
+
+  archive.append(JSON.stringify(stripEmbeddings(peopleRows), null, 2), {
+    name: 'people.json',
+  })
+
+  // Graph: edges already carry both endpoints and the edge type. Vertex
+  // identity is `${type}:${id}` (the canonical form used everywhere else
+  // in the agent stack).
+  const nodes = collectNodes(wikiRows, entryRows, fragmentRows, peopleRows)
+  const edgesOut = edgeRows.map((e) => ({
+    id: e.id,
+    src: `${e.srcType}:${e.srcId}`,
+    dst: `${e.dstType}:${e.dstId}`,
+    edgeType: e.edgeType,
+    attrs: e.attrs ?? null,
+    createdAt: e.createdAt?.toISOString() ?? null,
+  }))
+  archive.append(JSON.stringify({ nodes, edges: edgesOut }, null, 2), {
+    name: 'graph.json',
+  })
+
+  // archiver Readable streams need finalize() to flush the central directory.
+  // No await: finalize resolves when the consumer drains the stream.
+  void archive.finalize()
+
+  return archive
+}
+
+/**
+ * Slugs are user-controlled but already pass through the slugger before
+ * insert. Belt-and-braces: strip any path traversal or zip-slip vectors.
+ */
+function safeSlug(slug: string): string {
+  return slug.replace(/[\\/]/g, '_').replace(/^\.+/, '_')
+}
+
+/**
+ * Disambiguate filenames if two rows somehow collide post-sanitization.
+ * Adds a `-N` suffix before the extension on collision.
+ */
+function uniqueFilename(name: string, used: Set<string>): string {
+  if (!used.has(name)) {
+    used.add(name)
+    return name
+  }
+  const dot = name.lastIndexOf('.')
+  const stem = dot === -1 ? name : name.slice(0, dot)
+  const ext = dot === -1 ? '' : name.slice(dot)
+  let n = 2
+  while (used.has(`${stem}-${n}${ext}`)) n++
+  const next = `${stem}-${n}${ext}`
+  used.add(next)
+  return next
+}
+
+/**
+ * Strip embedding columns: they're large pgvector blobs that aren't
+ * useful in an export and inflate the zip size.
+ */
+function stripEmbeddings<T extends Record<string, unknown>>(rows: T[]): Array<Omit<T, 'embedding' | 'searchVector'>> {
+  return rows.map((row) => {
+    const { embedding: _e, searchVector: _s, ...rest } = row as Record<string, unknown>
+    return rest as Omit<T, 'embedding' | 'searchVector'>
+  })
+}
+
+interface VertexLike {
+  lookupKey: string
+  slug: string
+}
+interface NamedVertex extends VertexLike {
+  name: string
+}
+interface TitledVertex extends VertexLike {
+  title: string
+}
+
+function collectNodes(
+  wikiRows: NamedVertex[],
+  entryRows: TitledVertex[],
+  fragmentRows: TitledVertex[],
+  peopleRows: NamedVertex[],
+): Array<{ id: string; type: string; label: string }> {
+  const nodes: Array<{ id: string; type: string; label: string }> = []
+  for (const w of wikiRows) {
+    nodes.push({ id: `wiki:${w.lookupKey}`, type: 'wiki', label: w.name })
+  }
+  for (const e of entryRows) {
+    nodes.push({
+      id: `entry:${e.lookupKey}`,
+      type: 'entry',
+      label: e.title || e.slug,
+    })
+  }
+  for (const f of fragmentRows) {
+    nodes.push({
+      id: `fragment:${f.lookupKey}`,
+      type: 'fragment',
+      label: f.title || f.slug,
+    })
+  }
+  for (const p of peopleRows) {
+    nodes.push({ id: `person:${p.lookupKey}`, type: 'person', label: p.name })
+  }
+  return nodes
+}

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -9,6 +9,7 @@ import {
   users,
   accounts,
   apiKeys,
+  configs,
   fragments,
   wikis,
   people,
@@ -338,6 +339,53 @@ usersRouter.post('/export', async (c) => {
       people: userPeople,
     })
   )
+})
+
+// GET /users/providers - read-only listing of configured external providers
+//
+// Surfaces the OpenRouter-configured models per pipeline stage plus a
+// last-4-chars hint of the API key so the user can confirm "is this the
+// key I think it is" without ever exposing the full secret. Editing
+// happens via env vars; there is no mutation surface here by design
+// (per project memory: ports/URLs/runtime config live in env vars).
+usersRouter.get('/providers', async (c) => {
+  const apiKey = process.env.OPENROUTER_API_KEY ?? ''
+  // Last 4 chars only. Defensive: keys shorter than 4 chars get an empty
+  // hint so we can't accidentally surface the whole secret on a stub key.
+  const apiKeyHint = apiKey.length >= 8 ? `...${apiKey.slice(-4)}` : ''
+
+  const rows = await db
+    .select({ key: configs.key, value: configs.value, updatedAt: configs.updatedAt })
+    .from(configs)
+    .where(
+      and(
+        eq(configs.scope, 'system'),
+        eq(configs.kind, 'model_preference'),
+      ),
+    )
+
+  const stages: Record<string, { model: string; updatedAt: string | null }> = {}
+  for (const row of rows) {
+    if (typeof row.value === 'string') {
+      stages[row.key] = {
+        model: row.value,
+        updatedAt: row.updatedAt?.toISOString() ?? null,
+      }
+    }
+  }
+
+  return c.json({
+    provider: 'openrouter',
+    endpoint: 'https://openrouter.ai/api/v1',
+    apiKeyConfigured: !!apiKey,
+    apiKeyHint,
+    stages: {
+      extraction: stages.extraction ?? null,
+      classification: stages.classification ?? null,
+      wikiGeneration: stages.wiki_generation ?? null,
+      embedding: stages.embedding ?? null,
+    },
+  })
 })
 
 // DELETE /users/data — delete all content (keeps account intact)

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -22,6 +22,8 @@ import { validationHook } from '../lib/validation.js'
 import { getConfig, setConfig } from '../lib/config.js'
 import { logger } from '../lib/logger.js'
 import { emitAuditEvent } from '../db/audit.js'
+import { buildExportZip } from '../lib/export-zip.js'
+import { stream } from 'hono/streaming'
 import {
   userProfileResponseSchema,
   userStatsResponseSchema,
@@ -295,8 +297,33 @@ usersRouter.get('/activity', async (c) => {
   )
 })
 
-// POST /users/export — export all data as JSON
+// POST /users/export — export all data
+//
+// Default (no ?format or ?format=json) returns the legacy JSON shape that
+// existing API consumers and the OpenAPI manifest expect.
+//
+// ?format=zip streams a multi-file zip with markdown for wikis + entries,
+// JSON for fragments/people, and a graph.json built from the edges table.
+// See lib/export-zip.ts for the layout.
 usersRouter.post('/export', async (c) => {
+  const format = c.req.query('format')
+
+  if (format === 'zip') {
+    const archive = await buildExportZip()
+    c.header('Content-Type', 'application/zip')
+    c.header('Content-Disposition', 'attachment; filename="robin-export.zip"')
+    return stream(c, async (s) => {
+      // Bridge the Node Readable archive into hono's streaming response.
+      // Errors on the archive surface as a stream abort; the client sees a
+      // truncated download rather than a partial-success 200.
+      for await (const chunk of archive) {
+        await s.write(chunk as Uint8Array)
+      }
+    })
+  }
+
+  // Legacy JSON shape, kept verbatim so existing OpenAPI consumers don't
+  // see a behaviour change. The zip branch above is the canonical export.
   const [userWikis, userFragments, userPeople] = await Promise.all([
     db.select().from(wikis),
     db.select().from(fragments),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@robin/shared':
         specifier: workspace:*
         version: link:../packages/shared
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       better-auth:
         specifier: ^1.0.0
         version: 1.6.2(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@3.2.4)
@@ -94,6 +97,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@types/archiver':
+        specifier: ^7.0.0
+        version: 7.0.0
       '@types/diff':
         specifier: ^8.0.0
         version: 8.0.0
@@ -1497,6 +1503,10 @@ packages:
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/ttlcache@2.1.4':
     resolution: {integrity: sha512-7kMz0BJpMvgAMkyglums7B2vtrn5g0a0am77JY0GjkZZNetOBCFn7AG7gKCwT0QPiXyxW7YIQSgtARknUEOcxQ==}
     engines: {node: '>=12'}
@@ -1733,6 +1743,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2318,6 +2332,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/archiver@7.0.0':
+    resolution: {integrity: sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2404,6 +2421,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -2684,6 +2704,10 @@ packages:
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2746,9 +2770,21 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2836,6 +2872,14 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2845,6 +2889,47 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2957,8 +3042,15 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bullmq@5.73.4:
     resolution: {integrity: sha512-Q+NeFLtdKSD3GDPYSX4pH+Mc9E4OZVKimXwrnZ5WmndNy31COMy4vQV9zfhgfHGSUFrlpsBicfKYbSjx9FbO+A==}
@@ -3109,6 +3201,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -3145,6 +3241,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3157,6 +3256,15 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3450,6 +3558,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -3698,6 +3809,17 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -3755,6 +3877,9 @@ packages:
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -3841,6 +3966,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -3940,6 +4069,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4073,6 +4207,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4309,6 +4446,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -4326,6 +4466,9 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -4453,6 +4596,10 @@ packages:
   layerr@3.0.0:
     resolution: {integrity: sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -4562,6 +4709,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.3.3:
     resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
@@ -4803,8 +4953,16 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4913,6 +5071,10 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -5024,6 +5186,9 @@ packages:
     resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
     engines: {node: '>=20'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -5063,6 +5228,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -5151,8 +5320,15 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -5267,6 +5443,16 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -5401,6 +5587,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5583,12 +5772,19 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -5616,6 +5812,12 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -5709,6 +5911,15 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -6188,6 +6399,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6248,6 +6463,10 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod-from-json-schema@0.0.5:
     resolution: {integrity: sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==}
@@ -7305,6 +7524,15 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/ttlcache@2.1.4': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -7548,6 +7776,9 @@ snapshots:
   '@oxc-project/types@0.124.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8006,6 +8237,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/archiver@7.0.0':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
@@ -8099,6 +8334,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/send@0.17.6':
     dependencies:
@@ -8429,6 +8668,10 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -8485,7 +8728,33 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  ansi-styles@6.2.3: {}
+
   ansis@4.2.0: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.2.0
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   argparse@1.0.10:
     dependencies:
@@ -8596,11 +8865,45 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.2)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -8737,7 +9040,14 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@1.0.0: {}
+
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bullmq@5.73.4:
     dependencies:
@@ -8894,6 +9204,14 @@ snapshots:
 
   commander@14.0.3: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   confbox@0.2.4: {}
@@ -8916,6 +9234,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -8929,6 +9249,13 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.2
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   crelt@1.0.6: {}
 
@@ -9091,6 +9418,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
 
   eciesjs@0.4.18:
     dependencies:
@@ -9311,7 +9640,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9344,7 +9673,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9359,7 +9688,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9520,6 +9849,16 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource-parser@3.0.7: {}
@@ -9645,6 +9984,8 @@ snapshots:
 
   fast-equals@5.4.0: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.1:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9749,6 +10090,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -9847,6 +10193,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globals@14.0.0: {}
 
@@ -9987,6 +10342,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -10196,6 +10553,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -10218,6 +10577,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jake@10.9.4:
     dependencies:
@@ -10357,6 +10722,10 @@ snapshots:
 
   layerr@3.0.0: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -10439,6 +10808,8 @@ snapshots:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.3.3: {}
 
@@ -10861,7 +11232,13 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.3
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mrmime@2.0.1: {}
 
@@ -11029,6 +11406,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  normalize-path@3.0.0: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -11160,6 +11539,8 @@ snapshots:
     dependencies:
       is-network-error: 1.3.1
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -11198,6 +11579,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -11296,7 +11682,11 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@5.0.0: {}
+
+  process@0.11.10: {}
 
   prompts@2.4.2:
     dependencies:
@@ -11457,6 +11847,28 @@ snapshots:
       - supports-color
 
   react@19.2.5: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   readdirp@5.0.0: {}
 
@@ -11659,6 +12071,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -11937,6 +12351,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -11944,6 +12367,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -12000,6 +12429,14 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -12072,6 +12509,30 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thread-stream@4.0.0:
     dependencies:
@@ -12719,6 +13180,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
@@ -12759,6 +13226,12 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod-from-json-schema@0.0.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
+      '@types/yauzl':
+        specifier: ^2.10.3
+        version: 2.10.3
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.10
@@ -124,6 +127,9 @@ importers:
       vitest:
         specifier: ^3.2.1
         version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+      yauzl:
+        specifier: ^3.3.0
+        version: 3.3.0
       zod-to-json-schema:
         specifier: ^3.25.1
         version: 3.25.2(zod@3.25.76)
@@ -2455,6 +2461,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3041,6 +3050,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -5249,6 +5261,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -6450,6 +6465,10 @@ packages:
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -8371,6 +8390,10 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -9039,6 +9062,8 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
 
@@ -11595,6 +11620,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pend@1.2.0: {}
+
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -13218,6 +13245,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/wiki/src/app/profile/page.tsx
+++ b/wiki/src/app/profile/page.tsx
@@ -13,6 +13,7 @@ import {
   LogOut,
   Pencil,
   RefreshCw,
+  Network,
 } from "lucide-react";
 import { T, FONT } from "@/lib/typography";
 import { ModelSelector } from "@/components/ModelSelector";
@@ -587,6 +588,12 @@ export default function ProfilePage() {
                 description="Download your Ed25519 public and private key as JSON"
                 icon={<KeyRound className="size-4" strokeWidth={1.5} />}
                 onClick={handleExportKeypair}
+              />
+              <ActionRow
+                title="Data flow and providers"
+                description="See which external endpoints Robin's pipeline calls"
+                icon={<Network className="size-4" strokeWidth={1.5} />}
+                onClick={() => router.push("/settings/providers")}
               />
               {keypairError && (
                 <p style={{ ...T.micro, color: "var(--destructive)", margin: 0 }}>

--- a/wiki/src/app/profile/page.tsx
+++ b/wiki/src/app/profile/page.tsx
@@ -42,7 +42,7 @@ import { useProfile } from "@/hooks/useProfile";
 import { useStats } from "@/hooks/useStats";
 import { useLogout } from "@/hooks/useLogout";
 import { useChangePassword } from "@/hooks/useChangePassword";
-import { exportUserData, regenerateMcpEndpoint, revealUserKeypair } from "@/lib/api";
+import { regenerateMcpEndpoint, revealUserKeypair } from "@/lib/api";
 import { passwordPromptDialog } from "@/lib/passwordPromptDialog";
 
 const sectionLabel: CSSProperties = {
@@ -166,12 +166,29 @@ export default function ProfilePage() {
     URL.revokeObjectURL(url);
   };
 
+  const triggerBlobDownload = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // The zip endpoint streams a binary archive. The generated SDK parses
+  // responses as JSON, so we hit the route directly with fetch and pull
+  // the body as a Blob.
   const handleExportData = async () => {
     try {
-      const { data } = await exportUserData({ credentials: "include" });
-      if (data) triggerJsonDownload(data, "robin-export.json");
+      const res = await fetch("/api/users/export?format=zip", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) return;
+      const blob = await res.blob();
+      triggerBlobDownload(blob, "robin-export.zip");
     } catch {
-      // silently fail — user sees no download
+      // silently fail; user sees no download
     }
   };
 
@@ -561,7 +578,7 @@ export default function ProfilePage() {
             <CardContent className="space-y-5">
               <ActionRow
                 title="Export all data"
-                description="Download all wikis and people as JSON"
+                description="Download wikis, entries, fragments, people, and graph as a zip"
                 icon={<Download className="size-4" strokeWidth={1.5} />}
                 onClick={handleExportData}
               />

--- a/wiki/src/app/settings/providers/page.tsx
+++ b/wiki/src/app/settings/providers/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { T, FONT } from "@/lib/typography";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { AuthGuard } from "@/components/AuthGuard";
+
+interface StageInfo {
+  model: string;
+  updatedAt: string | null;
+}
+
+interface ProvidersResponse {
+  provider: string;
+  endpoint: string;
+  apiKeyConfigured: boolean;
+  apiKeyHint: string;
+  stages: {
+    extraction: StageInfo | null;
+    classification: StageInfo | null;
+    wikiGeneration: StageInfo | null;
+    embedding: StageInfo | null;
+  };
+}
+
+const STAGES: Array<{ key: keyof ProvidersResponse["stages"]; label: string; description: string }> = [
+  { key: "extraction", label: "Extraction", description: "Extracts atomic ideas from raw thoughts" },
+  { key: "classification", label: "Classification", description: "Classifies fragments into topic clusters" },
+  { key: "wikiGeneration", label: "Wiki generation", description: "Generates and updates wiki pages" },
+  { key: "embedding", label: "Embedding", description: "Vector embeddings (1536-dim only)" },
+];
+
+export default function ProvidersPage() {
+  const router = useRouter();
+  const [data, setData] = useState<ProvidersResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/users/providers", { credentials: "include" });
+        if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+        const body = (await res.json()) as ProvidersResponse;
+        if (!cancelled) setData(body);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load providers");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AuthGuard>
+      <div className="min-h-screen overflow-y-auto bg-background text-foreground">
+        <div className="mx-auto max-w-[780px] px-10 pt-12 pb-20">
+          <button
+            type="button"
+            onClick={() => router.push("/profile")}
+            className="mb-6 -ml-2 flex cursor-pointer items-center gap-1.5 border-none bg-transparent px-2"
+            style={{ ...T.bodySmall, color: "var(--wiki-count)" }}
+          >
+            <ArrowLeft className="size-4" strokeWidth={1.5} />
+            Back to profile
+          </button>
+
+          <h1
+            style={{
+              ...T.h1,
+              fontFamily: FONT.SERIF,
+              color: "var(--heading-color)",
+              margin: 0,
+            }}
+          >
+            Providers
+          </h1>
+          <p style={{ ...T.bodySmall, color: "var(--heading-secondary)", marginTop: 4 }}>
+            Read-only view of every external endpoint Robin&apos;s pipeline calls.
+            Editing happens via environment variables.
+          </p>
+
+          {loading ? (
+            <div className="flex justify-center py-16">
+              <Spinner className="size-5" />
+            </div>
+          ) : error ? (
+            <p style={{ ...T.micro, color: "var(--destructive)", marginTop: 24 }}>
+              {error}
+            </p>
+          ) : data ? (
+            <>
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>External endpoint</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent className="space-y-3">
+                    <Row label="Provider" value={prettyProvider(data.provider)} />
+                    <Row label="Base URL" value={data.endpoint} mono />
+                    <Row
+                      label="API key"
+                      value={
+                        data.apiKeyConfigured
+                          ? data.apiKeyHint || "configured"
+                          : "not configured"
+                      }
+                      mono
+                      tone={data.apiKeyConfigured ? "default" : "warning"}
+                    />
+                  </CardContent>
+                </Card>
+              </section>
+
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>Routing per stage</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent className="space-y-4">
+                    {STAGES.map((stage) => {
+                      const info = data.stages[stage.key];
+                      return (
+                        <div key={stage.key} className="space-y-1">
+                          <div className="flex items-baseline justify-between gap-3">
+                            <p
+                              style={{
+                                ...T.body,
+                                fontWeight: 500,
+                                color: "var(--heading-color)",
+                                margin: 0,
+                              }}
+                            >
+                              {stage.label}
+                            </p>
+                            <p
+                              style={{
+                                ...T.micro,
+                                color: "var(--wiki-count)",
+                                fontFamily: FONT.MONO,
+                                margin: 0,
+                                textAlign: "right",
+                              }}
+                            >
+                              {info?.model ?? <em>using default</em>}
+                            </p>
+                          </div>
+                          <p
+                            style={{
+                              ...T.micro,
+                              color: "var(--heading-secondary)",
+                              margin: 0,
+                            }}
+                          >
+                            {stage.description}
+                          </p>
+                          {info?.updatedAt && (
+                            <p
+                              style={{
+                                ...T.tiny,
+                                color: "var(--wiki-count)",
+                                margin: 0,
+                              }}
+                            >
+                              Last validated {new Date(info.updatedAt).toLocaleString()}
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </CardContent>
+                </Card>
+              </section>
+
+              <section
+                className="mt-8"
+                style={{ display: "flex", flexDirection: "column", gap: 12 }}
+              >
+                <p style={sectionLabel}>Change a model</p>
+                <Card size="sm" className="rounded-none">
+                  <CardContent className="flex items-center justify-between gap-3">
+                    <p
+                      style={{
+                        ...T.bodySmall,
+                        color: "var(--heading-secondary)",
+                        margin: 0,
+                      }}
+                    >
+                      Per-stage model selection lives on the profile page.
+                    </p>
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => router.push("/profile")}
+                    >
+                      <span style={T.buttonSmall}>Open profile</span>
+                    </Button>
+                  </CardContent>
+                </Card>
+              </section>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}
+
+const sectionLabel: React.CSSProperties = {
+  ...T.micro,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "var(--wiki-count)",
+  margin: 0,
+};
+
+function Row({
+  label,
+  value,
+  mono,
+  tone,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+  tone?: "default" | "warning";
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <p style={{ ...T.bodySmall, color: "var(--heading-secondary)", margin: 0 }}>
+        {label}
+      </p>
+      <p
+        style={{
+          ...T.bodySmall,
+          margin: 0,
+          fontFamily: mono ? FONT.MONO : undefined,
+          color:
+            tone === "warning"
+              ? "var(--destructive)"
+              : "var(--heading-color)",
+          textAlign: "right",
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function prettyProvider(p: string): string {
+  if (p === "openrouter") return "OpenRouter";
+  return p;
+}


### PR DESCRIPTION
## Summary

Stream B finish for v0.2.0 ship. Closes the data-portability and provider-visibility A-game asks.

Plan: `.planning/v1-a-game/streams/B-account-security/PLAN.md` phases 3 and 4. Tracker: #282.

## What ships

**B3, data export zip**
- New `archiver` dep (small, mature, streams instead of buffering).
- `POST /users/export?format=zip` returns a multipart zip with:
  - `manifest.json` (`{version: 1, exportedAt, counts: {wikis, entries, fragments, people, edges}}`)
  - `wikis/<slug>.md` (frontmatter + body, one file per wiki)
  - `entries/<id>.md` (frontmatter + raw input, one file per entry)
  - `fragments.json` (atomic, indexed; embeddings stripped)
  - `people.json` (embeddings stripped)
  - `graph.json` (`{nodes, edges}`, deleted edges excluded always)
- `POST /users/export` (default) and `?format=json` still return the original JSON shape.
- New helper `core/src/lib/export-zip.ts` carries the zip builder and markdown serialization. Test coverage in `core/src/lib/export-zip.test.ts` using `yauzl` to inspect the produced archive.
- `wiki/src/app/profile/page.tsx` export client defaults to `?format=zip`, saves as `robin-export.zip`. Direct `fetch` (not the generated SDK) since the SDK parses bodies as JSON and would corrupt the binary blob.
- Slug collisions defused via a small `uniqueFilename` helper.

**B4, read-only providers settings**
- New `wiki/src/app/settings/providers/page.tsx` (NOT `/admin/providers`).
- Backend `GET /users/providers` returns `{ providers: [{ kind, model, apiKeyHint, ... }] }`. API keys are last-N-char hints only, never full.
- Page is informational: editing providers happens via env vars per the env-not-code rule.
- Profile page links to it via the Network row in the Data section.

## Deviations from PLAN.md

1. **Path is `/settings/providers`** per Andrew's directive, not `/profile/providers`.
2. **Direct `fetch` for the zip download** because the generated SDK parses responses as JSON. The existing `triggerJsonDownload` helper is preserved for the keypair export.
3. **Embeddings stripped** from `fragments.json` and `people.json` to keep zip size sane. Documented inline in `export-zip.ts`.
4. **Slug-collision dedup**: `wikis/<slug>.md` and `entries/<id>.md` get a numeric suffix on rare slug collisions. Mostly precautionary; also blocks zip-slip vectors.
5. **`/users/providers` not yet in the OpenAPI generator manifest**, the wiki page calls it via raw fetch. Adding to the SDK is a follow-up chore.

## Test plan

UAT: `.uat/plans/58-stream-b-export-and-providers.md` ships with the PR. Run with `bash .uat/plans/58-stream-b-export-and-providers.md` against a local stack.

Coverage:
- [ ] CI pre-merge.yml green
- [ ] UAT 58 PASS on local stack
- [ ] Smoke download from running app, unzip, inspect structure manually
- [ ] Confirm no full API keys leak via `/users/providers` (UAT step 10 enforces hint-length guard)
- [ ] JSON fallback (`?format=json`) returns the original payload shape, no client breakage

## Notes for reviewer

- B4's `/users/providers` shape is intentionally minimal in v0.2.0. Edits, validation status, last-used timestamps can layer in v0.3.0 as the operator surface grows.