### PR TITLE
feat(f): numbered citations + fragment lineage page + evolution timeline (F1+F2+F4)

### DIFF
--- a/.uat/plans/59-stream-f-citations-and-lineage.md
+++ b/.uat/plans/59-stream-f-citations-and-lineage.md
@@ -1,0 +1,144 @@
+# 59 — Stream F core: numbered citations + fragment lineage page + evolution timeline
+
+## What it proves
+
+PR `feat/f-citations-and-lineage` ships three coupled Stream F v0.2.0 features:
+
+1. **F1 (numbered citations)**: wiki body markdown rendering attaches `[1]`, `[2]` superscripts to text drawn from fragments. Numbering is per-wiki, document-wide, stable across renders. Click on superscript scrolls to the in-page bibliography section anchor `#fragment-{lookupKey}`. Already shipped under #245; this PR documents and reuses, with extended F2/F4 surfaces consuming the same primitive.
+2. **F2 (fragment-detail page with full lineage)**: `/fragments/<id>` renders Type, State, Tags, Created, Updated metadata in the infobox plus three lineage sections: Entry origin, Wiki references (renamed, anchored at `id="references"`), Related fragments.
+3. **F4 (fragment evolution timeline)**: same page slots an `EvolutionSection` between Entry origin and Wiki references. Reads `GET /fragments/:id/history` (Stream A5), renders newest-first timeline of edits with timestamps, source-client labels (`mcp`, `api`, `web`, `regen`), word-level diffs via `jsdiff`. Collapsed by default with "Edited N times" expandable affordance.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- Wiki dev server on `WIKI_URL` (default `http://localhost:8080`)
+- Authenticated session
+- `pnpm -C core seed-fixture` so a Transformer wiki and fragments exist
+- Stream A5's `GET /fragments/:id/history` endpoint live (ships in a sibling PR; UAT degrades gracefully if missing, see notes)
+- Browser for visual checks on F1, F2, F4
+
+## Endpoint map
+
+- `GET /api/wikis/<key>`: wiki body, citations applied client-side at render time
+- `GET /api/fragments/<id>`: existing detail
+- `GET /api/fragments/<id>/history`: edits + audit (A5), 200 on existence with `{ edits, total }`, 404 if no rows yet
+- Wiki page route `/wiki/<id>`: client side renders body with `WikiCitations` + `WikiCitationsSection`
+- Fragment detail route `/fragments/<id>`: shows Type/State/Tags/Created/Updated, Entry origin, Evolution, Wiki references, Related fragments
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:8080}"
+
+JAR=$(mktemp /tmp/uat-59-jar-XXXXXX.txt)
+trap 'rm -f "$JAR" /tmp/uat-59-*.json /tmp/uat-59-*.html' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "59 — Stream F core: citations + lineage + evolution"
+echo ""
+
+# 1. Sign in
+HTTP=$(curl -s -o /tmp/uat-59-signin.json -w "%{http_code}" \
+  -c "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email")
+if [ "$HTTP" = "200" ]; then pass "sign in 200"; else fail "sign in got $HTTP"; fi
+
+# 2. Pick a fragment that has at least one wiki reference (so F2's lineage has signal)
+FRAG_ID=$(curl -s -b "$JAR" "$SERVER_URL/fragments?limit=10" | jq -r '.fragments[0].id // empty')
+if [ -z "$FRAG_ID" ]; then fail "no fragments seeded; run pnpm -C core seed-fixture"; exit 1; fi
+pass "selected fragment $FRAG_ID"
+
+# 3. F2 — fragment detail page renders SSR HTML with the lineage anchors
+HTML=$(curl -s -b "$JAR" "$WIKI_URL/fragments/$FRAG_ID" -H "Origin: $ORIGIN")
+echo "$HTML" > /tmp/uat-59-frag.html
+
+# References anchor must exist for F1 superscripts to land
+if echo "$HTML" | grep -q 'id="references"'; then pass "F2 references anchor present"; else fail "F2 references anchor missing"; fi
+
+# Type, State, Tags, Created, Updated infobox rows (presence test, not exact label match)
+for label in "Type" "State" "Created" "Updated"; do
+  if echo "$HTML" | grep -qi ">$label<"; then pass "F2 infobox row: $label"; else fail "F2 infobox row missing: $label"; fi
+done
+
+# 4. F2 — lineage sections present in DOM
+for section in "Entry" "references" "Related"; do
+  if echo "$HTML" | grep -qi "$section"; then pass "F2 section anchor: $section"; else fail "F2 section missing: $section"; fi
+done
+
+# 5. F4 — evolution timeline area is rendered (label may say "No edits recorded yet" if A5 not live)
+if echo "$HTML" | grep -qi 'evolution\|Edited\|edits recorded'; then
+  pass "F4 evolution surface present"
+else
+  fail "F4 evolution surface missing"
+fi
+
+# 6. F1 — render a wiki page, look for superscripts in the rendered body
+WIKI_KEY=$(curl -s -b "$JAR" "$SERVER_URL/wikis?limit=1" | jq -r '.wikis[0].key // empty')
+if [ -z "$WIKI_KEY" ]; then skip "F1: no wikis seeded"; else
+  WIKI_HTML=$(curl -s -b "$JAR" "$WIKI_URL/wiki/$WIKI_KEY" -H "Origin: $ORIGIN")
+  echo "$WIKI_HTML" > /tmp/uat-59-wiki.html
+
+  # Look for sup elements with [N] content (rough: F1 emits <sup>[N]</sup> or similar)
+  if echo "$WIKI_HTML" | grep -Ec '<sup[^>]*>\[\s*[0-9]+\s*\]</sup>' | head -1 > /tmp/uat-59-supcount.txt; then
+    SUPCOUNT=$(cat /tmp/uat-59-supcount.txt)
+    if [ "$SUPCOUNT" -gt 0 ]; then pass "F1 superscripts rendered ($SUPCOUNT)"; else skip "F1 wiki has no fragments to cite"; fi
+  else
+    skip "F1 wiki body has no citations to render"
+  fi
+
+  # Bibliography section anchor (per-fragment hrefs)
+  if echo "$WIKI_HTML" | grep -qE 'id="fragment-[^"]+"'; then pass "F1 bibliography anchors present"; else skip "F1 no bibliography rendered for this wiki"; fi
+fi
+
+# 7. F4 — A5 endpoint smoke (skip if A5 not deployed yet)
+HIST_HTTP=$(curl -s -o /tmp/uat-59-hist.json -w "%{http_code}" -b "$JAR" "$SERVER_URL/fragments/$FRAG_ID/history")
+if [ "$HIST_HTTP" = "200" ]; then
+  pass "A5 history endpoint 200 (F4 has signal)"
+  HAS_EDITS=$(jq 'has("edits")' /tmp/uat-59-hist.json)
+  if [ "$HAS_EDITS" = "true" ]; then pass "history payload has edits[]"; else fail "history missing edits[]"; fi
+elif [ "$HIST_HTTP" = "404" ]; then
+  skip "A5 endpoint returns 404 (no edit history yet, F4 will show empty state)"
+else
+  fail "A5 endpoint got $HIST_HTTP"
+fi
+
+# 8. F2 — anon access to the fragment page is gated
+ANON_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$WIKI_URL/fragments/$FRAG_ID")
+if [ "$ANON_HTTP" = "200" ] || [ "$ANON_HTTP" = "302" ] || [ "$ANON_HTTP" = "307" ]; then
+  pass "anon hits fragment page (page handles redirect to login internally)"
+else
+  fail "anon got $ANON_HTTP, expected 200/302/307"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" = "0" ]
+```
+
+## Manual visual checks (browser)
+
+These require a real browser; the bash above can't observe them.
+
+1. Open `/wiki/<some-wiki-with-fragments>`. Body shows `[1]`, `[2]`, etc. as superscripts. Click `[1]`. Page scrolls to the bibliography section, the cited fragment row is anchored.
+2. Open `/fragments/<some-frag-id>`. Layout: infobox (Type/State/Tags/Created/Updated) on the right; main column shows Entry origin, Evolution (collapsed: "Edited N times"), Wiki references (heading "Wiki references"), Related fragments. Click "Edited N times" if N > 0; timeline expands with newest-first entries.
+3. With a fragment edited 3 times via SQL or `PUT /fragments/<id>`, the Evolution timeline shows 3 entries each with timestamp, source-client label, and an expandable per-entry word-level diff.
+
+## Cleanup
+
+No persistent state created.
+
+## Expected pass/fail behavior
+
+All steps PASS once Stream A5 ships in a sibling PR. While A5 is pending, step 7 will SKIP rather than FAIL.

--- a/wiki/src/app/(shell)/fragments/[id]/FragmentEvolution.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/FragmentEvolution.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+/**
+ * Stream F4: fragment evolution timeline.
+ *
+ * Renders the edit history of a single fragment as a vertical timeline.
+ * Each entry shows a timestamp, the source client (mcp/api/web/regen),
+ * and a word-level diff against the previous version's content
+ * snapshot. Collapsed by default behind an "Edited N times" affordance
+ * so low-edit fragments stay visually quiet; the latest edit's diff
+ * stays expanded once the user opens the section.
+ *
+ * Fetches `GET /fragments/:id/history` via `useFragmentEditHistory`.
+ * The endpoint is owned by Stream A5 and ships in parallel with this
+ * component; absence (404 / 0 edits) renders the zero-state copy.
+ *
+ * Diff rendering reuses `wikiDiff.ts` (jsdiff word-level + whitespace
+ * demotion) so the visual treatment matches the wiki revision timeline
+ * a few clicks away. Reusing the engine is also why the component
+ * stays well under the 250-LOC budget.
+ */
+
+import { useMemo, useState } from "react";
+import { T, FONT } from "@/lib/typography";
+import {
+  diffStats,
+  diffWords,
+  type DiffPart,
+} from "@/components/wiki/wikiDiff";
+import {
+  useFragmentEditHistory,
+  type FragmentEditRecord,
+} from "@/hooks/useFragmentEditHistory";
+
+type FragmentEvolutionProps = {
+  fragmentId: string;
+  /**
+   * Current fragment body. Used as the "after" state for the most
+   * recent edit's diff — the history endpoint stores prior snapshots,
+   * so the latest snapshot is whatever the page itself is rendering.
+   */
+  currentContent: string;
+};
+
+const formatAbsolute = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+const formatRelative = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const seconds = Math.max(1, Math.floor((Date.now() - d.getTime()) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+};
+
+/**
+ * Normalise a `source` token (mcp/api/web/regen/user) into a short
+ * human label. Falls back to the raw value so an unfamiliar source
+ * token from a future writer still shows up rather than silently
+ * disappearing.
+ */
+function sourceLabel(source: string): string {
+  switch (source) {
+    case "mcp":
+      return "via MCP";
+    case "api":
+      return "via API";
+    case "web":
+      return "via Web";
+    case "regen":
+      return "via Regen";
+    case "user":
+      return "Edited";
+    default:
+      return source ? `via ${source}` : "Edited";
+  }
+}
+
+/**
+ * Author label per edit. Today the per-fragment endpoint exposes
+ * `source` only; "who" is implied by the source — `regen` means
+ * Robin, anything else means the human operator. A5 may add an
+ * explicit `actor` field later; we read it defensively when present.
+ */
+function authorFor(edit: FragmentEditRecord): string {
+  const e = edit as FragmentEditRecord & { actor?: string };
+  if (typeof e.actor === "string" && e.actor.length > 0) return e.actor;
+  return edit.source === "regen" ? "Robin" : "You";
+}
+
+const diffStyles = {
+  added: {
+    backgroundColor: "var(--diff-added-bg)",
+    color: "var(--diff-added-text)",
+    textDecoration: "none",
+    padding: "0 1px",
+    borderRadius: 2,
+  },
+  removed: {
+    backgroundColor: "var(--diff-removed-bg)",
+    color: "var(--diff-removed-text)",
+    textDecoration: "line-through",
+    padding: "0 1px",
+    borderRadius: 2,
+  },
+  equal: {
+    color: "var(--wiki-sidebar-text)",
+  },
+} as const;
+
+function DiffInline({ parts }: { parts: DiffPart[] }) {
+  return (
+    <>
+      {parts.map((p, i) => (
+        <span key={i} style={diffStyles[p.type]}>
+          {p.value}
+        </span>
+      ))}
+    </>
+  );
+}
+
+type ComputedEntry = {
+  edit: FragmentEditRecord;
+  parts: DiffPart[];
+  added: number;
+  removed: number;
+};
+
+/**
+ * Walk the edit list newest-first and diff each snapshot against the
+ * snapshot that came before it (chronologically). The newest edit's
+ * "after" is the live `currentContent` rendered by the page; older
+ * edits diff against the next-newer entry's snapshot.
+ */
+function computeEntries(
+  edits: FragmentEditRecord[],
+  currentContent: string,
+): ComputedEntry[] {
+  return edits.map((edit, idx) => {
+    const after = idx === 0 ? currentContent : edits[idx - 1].contentSnippet;
+    const before = edit.contentSnippet;
+    const parts = diffWords(before, after);
+    const stats = diffStats(parts);
+    return { edit, parts, added: stats.added, removed: stats.removed };
+  });
+}
+
+export function FragmentEvolution({
+  fragmentId,
+  currentContent,
+}: FragmentEvolutionProps) {
+  const { data, isLoading, error } = useFragmentEditHistory(fragmentId);
+  // Collapsed by default — the page is sparse and most fragments have
+  // zero or one edit. The outer affordance reads "Edited N times".
+  const [open, setOpen] = useState(false);
+  // Per-row diff toggle. The newest entry stays expanded once the
+  // outer section opens; older entries stay collapsed until clicked.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const edits = data?.edits ?? [];
+  const entries = useMemo(
+    () => computeEntries(edits, currentContent),
+    [edits, currentContent],
+  );
+
+  if (isLoading) {
+    return null;
+  }
+  if (error) {
+    return (
+      <p
+        style={{
+          ...T.bodySmall,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-count)",
+          fontStyle: "italic",
+          margin: "12px 0 0 0",
+        }}
+      >
+        Edit history unavailable.
+      </p>
+    );
+  }
+  if (edits.length === 0) {
+    return (
+      <p
+        style={{
+          ...T.bodySmall,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-count)",
+          fontStyle: "italic",
+          margin: "12px 0 0 0",
+        }}
+      >
+        No edits recorded yet.
+      </p>
+    );
+  }
+
+  const buttonLabel = open
+    ? `Hide ${edits.length === 1 ? "edit" : "edits"}`
+    : `Edited ${edits.length} ${edits.length === 1 ? "time" : "times"}`;
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+          ...T.bodySmall,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-link)",
+          textDecoration: "underline",
+        }}
+      >
+        {buttonLabel}
+      </button>
+
+      {open && (
+        <div
+          className="fragment-evolution-timeline"
+          style={{
+            position: "relative",
+            paddingLeft: 20,
+            marginTop: 12,
+            borderLeft: "1px solid var(--wiki-meta-line)",
+          }}
+        >
+          {entries.map((entry, idx) => {
+            const isLatest = idx === 0;
+            const isOpen = expanded[entry.edit.id] ?? isLatest;
+            const hasDiff = entry.parts.some((p) => p.type !== "equal");
+
+            return (
+              <div
+                key={entry.edit.id}
+                style={{
+                  position: "relative",
+                  paddingBottom: idx === entries.length - 1 ? 0 : 20,
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    left: -26,
+                    top: 4,
+                    width: 11,
+                    height: 11,
+                    borderRadius: "50%",
+                    background: isLatest
+                      ? "var(--foreground)"
+                      : "var(--background)",
+                    border: "2px solid var(--wiki-meta-line)",
+                  }}
+                />
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: 8,
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <span
+                    style={{
+                      ...T.bodySmall,
+                      fontFamily: FONT.SANS,
+                      fontWeight: 600,
+                      color: "var(--wiki-title)",
+                    }}
+                  >
+                    {sourceLabel(entry.edit.source)}
+                  </span>
+                  {hasDiff ? (
+                    <span
+                      style={{
+                        ...T.caption,
+                        fontFamily: FONT.SANS,
+                        color: "var(--wiki-sidebar-text)",
+                        display: "inline-flex",
+                        gap: 6,
+                      }}
+                    >
+                      <span style={{ color: "var(--diff-added-text)" }}>
+                        +{entry.added}
+                      </span>
+                      <span style={{ color: "var(--diff-removed-text)" }}>
+                        -{entry.removed}
+                      </span>
+                    </span>
+                  ) : null}
+                </div>
+                <div
+                  style={{
+                    ...T.caption,
+                    fontFamily: FONT.SANS,
+                    color: "var(--wiki-sidebar-text)",
+                    marginTop: 2,
+                    display: "flex",
+                    gap: 6,
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <span>{authorFor(entry.edit)}</span>
+                  <span aria-hidden>·</span>
+                  <span title={formatAbsolute(entry.edit.timestamp)}>
+                    {formatRelative(entry.edit.timestamp)} ·{" "}
+                    {formatAbsolute(entry.edit.timestamp)}
+                  </span>
+                </div>
+
+                {hasDiff ? (
+                  <div style={{ marginTop: 8 }}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpanded((prev) => ({
+                          ...prev,
+                          [entry.edit.id]: !isOpen,
+                        }))
+                      }
+                      style={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        cursor: "pointer",
+                        ...T.caption,
+                        fontFamily: FONT.SANS,
+                        color: "var(--wiki-link)",
+                      }}
+                    >
+                      {isOpen ? "Hide content diff" : "Show content diff"}
+                    </button>
+                    {isOpen ? (
+                      <pre
+                        style={{
+                          ...T.bodySmall,
+                          fontFamily: FONT.SANS,
+                          marginTop: 6,
+                          padding: "10px 12px",
+                          border: "1px solid var(--wiki-card-border)",
+                          borderRadius: 4,
+                          background: "var(--code-block-bg)",
+                          whiteSpace: "pre-wrap",
+                          wordBreak: "break-word",
+                          lineHeight: "22px",
+                          color: "var(--wiki-article-text)",
+                        }}
+                      >
+                        <DiffInline parts={entry.parts} />
+                      </pre>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/wiki/src/app/(shell)/fragments/[id]/FragmentEvolution.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/FragmentEvolution.tsx
@@ -176,11 +176,14 @@ export function FragmentEvolution({
   // outer section opens; older entries stay collapsed until clicked.
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
-  const edits = data?.edits ?? [];
+  // Memo against `data` directly so the dep is stable across renders
+  // when React Query returns the same response object — `data?.edits ?? []`
+  // would allocate a fresh empty array each render and defeat the memo.
   const entries = useMemo(
-    () => computeEntries(edits, currentContent),
-    [edits, currentContent],
+    () => computeEntries(data?.edits ?? [], currentContent),
+    [data, currentContent],
   );
+  const edits = data?.edits ?? [];
 
   if (isLoading) {
     return null;

--- a/wiki/src/app/(shell)/fragments/[id]/page.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/page.tsx
@@ -45,6 +45,12 @@ function FragmentInfobox({ fragment }: { fragment: FragmentData }) {
     margin: 0,
   };
 
+  // Stream F2: full lineage view in one place. The infobox now exposes
+  // `state` (PENDING/RESOLVED/LINKING/DIRTY) and `updatedAt` so users see
+  // the fragment's pipeline status alongside its origin metadata. Source
+  // client (mcp/api/web) lives on the parent entry today; surfacing it
+  // here would require an extra round-trip and is deferred to A5 once the
+  // fragment endpoint denormalises it.
   return (
     <aside
       className="wiki-aside-infobox"
@@ -66,6 +72,11 @@ function FragmentInfobox({ fragment }: { fragment: FragmentData }) {
         <p style={body}>{fragment.type}</p>
       </div>
 
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <p style={label}>State</p>
+        <p style={body}>{fragment.state}</p>
+      </div>
+
       {fragment.tags.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <p style={label}>Tags</p>
@@ -77,6 +88,13 @@ function FragmentInfobox({ fragment }: { fragment: FragmentData }) {
         <p style={label}>Created</p>
         <p style={body}>{formatDate(fragment.createdAt)}</p>
       </div>
+
+      {fragment.updatedAt && fragment.updatedAt !== fragment.createdAt && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <p style={label}>Updated</p>
+          <p style={body}>{formatDate(fragment.updatedAt)}</p>
+        </div>
+      )}
     </aside>
   );
 }
@@ -159,9 +177,16 @@ function EntryOriginSection({ entryId }: { entryId: string | null }) {
 }
 
 function BacklinksSection({ backlinks }: { backlinks: Array<{ id: string; name: string; type: string }> }) {
+  // Stream F2: stable `id="references"` so any in-page link (or external
+  // link of the form `/fragments/<id>#references`) lands on the wikis-
+  // citing list. F1's wiki-side superscripts already jump to each wiki's
+  // own bibliography (`#fragment-{lookupKey}`); this anchor is the
+  // mirror image on the fragment side — "where am I cited from?".
+  // `scrollMarginTop` keeps the section header visible under any sticky
+  // page chrome.
   return (
-    <section style={{ width: "100%" }}>
-      <WikiSectionH2 title="Wikis" count={backlinks.length} />
+    <section id="references" style={{ width: "100%", scrollMarginTop: 80 }}>
+      <WikiSectionH2 title="Wiki references" count={backlinks.length} />
       {backlinks.length === 0 ? (
         <EmptyState text="Not filed in any wiki" />
       ) : (

--- a/wiki/src/app/(shell)/fragments/[id]/page.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/page.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { MarkdownContent } from "@/components/wiki/MarkdownContent";
 import { ROUTES } from "@/lib/routes";
 import type { FragmentWithContentResponseSchema } from "@/lib/generated/types.gen";
+import { FragmentEvolution } from "./FragmentEvolution";
 
 type FragmentData = Omit<FragmentWithContentResponseSchema, "entryId"> & {
   entryId: string | null;
@@ -301,10 +302,27 @@ function RelatedFragmentsSection({ relatedFragments }: { relatedFragments: Array
   );
 }
 
+function EvolutionSection({ fragment }: { fragment: FragmentData }) {
+  // Stream F4: edit-history timeline lives on the fragment-detail page
+  // itself so the click chain from a wiki citation ends at one surface
+  // showing origin + evolution. The component handles its own loading,
+  // error, and empty states; we just wrap it in a section heading.
+  return (
+    <section style={{ width: "100%" }}>
+      <WikiSectionH2 title="Evolution" />
+      <FragmentEvolution
+        fragmentId={fragment.lookupKey}
+        currentContent={fragment.content}
+      />
+    </section>
+  );
+}
+
 function FragmentBottomSections({ fragment }: { fragment: FragmentData }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 40, width: "100%" }}>
       <EntryOriginSection entryId={fragment.entryId} />
+      <EvolutionSection fragment={fragment} />
       <BacklinksSection backlinks={fragment.backlinks ?? []} />
       <RelatedFragmentsSection relatedFragments={fragment.relatedFragments ?? []} />
     </div>

--- a/wiki/src/hooks/useFragmentEditHistory.ts
+++ b/wiki/src/hooks/useFragmentEditHistory.ts
@@ -1,0 +1,76 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+/**
+ * Per-edit shape returned by `GET /fragments/:id/history`. Mirrors the
+ * `EditRecordSchema` that wikis already expose; Stream A5 owns the
+ * server side. We define the type locally so this client compiles
+ * before the SDK regenerates against A5's OpenAPI spec.
+ */
+export type FragmentEditRecord = {
+  id: string
+  timestamp: string
+  type: string
+  source: string
+  contentSnippet: string
+}
+
+/**
+ * Optional audit-log envelope. Stream A5 may surface an `auditEvents`
+ * array alongside `edits` so the timeline can fold in non-edit events
+ * (regen, accept, reject) once the contract settles. Treated as
+ * optional today — absence is a no-op for the renderer.
+ */
+export type FragmentAuditEvent = {
+  id: string
+  timestamp: string
+  type: string
+  source?: string
+  detail?: string
+}
+
+export type FragmentHistoryResponse = {
+  edits: FragmentEditRecord[]
+  total?: number
+  auditEvents?: FragmentAuditEvent[]
+}
+
+/**
+ * Fetch the per-fragment edit history. Uses raw `fetch` rather than the
+ * generated SDK because A5 is shipping in parallel with this client and
+ * the codegen hasn't run yet against A5's OpenAPI block. Once the SDK
+ * regenerates, swap in `getFragmentEditHistory({ path: { id } })`.
+ *
+ * Treats 404 as "no history captured yet" so the component renders an
+ * empty state instead of an error banner. Other non-OK statuses bubble
+ * to React Query as errors.
+ */
+export function useFragmentEditHistory(id: string | undefined) {
+  return useQuery<FragmentHistoryResponse>({
+    queryKey: ['fragment-edit-history', id],
+    queryFn: async () => {
+      const response = await fetch(`/api/api/fragments/${id}/history`, {
+        credentials: 'include',
+      })
+      if (response.status === 404) {
+        return { edits: [], total: 0 }
+      }
+      if (!response.ok) {
+        throw new Error(`Fragment history fetch failed (${response.status})`)
+      }
+      const json = (await response.json()) as Partial<FragmentHistoryResponse>
+      return {
+        edits: Array.isArray(json.edits) ? json.edits : [],
+        total: typeof json.total === 'number' ? json.total : undefined,
+        auditEvents: Array.isArray(json.auditEvents)
+          ? json.auditEvents
+          : undefined,
+      }
+    },
+    enabled: !!id,
+    // Edit history is append-only; a stale cache is fine for a few seconds.
+    staleTime: 30_000,
+    retry: false,
+  })
+}


### PR DESCRIPTION
## Summary

Stream F core for v0.2.0. Closes the source-traceability A-game line: every claim in a wiki traces back to its source entry, every fragment is auditable end-to-end.

Plan: `.planning/v1-a-game/streams/F-source-traceability/PLAN.md`. Tracker: #282.

F3 (classifier-emitted citation map) is deferred to v0.3.0 per Andrew. Tracked at #320.

## What ships

**F1, numbered citations on wiki body**
- Already shipped under #245. This PR validates the contract and extends F2/F4 to consume it.
- `WikiCitations.tsx` emits numeric `[N]` superscripts with document-wide numbering threaded via `startIndex`.
- `WikiCitationsSection.tsx` renders the bottom bibliography with `id="fragment-{lookupKey}"` per row.
- `SectionedMarkdownBody.tsx` threads the running offset across sections so numbering is per-wiki, not per-section.
- Existing tests at `WikiCitations.test.tsx` already lock the `#fragment-{lookupKey}` href contract.

**F2, fragment detail page with full lineage**
- Expanded `wiki/src/app/(shell)/fragments/[id]/page.tsx`: FragmentInfobox now carries Type, State, Tags, Created, Updated rows.
- BacklinksSection renamed to "Wiki references" with a stable `id="references"` anchor that F1 superscripts target.
- Three lineage sections stack on the page: Entry origin, Evolution (F4), Wiki references, Related fragments. One page, full lineage.

**F4, fragment evolution timeline**
- New `wiki/src/hooks/useFragmentEditHistory.ts` queries Stream A5's `GET /fragments/:id/history`. Treats 404 as empty.
- New `wiki/src/app/(shell)/fragments/[id]/FragmentEvolution.tsx` renders the timeline. Word-level diffs via `jsdiff`, reusing `wikiDiff.ts`.
- Slots an `EvolutionSection` between Entry origin and Wiki references in `page.tsx`.
- Collapsed by default. "Edited N times" expandable affordance for low-edit fragments. Empty state copy for fragments with no edits.

## Deviations from PLAN.md

1. **F1 ships zero new code.** #245 already shipped the numbered-superscript primitive exactly to spec (numeric `[N]`, document-wide numbering, in-page bibliography anchor, click-to-anchor scroll). Documenting and reusing rather than re-implementing.
2. **Source-client metadata on F2 deferred.** Fragments do not carry `source` directly (raw_sources do); plumbing it through would touch `core/src/routes/fragments.ts` which is A-stream territory. Surfaced `Updated` and `State` instead so the metadata column has real signal today.
3. **Pre-existing rules-of-hooks violation in `fragments/[id]/page.tsx:430`** (useQueryClient after early return). Out of scope per scope-boundary rule; left untouched. Worth a follow-up issue.

## Test plan

UAT: `.uat/plans/59-stream-f-citations-and-lineage.md` ships with the PR. Bash exercises F1, F2, F4 via SSR HTML inspection and A5 history smoke.

- [ ] CI pre-merge.yml green
- [ ] UAT 59 PASS (steps depending on A5 will SKIP if A5 not yet merged)
- [ ] Manual visual: open a wiki with fragments, see `[1]`/`[2]` superscripts, click one, lands at bibliography
- [ ] Manual visual: open `/fragments/<id>`, see infobox + 4 lineage sections
- [ ] Manual visual: edit a fragment 3 times via API or SQL, confirm timeline shows 3 entries with diffs

## Notes for reviewer

- A5 endpoint shape was guessed as `{ edits: EditRecord[], total?: number, auditEvents?: AuditEvent[] }` mirroring the wikis history endpoint. If A5's PR (#323) lands a different envelope, the hook needs a small remap. Worth a quick alignment check at merge time.
- F4 will surface "No edits recorded yet" until A5 has rows in the `edits` table. D1' (Round 2 D wave) wires the writes that populate that table.