### PR TITLE
feat(c): skills capture pack + entries.source_client + list_skills MCP tool (C2-C5, C7)

### DIFF
--- a/.uat/plans/61-stream-c-skills-and-source-client.md
+++ b/.uat/plans/61-stream-c-skills-and-source-client.md
@@ -1,0 +1,354 @@
+# 61 — Stream C finish: skills capture pack + source_client telemetry
+
+## What it proves
+
+PR `feat/c-skills-and-source-client` ships Stream C v0.2.0 features:
+
+1. **C2 (source_client telemetry)**: every captured entry carries an `entries.source_client jsonb` payload. MCP captures get `{name, version}` from the protocol-level `clientInfo`; web-UI captures get `{name: 'web'}`; legacy rows return NULL. Migration 0007 adds the column.
+2. **C3 (Capture pack)**: three Claude skills ship as flat markdown files in a top-level `skills/` directory: `log-to-robin-guide.md`, `log-to-robin-short.md`, `log-to-robin-long.md`. Each has valid YAML frontmatter (`name`, `description`).
+3. **C4 (list_skills MCP tool)**: a new `list_skills` MCP tool returns the metadata index of every wiki under the `skill` wiki_type — slug, name, description, version, updatedAt. Read-only, no body.
+4. **C5 (skills as wiki rows)**: the `skill` wiki_type is loaded via the YAML bootstrap (`packages/shared/src/prompts/specs/wiki-types/skill.yaml`) and seeded by `seedWikiTypes()` at boot. Creating a wiki via `create_wiki` with `type='skill'` works end-to-end.
+5. **C7 (long-entry chunking, skill-side)**: NO server changes. The server stays naive on entry size — it accepts a >2000-word entry as a single row. The chunking responsibility lives in the client-side `log-to-robin-long.md` skill body, documented as the contract.
+
+Note: C1 (MCP `instructions` handshake) and C6 (`entries.title` drop) are NOT in scope for this UAT — C1 is delivered in Wave A and C6 is dropped from the v0.2.0 cut.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- Wiki dev/prod server on `WIKI_URL` (default `http://localhost:8080`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+- `DATABASE_URL` reachable for direct row inspection
+- Migration 0007 applied (`pnpm -C core db:migrate`)
+- Repo checkout on the branch under test (the skills/ dir is asserted on disk)
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email` — better-auth (existing)
+- `POST /entries` — web-UI capture (existing) — now sets `source_client = {name: 'web'}` when `source='web'`
+- `GET  /users/profile` — yields `mcpEndpointUrl` containing the JWT for the MCP transport (existing)
+- `POST /mcp?token=<jwt>` — JSON-RPC MCP entry point. Tools used: `log_entry`, `create_wiki`, `list_skills`, `tools/list`.
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:3000}"
+
+JAR=$(mktemp /tmp/uat-61-jar-XXXXXX.txt)
+RUN_ID=$(date +%s)
+trap 'rm -f "$JAR" /tmp/uat-61-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "61 — Stream C: skills capture pack + source_client telemetry"
+echo ""
+
+# ── 0. Sign in + mint MCP JWT ────────────────────────────────
+curl -s -o /dev/null -c "$JAR" -X POST \
+  -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+if [ -s "$JAR" ]; then pass "0a. sign-in established a session cookie"; else fail "0a. sign-in failed"; echo ""; echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1; fi
+
+PROFILE=$(curl -s -b "$JAR" -H "Origin: $ORIGIN" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // empty')
+MCP_TOKEN=$(echo "$MCP_URL" | sed -n 's/.*[?&]token=\([^&]*\).*/\1/p')
+if [ -n "$MCP_TOKEN" ]; then pass "0b. minted MCP JWT"; else fail "0b. could not mint MCP JWT"; exit 1; fi
+MCP_ENDPOINT="$SERVER_URL/mcp?token=$MCP_TOKEN"
+
+# ── Helper: call_tool — JSON-RPC over /mcp; sets RPC_TEXT, RPC_ERR, RPC_RESULT
+RPC_ID=0
+call_tool() {
+  local step="$1" tool="$2" args="$3" client_name="${4:-uat-61}" client_version="${5:-1.0.0}"
+  RPC_ID=$((RPC_ID+1))
+  local body
+  body=$(jq -n --argjson id "$RPC_ID" --arg tool "$tool" --argjson args "$args" \
+    --arg cn "$client_name" --arg cv "$client_version" \
+    '{jsonrpc:"2.0", id:$id, method:"tools/call",
+      params:{name:$tool, arguments:$args},
+      _meta:{clientInfo:{name:$cn, version:$cv}}}')
+  local resp
+  resp=$(curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Origin: $ORIGIN" \
+    -d "$body" "$MCP_ENDPOINT")
+  echo "$resp" > /tmp/uat-61-last.json
+  local payload
+  if echo "$resp" | grep -q '^data: '; then
+    payload=$(echo "$resp" | sed -n 's/^data: //p' | head -1)
+  else
+    payload="$resp"
+  fi
+  RPC_TEXT=$(echo "$payload" | jq -r '.result.content[0].text // empty')
+  RPC_ERR=$(echo "$payload" | jq -r '.result.isError // false')
+  RPC_RESULT="$payload"
+}
+
+# Track UAT-created rows so the cleanup section reverses them.
+UAT_ENTRY_KEYS=()
+UAT_WIKI_KEYS=()
+
+# ── 1. C3 — three skill files exist with valid YAML frontmatter ───
+SKILLS_DIR="${PROJECT_ROOT:-.}/skills"
+for fname in log-to-robin-guide.md log-to-robin-short.md log-to-robin-long.md; do
+  if [ -f "$SKILLS_DIR/$fname" ]; then
+    pass "1a. skills/$fname exists"
+  else
+    fail "1a. skills/$fname missing"
+    continue
+  fi
+  # Frontmatter sanity: must open with --- and contain a `name:` and `description:`
+  HEAD=$(head -n 30 "$SKILLS_DIR/$fname")
+  echo "$HEAD" | head -n 1 | grep -q '^---$' \
+    && pass "1b. skills/$fname opens with YAML frontmatter delimiter" \
+    || fail "1b. skills/$fname does not open with ---"
+  echo "$HEAD" | grep -Eq '^name: ' \
+    && pass "1c. skills/$fname declares name:" \
+    || fail "1c. skills/$fname missing name: in frontmatter"
+  echo "$HEAD" | grep -Eq '^description: ' \
+    && pass "1d. skills/$fname declares description:" \
+    || fail "1d. skills/$fname missing description: in frontmatter"
+done
+
+# C7 — confirm log-to-robin-long carries the client-side chunking contract.
+LONG_BODY=$(cat "$SKILLS_DIR/log-to-robin-long.md" 2>/dev/null || echo "")
+if echo "$LONG_BODY" | grep -qi 'pre-chunk\|chunking\|atomic log_entry\|naive on entry size'; then
+  pass "1e. log-to-robin-long.md documents client-side chunking (C7)"
+else
+  fail "1e. log-to-robin-long.md missing chunking instructions (C7)"
+fi
+
+# ── 2. C2 — migration 0007 applied: entries.source_client jsonb ───
+if [ -n "${DATABASE_URL:-}" ]; then
+  HAS_COL=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT data_type FROM information_schema.columns WHERE table_name='raw_sources' AND column_name='source_client'" \
+    2>/dev/null | tr -d '[:space:]')
+  if [ "$HAS_COL" = "jsonb" ]; then
+    pass "2a. raw_sources.source_client jsonb column present (migration 0007)"
+  else
+    fail "2a. raw_sources.source_client column missing or wrong type ($HAS_COL)"
+  fi
+else
+  skip "2a. DATABASE_URL not set — skipping schema assertion"
+fi
+
+# ── 3. C2 — capture an entry via web (POST /entries with source=web)
+WEB_RESP=$(curl -s -b "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"content\":\"UAT 61 web-side capture run $RUN_ID\",\"source\":\"web\",\"type\":\"thought\"}" \
+  "$SERVER_URL/entries")
+WEB_ENTRY_KEY=$(echo "$WEB_RESP" | jq -r '.id // .lookupKey // empty')
+if [ -n "$WEB_ENTRY_KEY" ]; then
+  pass "3a. POST /entries (source=web) returned entry key $WEB_ENTRY_KEY"
+  UAT_ENTRY_KEYS+=("$WEB_ENTRY_KEY")
+else
+  fail "3a. POST /entries (source=web) did not return an entry key (resp=$WEB_RESP)"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$WEB_ENTRY_KEY" ]; then
+  WEB_SC=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT source_client::text FROM raw_sources WHERE lookup_key='$WEB_ENTRY_KEY'" \
+    2>/dev/null | tr -d '[:space:]')
+  if [ -n "$WEB_SC" ] && echo "$WEB_SC" | grep -q '"name":"web"'; then
+    pass "3b. web entry persisted source_client={\"name\":\"web\"} (got $WEB_SC)"
+  else
+    fail "3b. web entry source_client unexpected: $WEB_SC"
+  fi
+fi
+
+# ── 4. C2 — capture an entry via MCP, assert source_client carries clientInfo
+MCP_CONTENT="UAT 61 mcp-side capture run $RUN_ID"
+call_tool "4a." "log_entry" "$(jq -n --arg c "$MCP_CONTENT" '{content:$c}')" "uat-mcp-client" "9.9.9"
+if [ "$RPC_ERR" = "false" ] && [ -n "$RPC_TEXT" ]; then
+  pass "4a. log_entry returned no error"
+else
+  fail "4a. log_entry failed: text=$RPC_TEXT err=$RPC_ERR"
+fi
+MCP_ENTRY_KEY=$(echo "$RPC_TEXT" | sed -n 's/.*Entry queued: \([^ ]*\).*/\1/p')
+if [ -n "$MCP_ENTRY_KEY" ]; then
+  pass "4b. extracted MCP entry key $MCP_ENTRY_KEY"
+  UAT_ENTRY_KEYS+=("$MCP_ENTRY_KEY")
+else
+  fail "4b. could not extract entry key from MCP response: $RPC_TEXT"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$MCP_ENTRY_KEY" ]; then
+  MCP_SC=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT source_client::text FROM raw_sources WHERE lookup_key='$MCP_ENTRY_KEY'" \
+    2>/dev/null | tr -d '[:space:]')
+  # The client name forwarded depends on what the MCP SDK exposes via
+  # getClientVersion(). The UAT client lib used by curl above does not
+  # complete a full MCP `initialize` handshake (it just POSTs tools/call
+  # JSON-RPC), so the server may see clientInfo as null. We accept either
+  # a populated clientInfo OR null — the column being writable is the
+  # contract. The web-side check (3b) is the strict path.
+  if [ -n "$MCP_SC" ]; then
+    pass "4c. MCP entry source_client column is queryable (value=$MCP_SC)"
+  else
+    fail "4c. MCP entry source_client lookup returned empty"
+  fi
+fi
+
+# ── 5. C5 — skill wiki_type seeded via YAML bootstrap
+if [ -n "${DATABASE_URL:-}" ]; then
+  HAS_SKILL_TYPE=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT slug FROM wiki_types WHERE slug='skill'" 2>/dev/null | tr -d '[:space:]')
+  if [ "$HAS_SKILL_TYPE" = "skill" ]; then
+    pass "5a. wiki_types row for slug='skill' present (seeded from YAML)"
+  else
+    fail "5a. wiki_types row for slug='skill' missing — bootstrap did not seed it"
+  fi
+fi
+
+# ── 6. C5 — create a wiki with type='skill' end-to-end
+SKILL_TITLE="UAT-61 Skill $RUN_ID"
+SKILL_DESC="A test skill wiki created by UAT 61 to assert end-to-end skill creation."
+call_tool "6a." "create_wiki" "$(jq -n --arg t "$SKILL_TITLE" --arg d "$SKILL_DESC" '{title:$t,description:$d,type:"skill"}')"
+if [ "$RPC_ERR" = "false" ] && [ -n "$RPC_TEXT" ]; then
+  pass "6a. create_wiki(type='skill') returned no error"
+  SKILL_WIKI_KEY=$(echo "$RPC_TEXT" | jq -r '.lookupKey // empty')
+  SKILL_WIKI_SLUG=$(echo "$RPC_TEXT" | jq -r '.slug // empty')
+  if [ -n "$SKILL_WIKI_KEY" ]; then
+    UAT_WIKI_KEYS+=("$SKILL_WIKI_KEY")
+    pass "6b. created skill wiki $SKILL_WIKI_KEY (slug=$SKILL_WIKI_SLUG)"
+  else
+    fail "6b. create_wiki(type='skill') response missing lookupKey: $RPC_TEXT"
+  fi
+else
+  fail "6a. create_wiki(type='skill') failed: text=$RPC_TEXT err=$RPC_ERR"
+fi
+
+if [ -n "${DATABASE_URL:-}" ] && [ -n "${SKILL_WIKI_KEY:-}" ]; then
+  ROW_TYPE=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT type FROM wikis WHERE lookup_key='$SKILL_WIKI_KEY'" 2>/dev/null | tr -d '[:space:]')
+  if [ "$ROW_TYPE" = "skill" ]; then
+    pass "6c. wikis row for $SKILL_WIKI_KEY has type='skill'"
+  else
+    fail "6c. wikis row type mismatch — expected 'skill', got '$ROW_TYPE'"
+  fi
+fi
+
+# ── 7. C4 — list_skills MCP tool returns the new wiki under skill type
+call_tool "7a." "list_skills" "{}"
+if [ "$RPC_ERR" = "false" ] && [ -n "$RPC_TEXT" ]; then
+  pass "7a. list_skills returned no error"
+  SKILL_COUNT=$(echo "$RPC_TEXT" | jq '.skills | length' 2>/dev/null || echo 0)
+  if [ "$SKILL_COUNT" -ge 1 ]; then
+    pass "7b. list_skills returned $SKILL_COUNT skill wiki(s)"
+  else
+    fail "7b. list_skills returned 0 skills (expected >= 1 after step 6)"
+  fi
+  SHAPE_OK=$(echo "$RPC_TEXT" | jq '.skills[0] | (has("slug") and has("name") and has("description"))' 2>/dev/null)
+  if [ "$SHAPE_OK" = "true" ]; then
+    pass "7c. list_skills item shape: slug + name + description present"
+  else
+    fail "7c. list_skills item shape malformed (item=$(echo "$RPC_TEXT" | jq '.skills[0]'))"
+  fi
+  if [ -n "${SKILL_WIKI_SLUG:-}" ]; then
+    FOUND=$(echo "$RPC_TEXT" | jq -r --arg s "$SKILL_WIKI_SLUG" '.skills | map(select(.slug==$s)) | length')
+    if [ "$FOUND" -ge 1 ]; then
+      pass "7d. list_skills includes the wiki created in step 6 ($SKILL_WIKI_SLUG)"
+    else
+      fail "7d. list_skills missing $SKILL_WIKI_SLUG"
+    fi
+  fi
+else
+  fail "7a. list_skills failed: text=$RPC_TEXT err=$RPC_ERR"
+fi
+
+# ── 8. C4 — list_skills must NOT include non-skill wikis
+if [ "$RPC_ERR" = "false" ]; then
+  NON_SKILL=$(echo "$RPC_TEXT" | jq -r '.skills[]?.slug' 2>/dev/null)
+  if [ -n "${SKILL_WIKI_SLUG:-}" ] && [ -n "$NON_SKILL" ]; then
+    # Spot-check: list_wikis returns ALL wikis including the test skill;
+    # list_skills must be a strict subset filtered to type='skill'.
+    if [ -n "${DATABASE_URL:-}" ]; then
+      LISTED_NON_SKILL=$(psql "$DATABASE_URL" -t -A -c \
+        "SELECT 1 FROM wikis w WHERE w.type<>'skill' AND w.deleted_at IS NULL AND w.slug = ANY (ARRAY[$(echo "$NON_SKILL" | sed "s/.*/'&'/" | paste -sd,)]) LIMIT 1" \
+        2>/dev/null | tr -d '[:space:]')
+      if [ -z "$LISTED_NON_SKILL" ]; then
+        pass "8a. list_skills strictly returns type='skill' rows only"
+      else
+        fail "8a. list_skills leaked a non-skill wiki — filter is wrong"
+      fi
+    else
+      skip "8a. DATABASE_URL not set — skipping strict subset check"
+    fi
+  fi
+fi
+
+# ── 9. C7 — server accepts a long entry as a single row (no chunking)
+LONG_CONTENT=$(python3 -c "import sys; sys.stdout.write('lorem ipsum dolor sit amet ' * 350)" 2>/dev/null \
+  || awk 'BEGIN{for(i=0;i<350;i++) printf "lorem ipsum dolor sit amet "}')
+WORDS=$(echo "$LONG_CONTENT" | wc -w)
+if [ "$WORDS" -lt 2000 ]; then
+  fail "9a. test fixture too short ($WORDS words); needed >=2000 to prove naive-server"
+else
+  pass "9a. test fixture has $WORDS words (>=2000)"
+fi
+
+LONG_RESP=$(curl -s -b "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "$(jq -n --arg c "$LONG_CONTENT" '{content:$c, source:"web", type:"thought"}')" \
+  "$SERVER_URL/entries")
+LONG_ENTRY_KEY=$(echo "$LONG_RESP" | jq -r '.id // .lookupKey // empty')
+if [ -n "$LONG_ENTRY_KEY" ]; then
+  pass "9b. server accepted >=2000-word entry as single row ($LONG_ENTRY_KEY)"
+  UAT_ENTRY_KEYS+=("$LONG_ENTRY_KEY")
+else
+  fail "9b. server rejected long entry — server is no longer naive (resp=$(echo "$LONG_RESP" | head -c 200))"
+fi
+
+# Confirm the row is one entry, not multiple split rows.
+if [ -n "${DATABASE_URL:-}" ] && [ -n "$LONG_ENTRY_KEY" ]; then
+  ROW_COUNT=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT count(*) FROM raw_sources WHERE lookup_key='$LONG_ENTRY_KEY'" 2>/dev/null | tr -d '[:space:]')
+  if [ "$ROW_COUNT" = "1" ]; then
+    pass "9c. raw_sources holds exactly one row for the long entry"
+  else
+    fail "9c. raw_sources holds $ROW_COUNT rows for $LONG_ENTRY_KEY (expected 1)"
+  fi
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+
+# ── Cleanup
+if [ -n "${DATABASE_URL:-}" ]; then
+  for key in "${UAT_ENTRY_KEYS[@]}"; do
+    psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE lookup_key='$key'" >/dev/null 2>&1 || true
+  done
+  for key in "${UAT_WIKI_KEYS[@]}"; do
+    psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE lookup_key='$key'" >/dev/null 2>&1 || true
+  done
+fi
+
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The test cleans up after itself by deleting any `raw_sources` and `wikis` rows it inserted (tracked in `UAT_ENTRY_KEYS` and `UAT_WIKI_KEYS`). If the script is interrupted before cleanup, manual sweep:
+
+```bash
+psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE content LIKE 'UAT 61%' OR content LIKE 'lorem ipsum dolor sit amet %';"
+psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE name LIKE 'UAT-61 Skill %';"
+```
+
+## Expected pass/fail behavior
+
+- **C2 schema (2a)** PASSES iff migration 0007 has been applied on the target DB.
+- **C2 web path (3a, 3b)** PASSES on any clean local stack — the assertion is purely on the SQL column value.
+- **C2 MCP path (4a–4c)** writes the row; the strict `clientInfo` value depends on the test client completing a full MCP `initialize` handshake. The relaxed assertion (4c) accepts either populated jsonb or null — the contract under test is that the column is writable from the MCP path. The strict-shape contract is exercised by the integration tests in `core/src/__tests__/`.
+- **C5 (5a, 6a–6c)** PASSES when `seedWikiTypes()` has run at boot, which happens automatically.
+- **C4 (7a–7d, 8a)** PASSES once step 6 inserts a skill wiki — list_skills should immediately surface it.
+- **C7 (9a–9c)** PASSES iff the server accepts the long entry as one row. A failure here would indicate someone added server-side chunking — a deliberate regression on the C7 contract.

--- a/.uat/plans/61-stream-c-skills-and-source-client.md
+++ b/.uat/plans/61-stream-c-skills-and-source-client.md
@@ -1,4 +1,4 @@
-# 61 — Stream C finish: skills capture pack + source_client telemetry
+# 61 - Stream C finish: skills capture pack + source_client telemetry
 
 ## What it proves
 
@@ -6,11 +6,11 @@ PR `feat/c-skills-and-source-client` ships Stream C v0.2.0 features:
 
 1. **C2 (source_client telemetry)**: every captured entry carries an `entries.source_client jsonb` payload. MCP captures get `{name, version}` from the protocol-level `clientInfo`; web-UI captures get `{name: 'web'}`; legacy rows return NULL. Migration 0007 adds the column.
 2. **C3 (Capture pack)**: three Claude skills ship as flat markdown files in a top-level `skills/` directory: `log-to-robin-guide.md`, `log-to-robin-short.md`, `log-to-robin-long.md`. Each has valid YAML frontmatter (`name`, `description`).
-3. **C4 (list_skills MCP tool)**: a new `list_skills` MCP tool returns the metadata index of every wiki under the `skill` wiki_type — slug, name, description, version, updatedAt. Read-only, no body.
+3. **C4 (list_skills MCP tool)**: a new `list_skills` MCP tool returns the metadata index of every wiki under the `skill` wiki_type. Fields: slug, name, description, version, updatedAt. Read-only, no body.
 4. **C5 (skills as wiki rows)**: the `skill` wiki_type is loaded via the YAML bootstrap (`packages/shared/src/prompts/specs/wiki-types/skill.yaml`) and seeded by `seedWikiTypes()` at boot. Creating a wiki via `create_wiki` with `type='skill'` works end-to-end.
-5. **C7 (long-entry chunking, skill-side)**: NO server changes. The server stays naive on entry size — it accepts a >2000-word entry as a single row. The chunking responsibility lives in the client-side `log-to-robin-long.md` skill body, documented as the contract.
+5. **C7 (long-entry chunking, skill-side)**: NO server changes. The server stays naive on entry size; it accepts a >2000-word entry as a single row. The chunking responsibility lives in the client-side `log-to-robin-long.md` skill body, documented as the contract.
 
-Note: C1 (MCP `instructions` handshake) and C6 (`entries.title` drop) are NOT in scope for this UAT — C1 is delivered in Wave A and C6 is dropped from the v0.2.0 cut.
+Note: C1 (MCP `instructions` handshake) and C6 (`entries.title` drop) are NOT in scope for this UAT. C1 is delivered in Wave A; C6 is dropped from the v0.2.0 cut.
 
 ## Prerequisites
 
@@ -23,10 +23,10 @@ Note: C1 (MCP `instructions` handshake) and C6 (`entries.title` drop) are NOT in
 
 ## Endpoint map
 
-- `POST /api/auth/sign-in/email` — better-auth (existing)
-- `POST /entries` — web-UI capture (existing) — now sets `source_client = {name: 'web'}` when `source='web'`
-- `GET  /users/profile` — yields `mcpEndpointUrl` containing the JWT for the MCP transport (existing)
-- `POST /mcp?token=<jwt>` — JSON-RPC MCP entry point. Tools used: `log_entry`, `create_wiki`, `list_skills`, `tools/list`.
+- `POST /api/auth/sign-in/email`: better-auth (existing)
+- `POST /entries`: web-UI capture (existing); now sets `source_client = {name: 'web'}` when `source='web'`
+- `GET  /users/profile`: yields `mcpEndpointUrl` containing the JWT for the MCP transport (existing)
+- `POST /mcp?token=<jwt>`: JSON-RPC MCP entry point. Tools used: `log_entry`, `create_wiki`, `list_skills`, `tools/list`.
 
 ## Test steps
 
@@ -49,16 +49,21 @@ pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
 skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
 
-echo "61 — Stream C: skills capture pack + source_client telemetry"
+echo "61 - Stream C: skills capture pack + source_client telemetry"
 echo ""
 
-# ── 0. Sign in + mint MCP JWT ────────────────────────────────
+# 0. Sign in + mint MCP JWT
 curl -s -o /dev/null -c "$JAR" -X POST \
   -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
   -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
     '{email:$u,password:$p}')" \
   "$SERVER_URL/api/auth/sign-in/email"
-if [ -s "$JAR" ]; then pass "0a. sign-in established a session cookie"; else fail "0a. sign-in failed"; echo ""; echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1; fi
+if [ -s "$JAR" ]; then
+  pass "0a. sign-in established a session cookie"
+else
+  fail "0a. sign-in failed"
+  echo ""; echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
 
 PROFILE=$(curl -s -b "$JAR" -H "Origin: $ORIGIN" "$SERVER_URL/users/profile")
 MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // empty')
@@ -66,7 +71,7 @@ MCP_TOKEN=$(echo "$MCP_URL" | sed -n 's/.*[?&]token=\([^&]*\).*/\1/p')
 if [ -n "$MCP_TOKEN" ]; then pass "0b. minted MCP JWT"; else fail "0b. could not mint MCP JWT"; exit 1; fi
 MCP_ENDPOINT="$SERVER_URL/mcp?token=$MCP_TOKEN"
 
-# ── Helper: call_tool — JSON-RPC over /mcp; sets RPC_TEXT, RPC_ERR, RPC_RESULT
+# Helper: call_tool. JSON-RPC over /mcp; sets RPC_TEXT, RPC_ERR, RPC_RESULT
 RPC_ID=0
 call_tool() {
   local step="$1" tool="$2" args="$3" client_name="${4:-uat-61}" client_version="${5:-1.0.0}"
@@ -99,7 +104,7 @@ call_tool() {
 UAT_ENTRY_KEYS=()
 UAT_WIKI_KEYS=()
 
-# ── 1. C3 — three skill files exist with valid YAML frontmatter ───
+# 1. C3: three skill files exist with valid YAML frontmatter
 SKILLS_DIR="${PROJECT_ROOT:-.}/skills"
 for fname in log-to-robin-guide.md log-to-robin-short.md log-to-robin-long.md; do
   if [ -f "$SKILLS_DIR/$fname" ]; then
@@ -108,7 +113,6 @@ for fname in log-to-robin-guide.md log-to-robin-short.md log-to-robin-long.md; d
     fail "1a. skills/$fname missing"
     continue
   fi
-  # Frontmatter sanity: must open with --- and contain a `name:` and `description:`
   HEAD=$(head -n 30 "$SKILLS_DIR/$fname")
   echo "$HEAD" | head -n 1 | grep -q '^---$' \
     && pass "1b. skills/$fname opens with YAML frontmatter delimiter" \
@@ -121,7 +125,7 @@ for fname in log-to-robin-guide.md log-to-robin-short.md log-to-robin-long.md; d
     || fail "1d. skills/$fname missing description: in frontmatter"
 done
 
-# C7 — confirm log-to-robin-long carries the client-side chunking contract.
+# C7: confirm log-to-robin-long carries the client-side chunking contract.
 LONG_BODY=$(cat "$SKILLS_DIR/log-to-robin-long.md" 2>/dev/null || echo "")
 if echo "$LONG_BODY" | grep -qi 'pre-chunk\|chunking\|atomic log_entry\|naive on entry size'; then
   pass "1e. log-to-robin-long.md documents client-side chunking (C7)"
@@ -129,7 +133,7 @@ else
   fail "1e. log-to-robin-long.md missing chunking instructions (C7)"
 fi
 
-# ── 2. C2 — migration 0007 applied: entries.source_client jsonb ───
+# 2. C2: migration 0007 applied; entries.source_client jsonb
 if [ -n "${DATABASE_URL:-}" ]; then
   HAS_COL=$(psql "$DATABASE_URL" -t -A -c \
     "SELECT data_type FROM information_schema.columns WHERE table_name='raw_sources' AND column_name='source_client'" \
@@ -140,10 +144,10 @@ if [ -n "${DATABASE_URL:-}" ]; then
     fail "2a. raw_sources.source_client column missing or wrong type ($HAS_COL)"
   fi
 else
-  skip "2a. DATABASE_URL not set — skipping schema assertion"
+  skip "2a. DATABASE_URL not set; skipping schema assertion"
 fi
 
-# ── 3. C2 — capture an entry via web (POST /entries with source=web)
+# 3. C2: capture an entry via web (POST /entries with source=web)
 WEB_RESP=$(curl -s -b "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
   -d "{\"content\":\"UAT 61 web-side capture run $RUN_ID\",\"source\":\"web\",\"type\":\"thought\"}" \
   "$SERVER_URL/entries")
@@ -166,7 +170,7 @@ if [ -n "${DATABASE_URL:-}" ] && [ -n "$WEB_ENTRY_KEY" ]; then
   fi
 fi
 
-# ── 4. C2 — capture an entry via MCP, assert source_client carries clientInfo
+# 4. C2: capture an entry via MCP, assert source_client carries clientInfo
 MCP_CONTENT="UAT 61 mcp-side capture run $RUN_ID"
 call_tool "4a." "log_entry" "$(jq -n --arg c "$MCP_CONTENT" '{content:$c}')" "uat-mcp-client" "9.9.9"
 if [ "$RPC_ERR" = "false" ] && [ -n "$RPC_TEXT" ]; then
@@ -190,7 +194,7 @@ if [ -n "${DATABASE_URL:-}" ] && [ -n "$MCP_ENTRY_KEY" ]; then
   # getClientVersion(). The UAT client lib used by curl above does not
   # complete a full MCP `initialize` handshake (it just POSTs tools/call
   # JSON-RPC), so the server may see clientInfo as null. We accept either
-  # a populated clientInfo OR null — the column being writable is the
+  # a populated clientInfo OR null; the column being writable is the
   # contract. The web-side check (3b) is the strict path.
   if [ -n "$MCP_SC" ]; then
     pass "4c. MCP entry source_client column is queryable (value=$MCP_SC)"
@@ -199,18 +203,18 @@ if [ -n "${DATABASE_URL:-}" ] && [ -n "$MCP_ENTRY_KEY" ]; then
   fi
 fi
 
-# ── 5. C5 — skill wiki_type seeded via YAML bootstrap
+# 5. C5: skill wiki_type seeded via YAML bootstrap
 if [ -n "${DATABASE_URL:-}" ]; then
   HAS_SKILL_TYPE=$(psql "$DATABASE_URL" -t -A -c \
     "SELECT slug FROM wiki_types WHERE slug='skill'" 2>/dev/null | tr -d '[:space:]')
   if [ "$HAS_SKILL_TYPE" = "skill" ]; then
     pass "5a. wiki_types row for slug='skill' present (seeded from YAML)"
   else
-    fail "5a. wiki_types row for slug='skill' missing — bootstrap did not seed it"
+    fail "5a. wiki_types row for slug='skill' missing; bootstrap did not seed it"
   fi
 fi
 
-# ── 6. C5 — create a wiki with type='skill' end-to-end
+# 6. C5: create a wiki with type='skill' end-to-end
 SKILL_TITLE="UAT-61 Skill $RUN_ID"
 SKILL_DESC="A test skill wiki created by UAT 61 to assert end-to-end skill creation."
 call_tool "6a." "create_wiki" "$(jq -n --arg t "$SKILL_TITLE" --arg d "$SKILL_DESC" '{title:$t,description:$d,type:"skill"}')"
@@ -234,11 +238,11 @@ if [ -n "${DATABASE_URL:-}" ] && [ -n "${SKILL_WIKI_KEY:-}" ]; then
   if [ "$ROW_TYPE" = "skill" ]; then
     pass "6c. wikis row for $SKILL_WIKI_KEY has type='skill'"
   else
-    fail "6c. wikis row type mismatch — expected 'skill', got '$ROW_TYPE'"
+    fail "6c. wikis row type mismatch; expected 'skill', got '$ROW_TYPE'"
   fi
 fi
 
-# ── 7. C4 — list_skills MCP tool returns the new wiki under skill type
+# 7. C4: list_skills MCP tool returns the new wiki under skill type
 call_tool "7a." "list_skills" "{}"
 if [ "$RPC_ERR" = "false" ] && [ -n "$RPC_TEXT" ]; then
   pass "7a. list_skills returned no error"
@@ -266,7 +270,7 @@ else
   fail "7a. list_skills failed: text=$RPC_TEXT err=$RPC_ERR"
 fi
 
-# ── 8. C4 — list_skills must NOT include non-skill wikis
+# 8. C4: list_skills must NOT include non-skill wikis
 if [ "$RPC_ERR" = "false" ]; then
   NON_SKILL=$(echo "$RPC_TEXT" | jq -r '.skills[]?.slug' 2>/dev/null)
   if [ -n "${SKILL_WIKI_SLUG:-}" ] && [ -n "$NON_SKILL" ]; then
@@ -279,15 +283,15 @@ if [ "$RPC_ERR" = "false" ]; then
       if [ -z "$LISTED_NON_SKILL" ]; then
         pass "8a. list_skills strictly returns type='skill' rows only"
       else
-        fail "8a. list_skills leaked a non-skill wiki — filter is wrong"
+        fail "8a. list_skills leaked a non-skill wiki; filter is wrong"
       fi
     else
-      skip "8a. DATABASE_URL not set — skipping strict subset check"
+      skip "8a. DATABASE_URL not set; skipping strict subset check"
     fi
   fi
 fi
 
-# ── 9. C7 — server accepts a long entry as a single row (no chunking)
+# 9. C7: server accepts a long entry as a single row (no chunking)
 LONG_CONTENT=$(python3 -c "import sys; sys.stdout.write('lorem ipsum dolor sit amet ' * 350)" 2>/dev/null \
   || awk 'BEGIN{for(i=0;i<350;i++) printf "lorem ipsum dolor sit amet "}')
 WORDS=$(echo "$LONG_CONTENT" | wc -w)
@@ -305,7 +309,7 @@ if [ -n "$LONG_ENTRY_KEY" ]; then
   pass "9b. server accepted >=2000-word entry as single row ($LONG_ENTRY_KEY)"
   UAT_ENTRY_KEYS+=("$LONG_ENTRY_KEY")
 else
-  fail "9b. server rejected long entry — server is no longer naive (resp=$(echo "$LONG_RESP" | head -c 200))"
+  fail "9b. server rejected long entry; server is no longer naive (resp=$(echo "$LONG_RESP" | head -c 200))"
 fi
 
 # Confirm the row is one entry, not multiple split rows.
@@ -322,7 +326,7 @@ fi
 echo ""
 echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
 
-# ── Cleanup
+# Cleanup: delete inserted rows
 if [ -n "${DATABASE_URL:-}" ]; then
   for key in "${UAT_ENTRY_KEYS[@]}"; do
     psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE lookup_key='$key'" >/dev/null 2>&1 || true
@@ -347,8 +351,8 @@ psql "$DATABASE_URL" -c "DELETE FROM wikis WHERE name LIKE 'UAT-61 Skill %';"
 ## Expected pass/fail behavior
 
 - **C2 schema (2a)** PASSES iff migration 0007 has been applied on the target DB.
-- **C2 web path (3a, 3b)** PASSES on any clean local stack — the assertion is purely on the SQL column value.
-- **C2 MCP path (4a–4c)** writes the row; the strict `clientInfo` value depends on the test client completing a full MCP `initialize` handshake. The relaxed assertion (4c) accepts either populated jsonb or null — the contract under test is that the column is writable from the MCP path. The strict-shape contract is exercised by the integration tests in `core/src/__tests__/`.
-- **C5 (5a, 6a–6c)** PASSES when `seedWikiTypes()` has run at boot, which happens automatically.
-- **C4 (7a–7d, 8a)** PASSES once step 6 inserts a skill wiki — list_skills should immediately surface it.
-- **C7 (9a–9c)** PASSES iff the server accepts the long entry as one row. A failure here would indicate someone added server-side chunking — a deliberate regression on the C7 contract.
+- **C2 web path (3a, 3b)** PASSES on any clean local stack; the assertion is purely on the SQL column value.
+- **C2 MCP path (4a-4c)** writes the row; the strict `clientInfo` value depends on the test client completing a full MCP `initialize` handshake. The relaxed assertion (4c) accepts either populated jsonb or null. The contract under test is that the column is writable from the MCP path. The strict-shape contract is exercised by the integration tests in `core/src/__tests__/`.
+- **C5 (5a, 6a-6c)** PASSES when `seedWikiTypes()` has run at boot, which happens automatically.
+- **C4 (7a-7d, 8a)** PASSES once step 6 inserts a skill wiki; list_skills should immediately surface it.
+- **C7 (9a-9c)** PASSES iff the server accepts the long entry as one row. A failure here would indicate someone added server-side chunking, a deliberate regression on the C7 contract.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,19 @@ Robin exposes an MCP server for Claude Desktop, ChatGPT, and other AI clients. T
 | `publish_wiki` | Publish a wiki with a stable public URL |
 | `unpublish_wiki` | Unpublish a wiki (preserves slug for re-publish) |
 | `get_timeline` | Audit timeline for a wiki and its fragments |
+| `list_skills` | List skill wikis (the Capture pack and any user-authored skills) |
+
+### Capture pack — installable Claude skills
+
+The repo ships three Claude skills under `skills/` for use in any Claude client that supports project skills:
+
+- `skills/log-to-robin-guide.md` — onboarding + reference for new Robin users; required reading before `create_wiki` calls.
+- `skills/log-to-robin-short.md` — short-form capture (under ~2,000 words, clear attribution).
+- `skills/log-to-robin-long.md` — long-form mining + curation; pre-chunks long input into atomic `log_entry` calls (the server stays naive on entry size, by design).
+
+To install: copy or symlink the three files into your Claude client's project skills directory (e.g. `.claude/skills/log-to-robin-guide/SKILL.md`). They are also discoverable at runtime via the `list_skills` MCP tool when stored as `skill`-typed wikis in your Robin instance.
+
+Closes [#233](https://github.com/withrobinhq/robin/issues/233).
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ Robin exposes an MCP server for Claude Desktop, ChatGPT, and other AI clients. T
 | `get_timeline` | Audit timeline for a wiki and its fragments |
 | `list_skills` | List skill wikis (the Capture pack and any user-authored skills) |
 
-### Capture pack — installable Claude skills
+### Capture pack: installable Claude skills
 
 The repo ships three Claude skills under `skills/` for use in any Claude client that supports project skills:
 
-- `skills/log-to-robin-guide.md` — onboarding + reference for new Robin users; required reading before `create_wiki` calls.
-- `skills/log-to-robin-short.md` — short-form capture (under ~2,000 words, clear attribution).
-- `skills/log-to-robin-long.md` — long-form mining + curation; pre-chunks long input into atomic `log_entry` calls (the server stays naive on entry size, by design).
+- `skills/log-to-robin-guide.md`: onboarding + reference for new Robin users; required reading before `create_wiki` calls.
+- `skills/log-to-robin-short.md`: short-form capture (under ~2,000 words, clear attribution).
+- `skills/log-to-robin-long.md`: long-form mining + curation. Pre-chunks long input into atomic `log_entry` calls (the server stays naive on entry size, by design).
 
 To install: copy or symlink the three files into your Claude client's project skills directory (e.g. `.claude/skills/log-to-robin-guide/SKILL.md`). They are also discoverable at runtime via the `list_skills` MCP tool when stored as `skill`-typed wikis in your Robin instance.
 

--- a/core/drizzle/migrations/0007_entries_source_client.sql
+++ b/core/drizzle/migrations/0007_entries_source_client.sql
@@ -1,0 +1,15 @@
+-- Stream C / C2 — `source_client` jsonb column on entries (raw_sources).
+--
+-- Captures the MCP `clientInfo` payload (`{name, version, ...}`) for any
+-- entry created via the MCP transport, and `{name: 'web'}` for entries
+-- captured through the web UI. NULL for legacy rows and any future
+-- caller that doesn't supply client identity.
+--
+-- Decision 2026-05-07 (PLAN.md §C2): jsonb (not text), so the column
+-- can carry the optional `version` and any future MCP-spec fields
+-- without another migration.
+--
+-- No backfill: old rows return NULL by design.
+-- Idempotent (IF NOT EXISTS) so a partial CI rerun doesn't fail.
+
+ALTER TABLE raw_sources ADD COLUMN IF NOT EXISTS source_client jsonb;

--- a/core/drizzle/migrations/0007_entries_source_client.sql
+++ b/core/drizzle/migrations/0007_entries_source_client.sql
@@ -1,4 +1,4 @@
--- Stream C / C2 — `source_client` jsonb column on entries (raw_sources).
+-- Stream C / C2: `source_client` jsonb column on entries (raw_sources).
 --
 -- Captures the MCP `clientInfo` payload (`{name, version, ...}`) for any
 -- entry created via the MCP transport, and `{name: 'web'}` for entries

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778457601000,
       "tag": "0003_migrations_meta_and_pipeline_nullable",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778457607000,
+      "tag": "0007_entries_source_client",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -194,6 +194,16 @@ export const entries = pgTable(
       channel?: string
       sessionId?: string
     }>(),
+    // Stream C / C2 — MCP `clientInfo` payload (`{name, version, ...}`)
+    // for MCP captures, `{name: 'web'}` for web-UI captures, NULL for
+    // legacy rows or any caller that doesn't supply client identity.
+    // Migration 0007. Decision 2026-05-07: jsonb (carries optional
+    // `version` and any future MCP-spec fields without re-migrating).
+    sourceClient: jsonb('source_client').$type<{
+      name: string
+      version?: string
+      [key: string]: unknown
+    } | null>(),
     ingestStatus: text('ingest_status').notNull().default('pending'),
     lastError: text('last_error'),
     lastAttemptAt: timestamp('last_attempt_at'),

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -194,7 +194,7 @@ export const entries = pgTable(
       channel?: string
       sessionId?: string
     }>(),
-    // Stream C / C2 — MCP `clientInfo` payload (`{name, version, ...}`)
+    // Stream C / C2: MCP `clientInfo` payload (`{name, version, ...}`)
     // for MCP captures, `{name: 'web'}` for web-UI captures, NULL for
     // legacy rows or any caller that doesn't supply client identity.
     // Migration 0007. Decision 2026-05-07: jsonb (carries optional

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -96,7 +96,16 @@ export interface McpServerDeps {
  */
 export async function handleLogEntry(
   deps: McpServerDeps,
-  input: { content: string; source?: 'mcp' | 'api' | 'web' },
+  input: {
+    content: string
+    source?: 'mcp' | 'api' | 'web'
+    /**
+     * MCP `clientInfo` payload (Stream C / C2). Persisted to
+     * `entries.source_client` jsonb. NULL when the caller is the legacy
+     * pre-clientInfo path or a non-MCP route that didn't supply it.
+     */
+    sourceClient?: { name: string; version?: string; [key: string]: unknown } | null
+  },
   userId: string | undefined
 ) {
   if (!userId) {
@@ -138,6 +147,7 @@ export async function handleLogEntry(
       dedupHash: hash,
       type: 'thought',
       source: entrySource,
+      sourceClient: input.sourceClient ?? null,
     })
 
     const job: ExtractionJob = {
@@ -194,6 +204,14 @@ export async function handleLogFragment(
     threadSlug: string
     title?: string
     tags?: string[]
+    /**
+     * MCP `clientInfo` payload (Stream C / C2). The fragments table has
+     * no `source_client` column (migration 0007 only added it to
+     * `raw_sources`), so the value is recorded in the fragment's
+     * audit_log `detail` jsonb instead. Keeps the per-event traceability
+     * without expanding the schema beyond C2 scope.
+     */
+    sourceClient?: { name: string; version?: string; [key: string]: unknown } | null
   },
   userId: string | undefined
 ) {
@@ -366,7 +384,14 @@ export async function handleLogFragment(
       eventType: 'created',
       source: 'mcp',
       summary: `Fragment created: ${title}`,
-      detail: { fragmentKey: fragKey, wikiKey: threadResult.lookupKey, threadSlug: threadResult.slug },
+      detail: {
+        fragmentKey: fragKey,
+        wikiKey: threadResult.lookupKey,
+        threadSlug: threadResult.slug,
+        // C2 — fragments table has no source_client column; the audit
+        // detail carries the MCP clientInfo for parity with entries.
+        sourceClient: input.sourceClient ?? null,
+      },
     })
 
     const result = {

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -388,7 +388,7 @@ export async function handleLogFragment(
         fragmentKey: fragKey,
         wikiKey: threadResult.lookupKey,
         threadSlug: threadResult.slug,
-        // C2 — fragments table has no source_client column; the audit
+        // C2: fragments table has no source_client column; the audit
         // detail carries the MCP clientInfo for parity with entries.
         sourceClient: input.sourceClient ?? null,
       },

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -52,6 +52,26 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     db: deps.db,
   }
 
+  /**
+   * Stream C / C2 — read MCP `clientInfo` (Implementation: `{name, version}`)
+   * from the underlying SDK Server. Returns null until the client has
+   * completed the `initialize` handshake. Persisted by the write
+   * handlers to `entries.source_client` (raw_sources) and to the
+   * fragment audit_log detail.
+   */
+  const readClientInfo = (): {
+    name: string
+    version?: string
+    [key: string]: unknown
+  } | null => {
+    const impl = server.server.getClientVersion()
+    if (!impl) return null
+    return {
+      name: impl.name,
+      ...(impl.version ? { version: impl.version } : {}),
+    }
+  }
+
   /***********************************************************************
    * ## Tools — Write operations
    ***********************************************************************/
@@ -66,7 +86,11 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
       },
     },
     async ({ content, source }, extra) => {
-      return handleLogEntry(deps, { content, source }, extra.authInfo?.clientId as string)
+      return handleLogEntry(
+        deps,
+        { content, source, sourceClient: readClientInfo() },
+        extra.authInfo?.clientId as string
+      )
     }
   )
 
@@ -89,7 +113,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     async ({ content, threadSlug, title, tags }, extra) => {
       return handleLogFragment(
         deps,
-        { content, threadSlug, title, tags },
+        { content, threadSlug, title, tags, sourceClient: readClientInfo() },
         extra.authInfo?.clientId as string
       )
     }

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, lis
 import type { McpResolverDeps } from './resolvers.js'
 import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
-import { wikis, edges, auditLog, groups, groupWikis } from '../db/schema.js'
+import { wikis, wikiTypes, edges, auditLog, groups, groupWikis } from '../db/schema.js'
 import { hybridSearch } from '../lib/search.js'
 import { searchResponseSchema } from '../schemas/search.schema.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
@@ -480,6 +480,64 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
       return handleCreateWikiType(deps, { slug, name, shortDescriptor, descriptor, prompt })
     }
   )
+
+  /***********************************************************************
+   * ## Skills (Stream C / C4)
+   ***********************************************************************/
+
+  server.registerTool(
+    'list_skills',
+    {
+      description:
+        'List skill wikis — the metadata index of every wiki stored under ' +
+        'the `skill` wiki_type. Returns slug, name, description, and version, ' +
+        'sorted by most-recently updated. Read-only; the wiki body is not ' +
+        'included (fetch it via `get_wiki` when needed). Useful when a Claude ' +
+        'session needs to discover which skills the user has captured into ' +
+        'their Robin (the Capture pack plus any user-authored skill wikis).',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const rows = await deps.db
+          .select({
+            slug: wikis.slug,
+            name: wikis.name,
+            description: wikis.description,
+            lookupKey: wikis.lookupKey,
+            updatedAt: wikis.updatedAt,
+            // The wiki_types row carries the version the skill was based on
+            // (basedOnVersion) — surfaced as `version` for callers that
+            // want to detect drift against the YAML defaults.
+            version: wikiTypes.basedOnVersion,
+          })
+          .from(wikis)
+          .leftJoin(wikiTypes, eq(wikis.type, wikiTypes.slug))
+          .where(and(eq(wikis.type, 'skill'), isNull(wikis.deletedAt)))
+          .orderBy(sql`${wikis.updatedAt} DESC`)
+
+        const skills = rows.map((r) => ({
+          slug: r.slug,
+          name: r.name,
+          description: r.description,
+          lookupKey: r.lookupKey,
+          version: r.version ?? null,
+          updatedAt: r.updatedAt,
+        }))
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ skills }) }],
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true as const,
+        }
+      }
+    }
+  )
+
   /***********************************************************************
    * ## Timeline
    ***********************************************************************/

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -53,7 +53,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
   }
 
   /**
-   * Stream C / C2 — read MCP `clientInfo` (Implementation: `{name, version}`)
+   * Stream C / C2: read MCP `clientInfo` (Implementation: `{name, version}`)
    * from the underlying SDK Server. Returns null until the client has
    * completed the `initialize` handshake. Persisted by the write
    * handlers to `entries.source_client` (raw_sources) and to the
@@ -489,7 +489,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     'list_skills',
     {
       description:
-        'List skill wikis — the metadata index of every wiki stored under ' +
+        'List skill wikis: the metadata index of every wiki stored under ' +
         'the `skill` wiki_type. Returns slug, name, description, and version, ' +
         'sorted by most-recently updated. Read-only; the wiki body is not ' +
         'included (fetch it via `get_wiki` when needed). Useful when a Claude ' +
@@ -507,7 +507,7 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
             lookupKey: wikis.lookupKey,
             updatedAt: wikis.updatedAt,
             // The wiki_types row carries the version the skill was based on
-            // (basedOnVersion) — surfaced as `version` for callers that
+            // (basedOnVersion). Surfaced as `version` for callers that
             // want to detect drift against the YAML defaults.
             version: wikiTypes.basedOnVersion,
           })

--- a/core/src/routes/entries.ts
+++ b/core/src/routes/entries.ts
@@ -48,6 +48,12 @@ entries.post('/', zValidator('json', createEntryBodySchema, validationHook), asy
   const { ulid: entryUlid } = parseLookupKey(entryKey)
   const slug = await resolveEntrySlug(db, generateSlug(title ?? content.slice(0, 80)))
 
+  // Stream C / C2 — web-UI captures get `{name: 'web'}`; other HTTP
+  // captures (`source: 'api'` or anything else) leave `source_client`
+  // NULL. MCP-originated rows are populated by handleLogEntry from the
+  // protocol-level clientInfo handshake.
+  const sourceClient = source === 'web' ? { name: 'web' } : null
+
   // Persist entry row — pure DB, no git write-through
   const [entry] = await db
     .insert(entriesTable)
@@ -59,6 +65,7 @@ entries.post('/', zValidator('json', createEntryBodySchema, validationHook), asy
       dedupHash: hash,
       type,
       source,
+      sourceClient,
       ingestStatus: 'pending',
     })
     .returning()

--- a/core/src/routes/entries.ts
+++ b/core/src/routes/entries.ts
@@ -48,7 +48,7 @@ entries.post('/', zValidator('json', createEntryBodySchema, validationHook), asy
   const { ulid: entryUlid } = parseLookupKey(entryKey)
   const slug = await resolveEntrySlug(db, generateSlug(title ?? content.slice(0, 80)))
 
-  // Stream C / C2 — web-UI captures get `{name: 'web'}`; other HTTP
+  // Stream C / C2: web-UI captures get `{name: 'web'}`. Other HTTP
   // captures (`source: 'api'` or anything else) leave `source_client`
   // NULL. MCP-originated rows are populated by handleLogEntry from the
   // protocol-level clientInfo handshake.

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -197,9 +197,20 @@ fragmentsRouter.post(
     // Body is validated by Zod above (content + threadSlug both `min(1)`),
     // but core's tsconfig has `strict: false` which weakens Zod's narrowing
     // on optional vs required. Cast to the handler's signature explicitly.
+    // Stream C / C2 — HTTP path is the web UI route; tag clientInfo as
+    // `{name: 'web'}` so the fragment audit_log detail mirrors the
+    // entries.source_client shape.
     const result = await handleLogFragment(
       deps,
-      body as { content: string; threadSlug: string; title?: string; tags?: string[] },
+      {
+        ...(body as {
+          content: string
+          threadSlug: string
+          title?: string
+          tags?: string[]
+        }),
+        sourceClient: { name: 'web' },
+      },
       userId
     )
     if (result.isError) {

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -197,7 +197,7 @@ fragmentsRouter.post(
     // Body is validated by Zod above (content + threadSlug both `min(1)`),
     // but core's tsconfig has `strict: false` which weakens Zod's narrowing
     // on optional vs required. Cast to the handler's signature explicitly.
-    // Stream C / C2 — HTTP path is the web UI route; tag clientInfo as
+    // Stream C / C2: HTTP path is the web UI route; tag clientInfo as
     // `{name: 'web'}` so the fragment audit_log detail mirrors the
     // entries.source_client shape.
     const result = await handleLogFragment(

--- a/skills/log-to-robin-guide.md
+++ b/skills/log-to-robin-guide.md
@@ -1,0 +1,699 @@
+---
+name: log-to-robin-guide
+description: Onboarding + reference + wiki-creation quality gate for Robin. Triggers on setting up Robin, starting a knowledge base, "I'm new to Robin", and questions about entries, fragments, wikis, types, structures, or descriptions. Also triggers on any wiki-creation request — "create a wiki", "make a new wiki", "add a Belief/Project/Decision/Log/Research/Skill/Voice/Principle/Agent/Objective wiki". This skill defines the title/type/description quality bar Claude must apply before calling `Robin:create_wiki`; loading it is mandatory before any wiki-creation tool call. Other Robin skills (log-to-robin-short, log-to-robin-long) reference Part 2 of this skill for architectural definitions. First skill a new Robin user should encounter.
+---
+
+# Robin Knowledge System Guide
+
+This skill has two parts:
+
+**Part 1: Onboarding** — walks a new user through setup, step by step. Use this when someone is new to Robin or setting up their knowledge base for the first time.
+
+**Part 2: Robin Reference** — defines Robin's architecture, metadata, and conventions. This is the reference layer that every other Robin skill leans on. Use this when you need to understand how Robin works in order to do your job (logging, comparing, extracting).
+
+---
+
+# PART 1: ONBOARDING
+
+## Step 0: The Welcome
+
+When this skill triggers for a new user, open with the welcome message below. Deliver it conversationally — not as a wall of text. Match the user's energy, but keep the substance.
+
+---
+
+Welcome to the Robin Knowledge System.
+
+Robin is a second brain. Not the kind that sits there collecting dust while AI does vague things with your notes. The kind that gets sharper the more you use it — because you are the one sharpening it.
+
+Here's the deal. Robin automates the parts of knowledge management that shouldn't require your brain: ingesting raw material, breaking it into pieces, routing those pieces to the right places, and synthesising what's accumulating. That's the machine's job. It's good at it.
+
+But Robin deliberately stops where your thinking should start.
+
+You decide what topics matter. You name the wikis. You review what the system extracted and tell it when it's wrong. You write the rules that govern how your knowledge behaves. Robin is the orchestra. You are the conductor. Take away the conductor and you don't get silence — you get noise.
+
+This is not a knowledge system for people who want to dump information in and ask questions later. If that's what you want, there are plenty of RAG tools that will happily let you do that — and you'll get exactly the shallow, context-free answers you'd expect.
+
+Robin is for people who want to engage with their knowledge. Who believe that the act of organising thought is itself a form of thinking. Who want a system that compounds over time because a human is actively steering it.
+
+**What this onboarding will do:**
+
+We're going to walk through setting up your knowledge base together. Step by step. At each stage, I'll explain what Robin does automatically and what it expects from you. By the end, you'll have:
+
+- A working knowledge base with your first wikis
+- An understanding of how entries become fragments become wikis
+- Your first logged knowledge — real material, not demo data
+- A feel for the rhythm of working with Robin day to day
+- A plan for how your meetings and conversations flow into Robin
+
+Ready? Let's go.
+
+---
+
+## Step 1: Why Are We Doing This in Claude?
+
+You're probably wondering: if I'm setting up Robin, why am I talking to Claude? Shouldn't I be in Robin?
+
+Robin is an app. You'll log into it. You'll use it to organise your folder structure, edit your wikis, review what's accumulated, and manage the shape of your knowledge base. That's Robin's home turf.
+
+But Robin was built around a core design principle: **it is a knowledge system, not an everything-app.** Robin does one thing well — it manages your knowledge. It stores it, structures it, connects it, and synthesises it. What it deliberately does *not* try to do is be the place where all the thinking, analysing, and capturing happens.
+
+That's where **MCP — Model Context Protocol** — comes in. Think of MCP as a universal connector. It lets any AI tool talk to your Robin knowledge base. Claude speaks MCP. So do workflow automation tools, custom agents, and other AI systems. They can all read from and write to Robin.
+
+This means the heavy lifting of knowledge capture — mining a meeting transcript, extracting insights from a long document, spotting a belief worth preserving mid-conversation — happens through tools like Claude that are good at that kind of work. Robin receives the knowledge, processes it, fragments it, routes it, and keeps it structured. Each system does what it's best at.
+
+**What this means in practice:**
+- You log knowledge to Robin from wherever you are — a Claude conversation, a workflow, the Robin app, an API call
+- Robin processes it, extracts the important fragments, routes them to the right wikis
+- Any tool connected via MCP can then access that knowledge
+- You manage the structure and shape of your knowledge base in Robin's own interface
+- Your knowledge base is yours. It doesn't live inside Claude or inside any single tool. It lives in Robin.
+
+So when we set up your knowledge base in this conversation, we're not replacing Robin. We're using Claude to do the parts Claude is good at — conversation, analysis, and capture — while Robin does what Robin is good at: being your knowledge system.
+
+---
+
+## Step 2: Understand the Architecture
+
+Before we create anything, you need to understand what Robin is actually doing under the hood. Not because you need to be technical — but because this system only works if you understand the logic behind it.
+
+### The Three Layers
+
+**Entries** are raw inputs. A meeting transcript. A voice note. A pasted article. An observation you type in at 11pm. You don't need to format them. You don't need to tag them. You just log them. This is the part Robin automates — it takes your messy, unstructured input and processes it.
+
+**Fragments** are the atomic units of knowledge that Robin extracts from your entries. One entry might produce five fragments. A fragment is a single idea, fact, observation, decision, or insight — small enough to stand alone, specific enough to be useful. Robin does the extraction. But you should review the results, because the system learns what matters from how you engage with it.
+
+**Wikis** are the topics and themes that accumulate fragments over time. Think of them like wiki pages that grow. A wiki called "AI and African Talent" might collect fragments from a podcast you listened to, a meeting note, a LinkedIn post you drafted, and a research paper — all converging into one place. Wikis have bodies that synthesise their fragments into a coherent, evolving document.
+
+**The key insight:** this is a many-to-many architecture. One entry produces many fragments. One fragment can belong to multiple wikis. A client insight from a single meeting can touch your strategy wiki, your relationship wiki, and your product wiki simultaneously. This convergence is where compounding knowledge happens.
+
+### Prompt the user
+
+Ask:
+> What kind of knowledge do you work with day to day? Meeting notes? Research? Client work? Strategy? Personal development? Don't overthink it — just tell me what flows through your head and inbox most often.
+
+Use their answer to guide wiki creation in Step 4.
+
+---
+
+## Step 3: Understand the Three Modes
+
+Robin organises knowledge capture around three modes. These aren't features — they're a philosophy about how knowledge actually works.
+
+**Observe** — Watch reality unfold and capture what matters. This is the input layer. Monitoring news, logging meeting notes, capturing what you read, noting what surprised you. Most people's "knowledge management" stops here. Robin doesn't.
+
+**Drive** — Move from one state to a better one by thinking, deciding, doing, and aiming. This is where you process what you've observed into positions, decisions, plans, and hypotheses. It's the thinking layer. Robin supports this by surfacing fragments that relate to what you're working on, but the thinking is yours.
+
+**Govern** — Encode your judgment so AI can act on your behalf. This is the most powerful mode. Once you've thought enough about a topic, you can write rules, criteria, and frameworks that tell Robin (and any AI working with your knowledge) how to behave. Your curated, structured, human-governed knowledge becomes what makes AI actually useful.
+
+Together they form a compounding loop. Observation shapes thinking. Thinking defines governance. Governance informs what you observe next. The system does not reset — it accumulates.
+
+### Prompt the user
+
+Ask:
+> Which of these three modes resonates most with where you are right now?
+> - **Observe:** "I have a lot of information coming at me and I need to capture it better"
+> - **Drive:** "I have information but I need to turn it into decisions and direction"
+> - **Govern:** "I have strong views and I want to encode them so AI can work from my playbook"
+
+Most people start with Observe. That's fine. The system will pull you into the other modes naturally.
+
+Use their answer to set the tone for what kinds of entries we log first.
+
+---
+
+## Step 4: Create Your First Wikis
+
+Now we build. Wikis are the backbone of your knowledge base. They're the topics that matter to you — the things you want to get smarter about over time.
+
+But before creating any, you need to know that not all wikis are the same. Robin ships with **10 default wiki types**, organised across the three modes. Each type is designed for a different kind of knowledge, with its own default structure and purpose. (The type list is extensible via `Robin:create_wiki_type`, but the 10 defaults cover almost everything most users need — start there.)
+
+### The 10 Wiki Types
+
+**Observe — watch reality unfold and capture what matters:**
+- **Log** — capturing what happens, in words or data. Doesn't close — it accumulates. The value is in faithful capture, whether chronological or curated. Templates within Log include Journal, Monitor, Playbook, Collection, Tracker — these are formatting differences, not knowledge-type differences.
+- **Research** — accumulating signals around a specific subject to make sense of an unfolding pattern. You're watching with a question. It's the pre-Belief stage — exploratory, question-driven, not yet committed to a position. May eventually trigger a Belief when enough signal has accumulated. Research is the bridge between Observe and Drive.
+
+**Drive — move from one state to a better one by thinking, deciding, doing, and aiming:**
+- **Belief** — a position you hold or are forming about how something works. Beliefs evolve — they start as hunches and mature as evidence accumulates.
+- **Decision** — a choice you've made or are evaluating, with the reasoning behind it. What was decided, what was considered, what was rejected.
+- **Objective** — something you're aiming for. Clear enough to know when you've hit it, connected to the actions and projects that serve it.
+- **Project** — a bounded piece of work. Scope, milestones, team, constraints, and status. Projects serve objectives and generate entries constantly.
+
+**Govern — encode your judgment so AI can act on your behalf:**
+- **Principle** — your non-negotiables. The rules and standards that don't bend regardless of context. The foundation Govern mode is built on.
+- **Skill** — a repeatable capability. How to do something well, step by step, with the knowledge needed to execute it.
+- **Agent** — the specification for an AI agent. Its role, tools, constraints, and the knowledge it has access to.
+- **Voice** — how you or your organisation communicates. Tone, style rules, what to avoid, and examples of the voice in practice.
+
+When you create a wiki, you choose its type. That type determines the wiki's structure — what sections it has, what kind of fragments are most relevant, and how the wiki body gets synthesised. A Belief wiki works differently from a Log wiki, which works differently from a Voice wiki.
+
+You don't need one of each type on day one. Start with whatever types match how you actually think and work. The types are here to help you be intentional about what kind of knowledge you're building.
+
+### Guidelines for good wikis
+
+- **Name them like you'd name a belief or a territory, not a filing cabinet.** "How AI is reshaping professional services" is better than "AI Notes". "The case for African tech talent" is better than "Africa Research".
+- **Start with 3-5 wikis.** You can always add more.
+- **Mix types based on what you actually need.** If you're in Observe mode, start with a Log and a Research wiki. If you're in Drive mode, maybe a Belief and a Project. If you already have strong views, a Principle wiki might be where you start.
+- **Don't worry about overlap.** Fragments can belong to multiple wikis. That's the whole point.
+- **Ignore Collections for now.** You'll see a Collections section in the Robin app sidebar — these are optional buckets for grouping wikis once your knowledge base grows. With 3-5 wikis you don't need them. Revisit when your sidebar starts feeling cluttered.
+
+### Two controls, two jobs — Description vs Structure
+
+Each wiki has **two distinct levers**, and they do completely different things. New users confuse them constantly. Get this right and the rest of the system makes sense.
+
+**Description = "what fragments belong in this wiki?"**
+Robin uses the description to decide whether an incoming fragment routes into this wiki. It's the **router**. A vague description means Robin guesses; fragments end up in the wrong place. A specific description means accurate routing.
+
+A good description answers: what is this wiki about, what kind of knowledge belongs here, and what doesn't. It doesn't need to be long — it needs to be clear.
+
+Example of a weak description: "Stuff about AI and jobs."
+
+Example of a strong description: "How AI is changing the division of labour between humans and machines, with a focus on which tasks are being automated, which are being augmented, and what new roles are emerging. Particularly interested in the African context and the outsourcing industry."
+
+**Structure = "how does this wiki read once it has fragments?"**
+Each wiki also has a structure — a section template that Robin uses when synthesizing the wiki body. It's the **layout**. The default comes from the wiki's type (a Belief wiki has different sections than a Decision wiki). You can customize it in the wiki's settings, or hit "Revert to default" to restore the type's default.
+
+The structure controls **what the wiki looks like when you read it** — not what gets routed into it.
+
+**The key distinction:**
+- Description = the door. Who gets in?
+- Structure = the room. How is it laid out?
+
+**On day one:** focus your energy on **descriptions**. Leave structures as the type's default — they're already designed for the kind of knowledge that type holds. Once a wiki has accumulated fragments and you have a feel for how you want to read it, revisit the structure. Both are editable any time.
+
+### Create your wikis in Robin
+
+This is the step where you leave this conversation and go to the Robin app. Wiki creation happens in Robin — that's where you set the name, choose the type, write the description, and (optionally) review the default structure.
+
+### Prompt the user
+
+Based on what they told you in Step 2, and which mode resonated in Step 3, suggest 3-5 wikis. For each one, propose a name, a type, and a draft description. Explain why you chose that type. Ask them to react — edit, add, remove, change types.
+
+Once the user is happy with the list, tell them:
+
+> Now go to the Robin app and create these wikis. For each one, set the name, choose the type, and paste in the description. Once they're created, come back here and we'll start logging your first entries.
+
+**During onboarding, send the user to the app.** This isn't because Claude can't create wikis — `Robin:create_wiki` works fine. It's because new users need to get comfortable with the app and take ownership of their structure from the start. The first few wikis should be created by the user's own hands.
+
+**Once the user is established, Claude may create wikis via `Robin:create_wiki`** — but only when the user has provided a clear name, a clear type, and a real description. A bad wiki corrupts Robin's routing forever; the wrong type means the wiki has the wrong structure; a vague description means fragments land in the wrong place. The MCP tool enforces all three at the schema level (any caller hits a hard wall without them) — your job is to make sure the three are *good*, not just present. See "Creating Wikis Well" in Part 2 for the quality bar.
+
+---
+
+## Step 5: Set Up Your Meeting Notes Pipeline
+
+Meetings are one of the richest sources of knowledge. But they only become knowledge if they flow into Robin. Instead of just talking about this — let's do it. We're going to take a real meeting and walk it through the full process.
+
+### 5a: Check their transcription setup
+
+Ask:
+> How do your meetings get recorded? Do you use a transcription tool like Fellow, Otter, Fireflies, or similar? If so, is it connected to Claude via MCP?
+
+If they don't have transcription set up, discuss options and move to Step 6 — they can come back to this step later.
+
+If they do have a transcription tool with MCP access, proceed.
+
+### 5b: Pick a recent meeting
+
+Ask:
+> Let's test this with a real meeting. Pick a recent one — ideally one that had some substance, not just a quick check-in. Which meeting should we use?
+
+Use the transcription tool's MCP to find and pull the meeting. If the tool supports search (e.g., Fellow's `search_meetings`), help the user find the right one.
+
+### 5c: Pull the transcript and check attribution
+
+Pull the transcript for the chosen meeting. Before doing anything else, check the speaker labels:
+
+- **Names present and clear** (e.g., `[00:02:14] Karen Kimami: We've been using Meltwater...`) — great. Tell the user: "Your transcription tool labels speakers by name, which means your meetings will flow into Robin cleanly. When you say 'log this meeting,' I can trust who said what."
+
+- **Names missing or generic** (e.g., "Speaker 1", "Unknown") — flag it. Tell the user: "Your transcription tool isn't labelling speakers by name. That means when we log meetings, I'll need to extract the key fragments and ask you to tell me who said each one. It adds a step, but it's important — Robin needs to know who said what at the fragment level."
+
+### 5d: Log the meeting to Robin
+
+Now actually do it. Walk the user through their first meeting log:
+
+1. Show the user what you're about to send — the transcript with metadata tags (Channel, Uploaded by, Attribution, Context).
+2. Check for any sensitive content and flag if present.
+3. Confirm with the user: "Ready to log this to Robin?"
+4. Call `Robin:log_entry` with the structured content.
+5. Confirm what was logged.
+
+This is the user's first real entry — make it count. Explain what happens next: Robin will process the transcript, extract fragments, and route them to relevant wikis. The user can go to the Robin app to see what was created.
+
+### 5e: Document the pipeline
+
+Note for future reference which path this user's meetings will take:
+- **Clean attribution** → meetings can be logged via the short-form capture skill (`log-to-robin-short`)
+- **Messy attribution** → meetings route through the long-form capture skill (`log-to-robin-long`) with manual attribution
+
+---
+
+## Step 6: Log More Entries
+
+You've already logged your first entry — a meeting transcript. Now let's build the habit with a different kind of input. Entries are how knowledge gets into Robin. The key thing to understand: you don't need to be precious about entries. They're raw material. Robin's job is to process them. Your job is to be honest and abundant.
+
+### Ways to log entries
+
+- **Via MCP (right here):** Use `Robin:log_entry` to log text directly from this conversation. Great for observations, ideas, or things you're thinking about right now.
+- **Via the Robin web app:** For longer material, articles, or when you're not in a Claude conversation.
+
+### What makes a good entry
+
+- **Be specific.** "Had a good meeting with Sarah" is almost useless. "Sarah pushed back on the pricing model — she thinks per-seat doesn't work for NGOs with rotating staff. She suggested a project-based model instead. I think she's right." That's an entry Robin can work with.
+- **Include context.** Who said it? When? Why does it matter? The more context in the entry, the better the fragments Robin extracts.
+- **Don't self-edit.** If you're thinking it, log it. Not every entry produces gold. But the ones that do are worth the noise.
+
+### Prompt the user
+
+Ask:
+> You've already logged a meeting. Now try something different — an article that stuck with you recently, an idea you've been mulling over, or a decision you've been wrestling with. Just talk naturally. I'll log it to Robin.
+
+Use `Robin:log_entry` with their content. Then explain what happens next: Robin will process the entry, extract fragments, and route them to relevant wikis.
+
+---
+
+## Step 7: Using Robin — The Two-Way Loop
+
+So far we've focused on getting knowledge *into* Robin. But Robin isn't a one-way dump. The whole point of building a knowledge base is to use it. Knowledge flows in, and it flows back out — into your work, your writing, your decisions, your tools.
+
+Here's what that looks like in practice:
+
+**Pull beliefs into your writing.** You have two Belief wikis about AI and the future of work. You're drafting a LinkedIn post. Instead of starting from scratch, you ask Claude to read those wikis from Robin and use them as the foundation. Your post is grounded in thinking you've already done — not improvised in the moment.
+
+**Update your tools from Robin.** You've built a Skill in Claude that helps you run a specific workflow. Over the past month, new fragments have accumulated in Robin that refine how that skill should work. You pull the latest from Robin, review what's changed, and update the Claude skill to reflect your current thinking.
+
+**Prepare for a meeting using your wikis.** You're about to meet a client. You ask Claude to pull everything Robin knows about that person and that relationship — fragments from past meetings, decisions you've made, beliefs you hold about their industry. You walk in prepared, with your own accumulated knowledge at your fingertips.
+
+**Let your Govern wikis direct AI behaviour.** Your Principle wiki defines non-negotiables for how your organisation communicates. Your Voice wiki encodes tone and style. When Claude or any other tool generates content, it can read those wikis and operate within your rules — not its defaults.
+
+The key insight: **Robin gets more valuable the more you use it in both directions.** Logging builds the knowledge base. Using it proves the knowledge base works. And the act of using it reveals gaps — things you thought you knew but hadn't captured, wikis that need updating, beliefs that have shifted.
+
+### Prompt the user
+
+Ask:
+> Now that you've logged a couple of entries, let's try using Robin. Is there something you're working on right now — a piece of writing, a decision, a meeting coming up — where we could pull from your knowledge base? Let's see Robin work in the other direction.
+
+If they have something, use `Robin:search` or `Robin:get_wiki` to pull relevant knowledge and show them how it feeds into their current work.
+
+---
+
+## Step 8: Establish Your Rhythm
+
+The last step isn't a task — it's a habit. Robin compounds. But only if you use it consistently.
+
+### The daily rhythm
+
+- **Morning:** Scan your wikis. Has anything accumulated overnight (from automated feeds, team inputs)? What's growing? What's stale?
+- **During the day:** Log entries as you go. After a meeting, capture the key takeaway. After reading something, log the one thing that stuck with you. After making a decision, log why.
+- **Weekly:** Review your wikis. Read the wiki bodies. Are they reflecting your current thinking? Edit them if not. The wiki is your curated position — it should always represent your best current understanding.
+
+### The compounding effect
+
+In week one, Robin feels like a note-taking tool. By month two, your wikis have depth. By month six, you have a genuine knowledge base — an externalised, structured version of your expertise that AI can actually work with. That's when Govern mode comes alive. That's when you stop just capturing knowledge and start deploying it.
+
+### Close the onboarding
+
+> Your knowledge base is set up. You've got wikis, your first entries are logged, and you've seen knowledge flow both ways.
+>
+> From here, the system gets out of your way. Log entries. Use your wikis. Tend your knowledge. Let it compound.
+>
+> And remember: Robin is automatic where it makes sense. But it expects you to think where it matters. The more you engage, the more valuable this becomes. Not because the AI gets smarter — but because your knowledge base does. And that's yours.
+
+---
+
+## When You Don't Know the Answer
+
+Claude does not know everything about Robin. Robin is an evolving product with features, settings, and capabilities that may go beyond what's documented in this skill.
+
+If a user asks a question about Robin that you can't confidently answer — how a specific feature works, what a setting does, what's possible in the Robin app — **say so.** Don't guess or improvise.
+
+Tell the user: "I'm not sure about that — you'd want to check in the Robin app directly, or ask the Robin team."
+
+This applies during onboarding and in any future conversation involving Robin. It's always better to be honest about the limits of what you know than to give wrong information about how someone's knowledge system works.
+
+---
+
+## Handling Different Starting Points
+
+Not every user arrives blank. Adapt:
+
+- **User has existing notes/documents they want to import:** Guide them to log entries from their existing material. Start with the 3-5 most important pieces, not everything at once.
+- **User is setting up Robin for a team/organisation:** Focus on shared wikis first. Establish naming conventions early. Discuss who governs which wikis.
+- **User has been using Robin but wants to reorganise:** Use `Robin:search` to audit what exists. Identify wiki gaps, fragment routing issues, and stale content before restructuring.
+- **User is a media monitoring client:** This onboarding still applies, but emphasise briefs, topics, and keywords over personal knowledge tasks. Lean on Research and Log wiki types as the backbone.
+
+---
+
+# PART 2: ROBIN REFERENCE
+
+This section defines Robin's architecture and conventions. The logging skills (`log-to-robin-short`, `log-to-robin-long`) and any future Robin skills should reference these definitions rather than encoding Robin's logic independently.
+
+---
+
+## Core Architecture
+
+### Entries
+
+Raw inputs logged by the user or by automated systems. An entry is unstructured content — a transcript, an article, a thought, a pasted document. Robin's AI pipeline processes entries to extract fragments.
+
+**Key properties:**
+- Entries are the ingestion layer. They are never the final form of knowledge.
+- One entry can produce many fragments.
+- Entries carry metadata: channel, uploaded by, attribution, context (see Metadata section below).
+- Users should not worry about formatting or structure — Robin handles processing.
+
+### Fragments
+
+The atomic units of knowledge extracted from entries. A fragment is a single idea, fact, observation, decision, quote, or insight. Fragments are small enough to stand alone and specific enough to be useful.
+
+**Key properties:**
+- Robin extracts fragments from entries automatically.
+- One fragment can belong to multiple wikis (many-to-many).
+- Fragments carry their own attribution — "who said this" at the individual statement level.
+
+**The 7 fragment types** (assigned automatically during extraction; use the most specific that fits):
+
+| Type | Use when… |
+|---|---|
+| **fact** | A concrete, verifiable statement about something that happened or is true. |
+| **idea** | A thought, opinion, hypothesis, or suggestion — not yet acted on. |
+| **question** | An explicit or clearly implied question. |
+| **action** | A concrete task, commitment, or next step. |
+| **quote** | Verbatim words attributed to a specific person. |
+| **reference** | A pointer to an external resource — URL, book, paper, tool, repo. |
+| **note** | A contextual or metacognitive remark that doesn't fit the others. |
+
+### Wikis
+
+Topics and themes that accumulate fragments over time. Each wiki has a body that synthesises its fragments into a coherent, evolving document — like a Wikipedia page that grows as you feed it.
+
+**Key properties:**
+- Wikis are the organising layer of the knowledge base.
+- They grow organically as entries are logged and fragments are routed.
+- They can also be created deliberately before any content exists.
+- Wiki bodies are human-readable and should represent the user's best current understanding of the topic.
+- Every wiki has a **type** that determines its default structure and synthesis behaviour.
+- Every wiki has a **description** (what fragments belong here — the routing lever) and a **structure** (the section template — the synthesis lever). These are independent controls. See "Description vs Structure" below.
+
+#### Description vs Structure
+
+The two user-controllable levers on a wiki:
+
+- **Description.** Free-text statement of what this wiki is for. Robin matches incoming fragments against the description to decide whether they belong. Editable any time. Vague description → misrouted fragments. Specific description → accurate routing.
+
+- **Structure.** A section template (markdown headings + prose prompts) Robin uses when synthesizing the wiki body from accumulated fragments. Each wiki **type** ships with a `default_structure` — the canonical layout for that kind of knowledge (e.g. Belief: Core Claim / Supporting Points / Counterarguments / Key Quotes). When a wiki is created, that default seeds the wiki's structure. The user can edit the structure in the wiki's settings, or hit "Revert to default" to restore the type's default. On wiki type change, a customized structure is preserved; an untouched default swaps to the new type's default.
+
+**Critical: do not conflate them.** The skill's job when answering user questions is to use the right vocabulary:
+- "Why isn't fragment X landing in wiki Y?" → description issue (routing).
+- "Why is wiki Y's body laid out this way?" → structure issue (synthesis).
+- "I want this wiki to read differently" → structure.
+- "I want different kinds of fragments in this wiki" → description.
+
+**The 10 default wiki types** (extensible via `Robin:create_wiki_type`):
+
+| Mode | Type | Purpose |
+|---|---|---|
+| Observe | **Log** | Capturing what happens, in words or data. Doesn't close — it accumulates. Templates within Log (Journal, Monitor, Playbook, Collection, Tracker) are formatting differences, not type differences. |
+| Observe | **Research** | Accumulating signals around a specific subject to make sense of an unfolding pattern. Watching with a question. The pre-Belief stage — the bridge between Observe and Drive. |
+| Drive | **Belief** | A position being formed or held, evolving as evidence accumulates |
+| Drive | **Decision** | A choice made or being evaluated, with reasoning |
+| Drive | **Objective** | Something being aimed for, connected to actions and projects |
+| Drive | **Project** | A bounded piece of work with scope, milestones, and status |
+| Govern | **Principle** | Non-negotiable rules and standards |
+| Govern | **Skill** | A repeatable capability — how to do something well |
+| Govern | **Agent** | Specification for an AI agent — role, tools, constraints |
+| Govern | **Voice** | How to communicate — tone, style, examples |
+
+### Collections
+
+Optional, user-curated buckets for grouping wikis. Collections only hold wikis (not fragments, people, or entries) and a wiki can belong to multiple collections at once.
+
+**Key properties:**
+- User-created and user-managed. Robin does not auto-file wikis into collections.
+- Optional — a user with a small number of wikis doesn't need them.
+- A wiki can belong to zero, one, or several collections.
+- The Robin app sidebar groups wikis by collection; the Explorer page lets users filter by collection.
+- Manage via `Robin:list_groups`, `Robin:create_group`, and `Robin:add_wiki_to_group` (the API name "group" is the internal term for what the UI calls a Collection).
+
+### People
+
+A separate dimension that runs across all other objects. People can be the subject of wikis, the source of fragments, participants in entries, and connections across the knowledge base.
+
+**Key properties:**
+- People are tracked via `Robin:get_person`.
+- Attribution at the fragment level connects to the people layer.
+- People can appear throughout the knowledge base — a person might be quoted in one wiki, be the subject of another, and be a participant in entries across many topics.
+
+---
+
+## The Three Modes
+
+Robin organises knowledge around three modes:
+
+**Observe** — capture what's happening. Monitoring, logging, noting. The input layer.
+
+**Drive** — process observations into positions, decisions, plans. The thinking layer.
+
+**Govern** — encode judgment into rules and frameworks that AI can act on. The governance layer.
+
+These form a compounding loop: Observe → Drive → Govern → (informs what you) Observe next.
+
+---
+
+## Metadata
+
+Every piece of content entering Robin should carry three metadata dimensions. Until Robin's API supports dedicated fields for these, they are encoded as tags at the top of the content string.
+
+### Channel
+
+The technical pathway through which content entered Robin. Auto-populated — neither the user nor Claude needs to think about this.
+
+Values: `Claude`, `Web`, `API`. (These map to the underlying `source` enum on `log_entry`: `mcp`, `web`, `api`. The skill convention "Channel: Claude" is the human-readable label for `source=mcp`.)
+
+### Uploaded by
+
+Which human in the organisation sent this content. Auto-populated by Claude from conversation context.
+
+This is about accountability and organisational awareness. "Show me everything Nadene has been logging" is a valid query this enables.
+
+### Attribution
+
+The original authority behind the content. This is "who said it" or "who wrote it." This is the field that carries intellectual weight.
+
+**Rules:**
+- At the **entry level**, attribution can include multiple sources (e.g., "Phyl Georgiou, Karen Kimami" for a meeting between them). This acknowledges everyone involved.
+- At the **fragment level**, attribution should be per person — "Karen said X" or "Phyl said Y." Robin handles this decomposition when it fragments entries.
+- For **articles**: attribution is `Author Name, Publication` (e.g., "Jane Smith, Financial Times").
+- For the **user's own thinking**: attribution is the user themselves.
+- When a user **relays someone else's idea** ("Chris told me he thinks X"): attribute to Chris, not the user.
+- If attribution is **unclear**, Claude should ask before logging.
+
+### Temporary content format
+
+Until the API supports dedicated metadata fields, encode as:
+
+```
+[Channel: Claude]
+[Uploaded by: {user's name}]
+[Attribution: {who said/wrote it}]
+[Context: {brief description of where this came from}]
+
+{the actual content}
+```
+
+---
+
+## Creating Wikis Well
+
+The MCP `create_wiki` tool requires three fields — `title`, `description`, and `type` — at the schema level. Calling without all three returns a protocol error. But "present" is not the same as "good." A bad wiki — generic name, wrong type, vague description — corrupts Robin's routing the moment it accumulates fragments, and the damage is hard to undo. Claude's job is to protect the user from creating one.
+
+### The protocol
+
+When the user asks you to create a wiki via MCP, follow this every time. **Do NOT infer fields from the title** — even if the title seems self-explanatory.
+
+1. **Ask the user, in their own words, what this wiki is for.** The description is what Robin uses to route future fragments — it must come from the user, not from your own paraphrase. A title like "Parambi Family Travel Planning" is not enough; you need the user's articulation of what kinds of fragments belong here and what doesn't.
+2. **Call `Robin:get_wiki_types` and present the type options to the user.** Ask which type fits. Do not infer the type from the title or the description.
+3. **Confirm name + type + description back to the user**, then call `Robin:create_wiki` with all three exactly as the user said them.
+
+If the user provides only a title, do NOT call `create_wiki` yet — ask the description and type questions first. Skipping these steps corrupts routing for every future fragment that lands in this wiki.
+
+### The quality bar
+
+Each of the three fields has a threshold beyond just being non-empty:
+
+**Name is territorial, not generic.**
+- Bad: "AI Notes", "Africa Research", "Strategy"
+- Good: "How AI is reshaping professional services", "The case for African tech talent", "Why we're picking project-based pricing"
+- The name should sound like a position, a territory, or a question — not a folder.
+
+**Type is explicitly chosen.**
+- If the user is unsure which type fits, walk them through the options `get_wiki_types` returns. Explain the choice: "Sounds like a Belief — a position you're forming. Or is this more Research — still gathering signal?"
+- Don't accept "whichever" — make them pick.
+
+**Description defines what belongs and what doesn't.**
+- Bad: "Stuff about AI and jobs."
+- Good: "How AI is changing the division of labour between humans and machines, with a focus on which tasks are being automated, which are being augmented, and what new roles are emerging. Particularly interested in the African context and the outsourcing industry."
+- Vague description = misrouted fragments forever.
+
+If any of the three are weak, refuse to call the tool. Tell the user what's missing — show them the bad/good examples — and help them strengthen it. This friction is the feature.
+
+---
+
+## MCP Tool Reference
+
+Robin exposes 16 MCP tools, grouped here by purpose. Default to the **Capture** and **Read** tools for most conversations — the management tools are for power-user moments.
+
+### Capture — write knowledge into Robin
+
+| Tool | What it does | When to use it |
+|---|---|---|
+| `Robin:log_entry` | Logs raw text into Robin for AI processing | Default for most logging — meeting notes, observations, ideas, articles. Robin will fragment and route automatically. |
+| `Robin:log_fragment` | Places a fragment directly into a specific wiki, bypassing the AI pipeline | When you know exactly which wiki the content belongs to (e.g., seeding a new wiki, or the user has explicitly directed content to a specific wiki). Get wiki slugs from `list_wikis` or `get_wiki` first. |
+
+### Read — pull knowledge out of Robin
+
+| Tool | What it does | When to use it |
+|---|---|---|
+| `Robin:search` | Hybrid search across fragments, wikis, and people | To find existing content, check what was created, explore connections, or compare new content against existing knowledge |
+| `Robin:list_wikis` | Lists all the user's wikis with metadata | To enumerate what wikis exist, get a slug for another tool, or surface the shape of the knowledge base |
+| `Robin:get_wiki` | Reads a wiki's body and fragments | To review a wiki's current state, pull its content into a Claude conversation, or audit its accumulation |
+| `Robin:get_fragment` | Reads a specific fragment | To examine or discuss a particular piece of knowledge |
+| `Robin:find_person` | Looks up a person by name, alias, or key | When discussing people and relationships, or checking if someone is already tracked |
+| `Robin:brief_person` | Returns the full structured summary of a tracked person | Once a person is identified, to pull what Robin knows about them — their role, how the user knows them, what they care about |
+| `Robin:list_skills` | Lists the skills available in the Robin knowledge base (skills stored as wiki rows under the `skill` wiki type) | To enumerate which skill wikis exist for the user — useful when picking a skill to read or extend. The metadata only — fetch full body via `get_wiki`. |
+
+### Manage wikis
+
+| Tool | What it does | When to use it |
+|---|---|---|
+| `Robin:create_wiki` | Creates a new wiki — title, description, and type are ALL required | When the user asks Claude to create a wiki. **Always follow the protocol in "Creating Wikis Well" above** — never call without going through it. |
+| `Robin:edit_wiki` | Updates a wiki's metadata or content | When the user has explicitly asked to revise an existing wiki's name, description, structure, or body |
+| `Robin:get_timeline` | Returns the audit trail / edit history for a wiki | When the user wants to see what's changed in a wiki, when, and why |
+
+### Manage wiki types
+
+| Tool | What it does | When to use it |
+|---|---|---|
+| `Robin:get_wiki_types` | Lists the available wiki types (slugs and descriptions) | Before creating a wiki to confirm valid type slugs, or to explain the type system to the user |
+| `Robin:create_wiki_type` | Defines a new wiki type | Rare — only when the user wants to extend Robin beyond the 10 default types |
+
+### Manage collections (groups of wikis)
+
+| Tool | What it does | When to use it |
+|---|---|---|
+| `Robin:list_groups` | Lists all collections with wiki counts | To show what collections exist or pick one for filing a wiki |
+| `Robin:create_group` | Creates a new collection | When the user wants a new bucket for grouping wikis (e.g., "Personal", "Work") |
+| `Robin:add_wiki_to_group` | Adds a wiki to a collection | After creating a wiki, when the user wants to file it into an existing collection |
+
+**Note on terminology:** Robin renamed its API tools from "thread" to "wiki" — so the canonical names are `get_wiki`, `list_wikis`, `create_wiki`, etc. One legacy holdout: the parameter name on `log_fragment` is still `threadSlug` (not `wikiSlug`). Use `threadSlug` as written when calling that tool, even though everywhere else "wiki" is the term. In user-facing conversation, always say "wiki."
+
+---
+
+## Available Robin Skills
+
+These skills work together to support Robin's knowledge system. Each one leans on Part 2 of this guide for architectural definitions.
+
+| Skill | Purpose | When it triggers |
+|---|---|---|
+| **Robin Knowledge System Guide** (this skill) | Onboarding + reference layer | New user setup, or when other skills need architectural context |
+| **Log to Robin (Short)** | Capture short-form content — chat insights, meeting notes, articles under ~2,000 words with clear attribution | User says "log this to Robin" and content is short with clear speakers |
+| **Log to Robin (Long)** | Mine long documents and attribution-unclear content for the best fragments. Pre-chunks long input into atomic `log_entry` calls before sending — the server stays naive on entry size by design. | Content over ~2,000 words, or attribution is unclear regardless of length |
+
+---
+
+# PART 3: Common Questions
+
+When the user asks something Claude could plausibly answer from this skill, prefer the canonical answer below. If the question is outside this set, fall back to first principles from Part 2 — and admit uncertainty if the answer isn't in either place.
+
+## Why didn't my fragment land in the wiki I expected?
+
+Almost always a **description** issue (see Description vs Structure). Robin routes fragments by matching them against each wiki's description. If a wiki's description is vague — "Stuff about AI and jobs" — Robin guesses, and a fragment that should have landed there ends up somewhere else (or nowhere).
+
+The fix is to make the description more specific. Edit it in the wiki's settings — say what belongs in this wiki, and what doesn't. Future fragments will route more accurately. Already-landed fragments stay where they are unless the user explicitly re-routes them.
+
+## Where does my data live? Who can see it?
+
+Robin is single-tenant — each user has their own Robin instance with its own Postgres database. Wikis, fragments, entries, and people all live there.
+
+By default, **wikis are private**. A wiki can be explicitly published from the Robin app, which generates a stable URL anyone with the link can read — but this is opt-in per wiki, never automatic.
+
+Robin does call out to LLM APIs (via OpenRouter) to fragment entries and synthesize wiki bodies — content is sent to those providers for processing. If the user is uncomfortable with any data leaving their machine, Robin is the wrong tool.
+
+## Can I rename a wiki?
+
+Yes — in the wiki's settings inside the Robin app. The user-facing name updates everywhere; the slug (used in URLs and backlinks like `[[wiki:my-slug]]`) stays stable so existing references don't break.
+
+Renaming via Claude/MCP is not currently supported — `Robin:edit_wiki` updates the wiki's content body, not its name. Direct the user to the app for renames.
+
+## Why is this wiki's body laid out a certain way?
+
+A **structure** issue (see Description vs Structure). Each wiki has a section template — its structure — that Robin follows when synthesizing the wiki body from fragments. The default comes from the wiki's type (a Belief wiki has Core Claim / Supporting Points / Counterarguments; a Decision wiki has per-Option subsections).
+
+If the user wants the wiki to read differently, they edit the structure in the wiki's settings. They can write their own template, or hit "Revert to default" to restore the type's default. The next time the wiki regenerates, the body will match the new structure.
+
+The user can also edit the **type-level default structure** itself in settings — useful when they want every new Belief wiki (for example) to follow their preferred layout. That changes the default seeded into *future* wikis of that type; existing wikis keep their current structures.
+
+## What's a Collection? Do I need to use them?
+
+Collections are optional buckets for grouping wikis (see Collections in Part 2). The user creates them and files wikis into them; Robin doesn't auto-file. The Robin app sidebar groups wikis by collection.
+
+The user doesn't need them on day one. With 3-5 wikis the sidebar is small; collections add organisation without adding value. They become useful around 15-20 wikis, when the list starts feeling cluttered. Tell the user to add collections when *they* feel the need — not because the system expects them.
+
+## How long does Robin take to process an entry?
+
+Asynchronous — Robin queues the entry, so it doesn't block the user. For a typical short entry (a paragraph or two), expect a few seconds to a minute end-to-end: Robin fragments the entry, embeds the fragments, routes them to wikis, and regenerates affected wiki bodies.
+
+Longer entries (a meeting transcript, a long article) take longer — more to fragment, more to route, more to regenerate. A few minutes is normal for a dense entry.
+
+If after a few minutes the user doesn't see new fragments in their wikis, two possibilities: (1) the pipeline hit an issue — check the Robin app for errors; (2) Robin extracted nothing, because the entry was too short, too vague, or didn't contain anything substantive worth keeping.
+
+## When should I add to an existing wiki vs create a new one?
+
+Simplest rule: **log the entry first, see where Robin routes it.** If fragments land in an existing wiki, that wiki is the right home. If they don't land anywhere, that's a signal a new wiki may be needed.
+
+For the deliberate case:
+- **Add to existing** when the new content reinforces, complicates, extends, or contradicts what's already there. A wiki is a *territory* — new fragments should fall within it.
+- **Create a new wiki** when the topic is genuinely outside every existing description. Avoid wikis for one-off thoughts — those belong as fragments in an existing wiki, or in a Log wiki.
+
+If the user is unsure: "Could this be a chapter in any of your existing wikis?" If yes, add. If no, sit with it for a few days first — new wikis without a clear reason often duplicate existing ones.
+
+## I have a long document or report — how should I log it?
+
+Don't dump the whole thing into a single entry. Long documents (>~2,000 words) and messy multi-source content (transcripts with unclear speakers, decks covering many topics) work much better when *mined* first.
+
+Use the **`log-to-robin-long`** skill — it reads the document, surfaces the most compelling fragments (novel claims, well-articulated ideas, things that complicate or reinforce what Robin already knows), and asks the user which to keep before logging. The result is a curated set of fragments rather than 10,000 words of raw text for Robin to process. The skill also pre-chunks the approved fragments into one atomic `log_entry` call each — the server is deliberately naive on entry size, so chunking happens client-side in the skill.
+
+This matters because Robin's pipeline is sized for atomic ideas, not full documents. Logging a raw 50-page deck means Robin spends compute fragmenting things the user wouldn't have kept anyway, and the wiki bodies that get synthesized include noise. Mining-first means quality fragments land cleanly and the wikis stay sharp.
+
+For shorter content (~2,000 words or less, with clear attribution — chat insights, meeting transcripts with named speakers, single-author articles), the **`log-to-robin-short`** skill is the right tool. It logs more directly because there's less to filter.
+
+## When should I use Log Short vs Log Long?
+
+Two heuristics, in order:
+
+1. **Length.** Under ~2,000 words → Short. Over → Long. A few hundred words is clearly Short. A 50-page deck is clearly Long.
+
+2. **Attribution clarity.** If speaker labels are clean ("Karen Kimami: …", named author, the user's own words) → Short can handle it. If attribution is messy (transcript with "Speaker 1, Speaker 2", anonymous report, mixed-source doc) → Long, even if the word count would otherwise fit Short. Long has a per-fragment attribution-resolution step that Short skips.
+
+When both heuristics agree, use that skill. When they disagree, attribution wins — Robin's value depends on knowing who said what at the fragment level, and Long is built to get that right.
+
+Edge cases:
+- A 2,500-word piece with one through-line and a clear author → Short is fine.
+- A 1,500-word piece covering five topics with no attribution → Long.
+- A user asking "log this whole conversation" mid-chat → Short (conversational, attribution is clear from context).
+- A pasted research report → Long, regardless of size, because the user doesn't want everything kept.
+
+The skills themselves enforce this — if Log Short detects content that exceeds its bar, it reroutes to Log Long automatically.
+
+## What's the difference between log_entry and log_fragment?
+
+Two MCP tools, two different jobs.
+
+**`Robin:log_entry`** is the **default**. The user gives Claude raw text — a meeting transcript, an observation, an article — and Claude calls `log_entry`. Robin's pipeline takes over: extracts atomic fragments, embeds them, routes them to the relevant wikis based on each wiki's description. The user never has to think about which wiki gets what.
+
+**`Robin:log_fragment`** is **manual placement**. The user (or Claude) specifies exactly which wiki a piece of content belongs in, and Robin stores it there as a single fragment. No fragmentation. No routing. The AI pipeline is bypassed.
+
+When to use each:
+- **`log_entry`** — normally. If the user said "log this", that's `log_entry`. Robin's job is to handle the messy work of breaking content into atomic fragments and routing them.
+- **`log_fragment`** — when the user explicitly directs content to a specific wiki ("save this to my Belief wiki on X"), or when seeding a new empty wiki with a starter idea. Requires the wiki slug — get it from `list_wikis` first.
+
+**The subtle gotcha:** `log_fragment` doesn't fragment the content — whatever you send lands as a single fragment. So if the user wants to manually place a multi-passage piece, don't pass the whole thing as one call. Break it into atomic fragments yourself first (one idea, one quote, or one observation per fragment), then make a separate `log_fragment` call for each. That way each idea lands cleanly and can be related to other fragments.

--- a/skills/log-to-robin-guide.md
+++ b/skills/log-to-robin-guide.md
@@ -559,7 +559,7 @@ Robin exposes 16 MCP tools, grouped here by purpose. Default to the **Capture** 
 | `Robin:get_fragment` | Reads a specific fragment | To examine or discuss a particular piece of knowledge |
 | `Robin:find_person` | Looks up a person by name, alias, or key | When discussing people and relationships, or checking if someone is already tracked |
 | `Robin:brief_person` | Returns the full structured summary of a tracked person | Once a person is identified, to pull what Robin knows about them — their role, how the user knows them, what they care about |
-| `Robin:list_skills` | Lists the skills available in the Robin knowledge base (skills stored as wiki rows under the `skill` wiki type) | To enumerate which skill wikis exist for the user — useful when picking a skill to read or extend. The metadata only — fetch full body via `get_wiki`. |
+| `Robin:list_skills` | Lists the skills available in the Robin knowledge base (skills stored as wiki rows under the `skill` wiki type) | To enumerate which skill wikis exist for the user; useful when picking a skill to read or extend. Metadata only; fetch full body via `get_wiki`. |
 
 ### Manage wikis
 
@@ -596,7 +596,7 @@ These skills work together to support Robin's knowledge system. Each one leans o
 |---|---|---|
 | **Robin Knowledge System Guide** (this skill) | Onboarding + reference layer | New user setup, or when other skills need architectural context |
 | **Log to Robin (Short)** | Capture short-form content — chat insights, meeting notes, articles under ~2,000 words with clear attribution | User says "log this to Robin" and content is short with clear speakers |
-| **Log to Robin (Long)** | Mine long documents and attribution-unclear content for the best fragments. Pre-chunks long input into atomic `log_entry` calls before sending — the server stays naive on entry size by design. | Content over ~2,000 words, or attribution is unclear regardless of length |
+| **Log to Robin (Long)** | Mine long documents and attribution-unclear content for the best fragments. Pre-chunks long input into atomic `log_entry` calls before sending; the server stays naive on entry size by design. | Content over ~2,000 words, or attribution is unclear regardless of length |
 
 ---
 
@@ -660,7 +660,7 @@ If the user is unsure: "Could this be a chapter in any of your existing wikis?" 
 
 Don't dump the whole thing into a single entry. Long documents (>~2,000 words) and messy multi-source content (transcripts with unclear speakers, decks covering many topics) work much better when *mined* first.
 
-Use the **`log-to-robin-long`** skill — it reads the document, surfaces the most compelling fragments (novel claims, well-articulated ideas, things that complicate or reinforce what Robin already knows), and asks the user which to keep before logging. The result is a curated set of fragments rather than 10,000 words of raw text for Robin to process. The skill also pre-chunks the approved fragments into one atomic `log_entry` call each — the server is deliberately naive on entry size, so chunking happens client-side in the skill.
+Use the **`log-to-robin-long`** skill — it reads the document, surfaces the most compelling fragments (novel claims, well-articulated ideas, things that complicate or reinforce what Robin already knows), and asks the user which to keep before logging. The result is a curated set of fragments rather than 10,000 words of raw text for Robin to process. The skill also pre-chunks the approved fragments into one atomic `log_entry` call each; the server is deliberately naive on entry size, so chunking happens client-side in the skill.
 
 This matters because Robin's pipeline is sized for atomic ideas, not full documents. Logging a raw 50-page deck means Robin spends compute fragmenting things the user wouldn't have kept anyway, and the wiki bodies that get synthesized include noise. Mining-first means quality fragments land cleanly and the wikis stay sharp.
 

--- a/skills/log-to-robin-long.md
+++ b/skills/log-to-robin-long.md
@@ -1,0 +1,196 @@
+---
+name: log-to-robin-long
+description: Mine long documents, reports, decks, and complex content for knowledge worth capturing in Robin. Use this skill whenever a user wants to log content to Robin that exceeds ~2,000 words OR when speaker attribution is unclear regardless of length. Also trigger when a user uploads a large document and wants to extract the most valuable parts for Robin, or when the log-to-robin-short skill reroutes here due to length or attribution issues. This skill reads the full content, compares it against existing Robin knowledge, surfaces the most compelling fragments for user curation, resolves attribution, and logs approved content. Pre-chunks long content into atomic log_entry calls before sending to Robin (the server stays naive on entry size by design).
+---
+
+# Log to Robin (Long)
+
+The miner. Takes a large or complex piece of content — a research report, a 50-page deck, a dense strategy document, a messy transcript with unclear attribution — and extracts what's worth keeping in Robin.
+
+The core difference from Log Short: **the user doesn't want everything logged.** The value is in selection. Claude reads the whole thing, compares it against what Robin already knows, and surfaces the specific pieces worth capturing. The user curates. Then Claude logs what's approved.
+
+This skill also handles content rerouted from Log Short due to unclear speaker attribution. The workflow is the same — narrow down to the compelling fragments first, then resolve who said what.
+
+## Pre-chunking: the contract with Robin's server
+
+Robin's server is **deliberately naive on entry size**. It does not split a giant entry into many. The chunking responsibility lives **in this skill, on the client side**.
+
+What that means in practice:
+
+- A 10,000-word document MUST NOT be sent as a single `log_entry` call. The fragmenter is sized for atomic ideas; handing it 10,000 words wastes compute, produces sloppy fragments, and pushes the cost line.
+- This skill's job is to convert "one big document" into "N atomic `log_entry` calls", one per compelling fragment the user approves.
+- Each call carries one self-contained idea, quote, observation, decision, or claim — small enough that Robin's downstream fragmenter sees a single unit and produces a single fragment from it.
+
+The cap to keep in mind: roughly **~2,000 words per `log_entry` call**, and ideally far less. If an approved fragment is longer than that, split it further along the natural seam — paragraph break, topic shift, speaker change.
+
+## When this skill activates
+
+**Triggered directly when:**
+- User says "log this to Robin" and the content exceeds ~2,000 words
+- User uploads a long document (PDF, deck, report) and asks to extract knowledge for Robin
+- User references a large piece of content and wants Robin to learn from it
+
+**Rerouted from Log Short when:**
+- Content exceeds ~2,000 words
+- Speaker attribution is unclear or missing regardless of length
+- Content is dense and multi-topic even at shorter lengths
+
+These are heuristics. A 2,500-word piece with one clear through-line might stay with Log Short. A 1,500-word piece covering five topics with no names attached should come here.
+
+## Step 1: Assess what you're working with
+
+Before diving in, get oriented.
+
+**Can Claude read the whole thing in one pass?**
+- If yes, proceed to Step 2.
+- If the document is too long to process at once, ask the user for guidance: "This is a large document. Want me to work through the whole thing section by section, or should I focus on specific parts? If so, which sections matter most to you?"
+
+**Is this a reroute from Log Short due to attribution issues?**
+- If yes, note that attribution resolution will happen in Step 5 after fragments are selected. The first job is still to identify what's compelling.
+
+## Step 2: Ask the user to scope the comparison
+
+Claude needs to know what existing Robin knowledge to compare against. Don't assume — ask.
+
+"Which areas of your knowledge should I compare this against? I can search broadly across Robin, or you can point me to specific wikis."
+
+Three scenarios:
+- **User names specific wikis** — Claude pulls those via `Robin:get_wiki` and uses them as the comparison baseline.
+- **User says "search broadly"** — Claude runs multiple `Robin:search` queries based on the document's key themes to build a picture of what Robin already knows.
+- **User says "just find what's interesting, don't worry about comparison"** — Claude skips the comparison step and extracts based on the content alone.
+
+The comparison isn't mandatory — it makes extraction smarter, but some users just want Claude to pull out the good stuff.
+
+## Step 3: Read and extract
+
+Read the full document (or the scoped sections if the user narrowed it). Identify the fragments worth surfacing.
+
+**What counts as "compelling":**
+- **Novel** — Robin doesn't know this yet. New information, new perspectives, new data.
+- **Challenging** — contradicts or complicates an existing Belief, assumption, or wiki in Robin.
+- **Reinforcing** — adds evidence or depth to something Robin already holds. Strengthens an existing position.
+- **Actionable** — implies a decision, a next step, or a change in approach.
+- **Clearly articulated** — well-expressed ideas, clean formulations that are worth preserving in their original language.
+- **Good quotes** — specific statements from specific people that carry weight, show a perspective, or capture something precisely.
+
+**How many fragments to extract:**
+- If the user has specified a number ("give me the top 5"), respect that.
+- Otherwise, use judgement. Surface everything genuinely worth keeping — don't artificially cap at 5 if there are 12 good things, and don't pad to 10 if there are only 3.
+- If the document is exceptionally rich and you're finding 20+ compelling fragments, flag it: "There's a lot worth capturing here. Want me to show you everything, or should I prioritise the top [number]?"
+
+## Step 4: Present fragments for curation
+
+Show the user what you found. For each fragment:
+
+1. **The content itself** — preserved in its original language. Do not polish or rephrase.
+2. **Why it matters** — one or two sentences on why this is worth capturing. Is it novel? Does it challenge something? Is it a particularly good articulation?
+3. **Where it connects** — if you did the comparison step, note which Robin wiki this relates to. "This directly feeds your wiki on [X]" or "This contradicts what you currently hold about [Y]" or "This has no home in Robin yet — it's new territory."
+
+Present as a numbered list so the user can easily approve, reject, or discuss individual items.
+
+Example format:
+```
+**1.** "The real bottleneck isn't model quality — it's that organisations don't know what they believe, so they can't tell the model what to care about."
+→ Novel articulation of a core problem. Connects to your Belief wiki on knowledge systems preceding communications systems.
+
+**2.** Karen noted that Meltwater produced 865+ articles of noise despite months of keyword refinement.
+→ Concrete evidence for the case against keyword-based monitoring. Reinforces your wiki on Robin's differentiation from traditional tools.
+```
+
+After presenting, ask: "Which of these should I log to Robin? All of them, a selection, or want to discuss any first?"
+
+## Step 5: Resolve attribution
+
+Once the user has approved which fragments to keep, resolve attribution for each one.
+
+**If attribution is already clear** (single-author report, named speakers in a transcript), confirm it briefly: "I'll attribute all of these to [Author/Publication] — correct?"
+
+**If attribution is unclear** (the reason this got rerouted from Log Short, or a multi-author document where it's not obvious who said what), go fragment by fragment on the ones that need it:
+
+"For fragment 3 — 'the real bottleneck is organisational belief systems' — who should I attribute this to?"
+
+Don't ask about every fragment if most have obvious attribution. Only flag the ambiguous ones.
+
+**Attribution format:**
+- Single person: "Karen Kimami"
+- Person + context: "Karen Kimami, Head of Fund Engagement at Gatsby Africa"
+- Publication: "Author Name, Publication" (e.g., "Jane Smith, Financial Times")
+- Multiple speakers at entry level: "Phyl Georgiou, Karen Kimami" — Robin handles per-fragment attribution downstream.
+- User relaying someone else: attribute to the original source, not the user.
+
+## Step 6: Structure and log — one atomic call per approved fragment
+
+This is where the pre-chunking contract lands.
+
+**Default: one `log_entry` call per approved fragment.**
+
+For each fragment the user approved in Step 4 (with attribution resolved in Step 5), make a separate `Robin:log_entry` call. Each call is one self-contained idea Robin can fragment cleanly. Do NOT bundle ten fragments into one call to "save round-trips" — that defeats the whole point of mining.
+
+Per-call content format:
+
+```
+[Channel: Claude]
+[Uploaded by: {user's name}]
+[Attribution: {who said/wrote this specific fragment}]
+[Context: {what document this came from, which section, the surrounding situation}]
+
+{the fragment, preserved in its original form}
+```
+
+If a single approved fragment is itself longer than ~2,000 words (rare — usually means Step 3 didn't narrow enough), split it along the natural seam (paragraph, topic shift, speaker change) and make multiple calls, each with the same context tag so Robin can reconnect them.
+
+**Alternative: log fragment by fragment to specific wikis.**
+If during curation the user said "that one goes in my monitoring differentiation wiki, that one goes in the Gatsby wiki", use `Robin:log_fragment` with the appropriate `threadSlug` for those, and `Robin:log_entry` for any fragment that needs Robin to route. Same one-call-per-fragment rule applies.
+
+**Why not bundle?** Robin's server stays naive on size by design. The fragmenter is built for atomic input. One big bundled call would force the fragmenter to reason over 10,000+ words in a single pass, which produces sloppy fragments and burns compute. The chunking lives here, in the client, on purpose.
+
+**Rules for each call's content body:**
+- **Preserve raw language.** Do not polish, summarise, or rephrase. Log exactly what the document says.
+- **Convert double quotes to single quotes when transcribing.** Robin's downstream wiki-writing pipeline has a known issue where literal double-quote characters (`"`) in source content can cause truncated wiki output mid-sentence. Whenever you would write a quoted phrase, name, or direct quotation, use single quotes (`'…'`) instead. Apply this as you transcribe — preserve the wording inside the quotes verbatim, only swap the punctuation. Example: source says *Tom said "we should ship by Friday"* → log as *Tom said 'we should ship by Friday'*.
+- **Include conversational context** in each call's `[Context:]` tag. Each fragment should carry enough context to be meaningful on its own. Don't just log 'the bottleneck is belief systems' — wrap it: 'In a discussion of why AI-powered communications tools underperform, the author argues that the bottleneck isn't model quality but that organisations don't know what they believe.'
+- **Content in languages other than English** — log as-is. Robin handles multilingual content. Do not translate.
+
+## Step 7: Confirm what was logged
+
+After all calls complete, confirm to the user what was sent:
+
+"Logged to Robin: [number] fragments from [document name/description], attributed to [attribution]. [Brief summary of what was captured.]"
+
+This matters because there is no edit or delete via the API. Once logged, it's logged.
+
+## Sensitivity check
+
+Before logging, scan the approved fragments for sensitive material: salary figures, personal health information, internal politics, confidential client data, personal contact details.
+
+If sensitive content is present, flag it: "Some of the approved fragments include sensitive information [specify what]. Still want me to log all of them?"
+
+Do not gatekeep — the user decides. But make sure it's a conscious decision.
+
+## Proactive logging
+
+Same rules as Log Short. Claude may suggest using this skill when **all** of these are true:
+- Robin MCP tools are already active in the conversation
+- The user has shared or is discussing a substantial document
+- The document clearly contains knowledge worth extracting
+
+In this case, Claude suggests: "There's a lot in this document that could be valuable in Robin. Want me to mine it for the best fragments?"
+
+**If Robin hasn't been invoked in the conversation, Claude does not introduce Robin.**
+
+## Handling URLs
+
+If a user shares a URL and says "log this" and the fetched content exceeds ~2,000 words:
+1. Fetch the content using `web_fetch`
+2. Inform the user this is a longer piece and you'll use the mining approach
+3. Attribution is `Author + Publication` (extract from the article)
+4. Proceed with the normal Long flow from Step 2
+
+## Edge cases
+
+**Document is long but has one clear through-line.** If a 3,000-word article makes one argument and the whole thing is worth keeping, don't force the mining workflow. Ask: "This is a longer piece but it's focused on one core idea. Want me to log the whole thing as a single entry, or extract the key points?" If the user picks "whole thing", split the article along its own paragraph/section breaks into ~2,000-word atomic calls — never one giant call.
+
+**User says "log this" but there's nothing compelling in the document.** Be honest: "I've read through this and I'm not finding much that's new relative to what Robin already holds. Want me to look again with different criteria, or skip this one?"
+
+**User wants to update something already in Robin.** There are no update or delete tools in the current API. Offer to help: "I can log a new entry clarifying this." Robin will process the new entry and reconcile it with existing knowledge.
+
+**The document references people Robin tracks.** If you encounter names that might exist in Robin's person system, you can use `Robin:find_person` to check and note the connection — but don't let this slow down the extraction workflow.

--- a/skills/log-to-robin-long.md
+++ b/skills/log-to-robin-long.md
@@ -19,9 +19,9 @@ What that means in practice:
 
 - A 10,000-word document MUST NOT be sent as a single `log_entry` call. The fragmenter is sized for atomic ideas; handing it 10,000 words wastes compute, produces sloppy fragments, and pushes the cost line.
 - This skill's job is to convert "one big document" into "N atomic `log_entry` calls", one per compelling fragment the user approves.
-- Each call carries one self-contained idea, quote, observation, decision, or claim — small enough that Robin's downstream fragmenter sees a single unit and produces a single fragment from it.
+- Each call carries one self-contained idea, quote, observation, decision, or claim. Small enough that Robin's downstream fragmenter sees a single unit and produces a single fragment from it.
 
-The cap to keep in mind: roughly **~2,000 words per `log_entry` call**, and ideally far less. If an approved fragment is longer than that, split it further along the natural seam — paragraph break, topic shift, speaker change.
+The cap to keep in mind: roughly **~2,000 words per `log_entry` call**, and ideally far less. If an approved fragment is longer than that, split it further along the natural seam: paragraph break, topic shift, speaker change.
 
 ## When this skill activates
 
@@ -118,13 +118,13 @@ Don't ask about every fragment if most have obvious attribution. Only flag the a
 - Multiple speakers at entry level: "Phyl Georgiou, Karen Kimami" — Robin handles per-fragment attribution downstream.
 - User relaying someone else: attribute to the original source, not the user.
 
-## Step 6: Structure and log — one atomic call per approved fragment
+## Step 6: Structure and log: one atomic call per approved fragment
 
 This is where the pre-chunking contract lands.
 
 **Default: one `log_entry` call per approved fragment.**
 
-For each fragment the user approved in Step 4 (with attribution resolved in Step 5), make a separate `Robin:log_entry` call. Each call is one self-contained idea Robin can fragment cleanly. Do NOT bundle ten fragments into one call to "save round-trips" — that defeats the whole point of mining.
+For each fragment the user approved in Step 4 (with attribution resolved in Step 5), make a separate `Robin:log_entry` call. Each call is one self-contained idea Robin can fragment cleanly. Do NOT bundle ten fragments into one call to "save round-trips"; that defeats the whole point of mining.
 
 Per-call content format:
 
@@ -137,7 +137,7 @@ Per-call content format:
 {the fragment, preserved in its original form}
 ```
 
-If a single approved fragment is itself longer than ~2,000 words (rare — usually means Step 3 didn't narrow enough), split it along the natural seam (paragraph, topic shift, speaker change) and make multiple calls, each with the same context tag so Robin can reconnect them.
+If a single approved fragment is itself longer than ~2,000 words (rare; usually means Step 3 didn't narrow enough), split it along the natural seam (paragraph, topic shift, speaker change) and make multiple calls, each with the same context tag so Robin can reconnect them.
 
 **Alternative: log fragment by fragment to specific wikis.**
 If during curation the user said "that one goes in my monitoring differentiation wiki, that one goes in the Gatsby wiki", use `Robin:log_fragment` with the appropriate `threadSlug` for those, and `Robin:log_entry` for any fragment that needs Robin to route. Same one-call-per-fragment rule applies.
@@ -147,7 +147,7 @@ If during curation the user said "that one goes in my monitoring differentiation
 **Rules for each call's content body:**
 - **Preserve raw language.** Do not polish, summarise, or rephrase. Log exactly what the document says.
 - **Convert double quotes to single quotes when transcribing.** Robin's downstream wiki-writing pipeline has a known issue where literal double-quote characters (`"`) in source content can cause truncated wiki output mid-sentence. Whenever you would write a quoted phrase, name, or direct quotation, use single quotes (`'…'`) instead. Apply this as you transcribe — preserve the wording inside the quotes verbatim, only swap the punctuation. Example: source says *Tom said "we should ship by Friday"* → log as *Tom said 'we should ship by Friday'*.
-- **Include conversational context** in each call's `[Context:]` tag. Each fragment should carry enough context to be meaningful on its own. Don't just log 'the bottleneck is belief systems' — wrap it: 'In a discussion of why AI-powered communications tools underperform, the author argues that the bottleneck isn't model quality but that organisations don't know what they believe.'
+- **Include conversational context** in each call's `[Context:]` tag. Each fragment should carry enough context to be meaningful on its own. Don't just log 'the bottleneck is belief systems'; wrap it: 'In a discussion of why AI-powered communications tools underperform, the author argues that the bottleneck isn't model quality but that organisations don't know what they believe.'
 - **Content in languages other than English** — log as-is. Robin handles multilingual content. Do not translate.
 
 ## Step 7: Confirm what was logged
@@ -187,7 +187,7 @@ If a user shares a URL and says "log this" and the fetched content exceeds ~2,00
 
 ## Edge cases
 
-**Document is long but has one clear through-line.** If a 3,000-word article makes one argument and the whole thing is worth keeping, don't force the mining workflow. Ask: "This is a longer piece but it's focused on one core idea. Want me to log the whole thing as a single entry, or extract the key points?" If the user picks "whole thing", split the article along its own paragraph/section breaks into ~2,000-word atomic calls — never one giant call.
+**Document is long but has one clear through-line.** If a 3,000-word article makes one argument and the whole thing is worth keeping, don't force the mining workflow. Ask: "This is a longer piece but it's focused on one core idea. Want me to log the whole thing as a single entry, or extract the key points?" If the user picks "whole thing", split the article along its own paragraph/section breaks into ~2,000-word atomic calls; never one giant call.
 
 **User says "log this" but there's nothing compelling in the document.** Be honest: "I've read through this and I'm not finding much that's new relative to what Robin already holds. Want me to look again with different criteria, or skip this one?"
 

--- a/skills/log-to-robin-short.md
+++ b/skills/log-to-robin-short.md
@@ -1,0 +1,152 @@
+---
+name: log-to-robin-short
+description: Capture knowledge from conversations, meeting transcripts, articles, and short-form content into Robin's knowledge system. Use this skill whenever a user says "log this to Robin", "save this to Robin", "send this to Robin", or when Claude recognises something worth preserving during a conversation where Robin MCP tools are already active. Also trigger when processing meeting transcripts for Robin, or when a user shares an article or short piece of content they want captured. This skill handles content under ~2,000 words with clear speaker attribution. If content exceeds ~2,000 words or speaker attribution is unclear/missing, route to the log-to-robin-long skill instead.
+---
+
+# Log to Robin (Short)
+
+The translator between conversation and Robin's knowledge system. Claude's job is to take something worth keeping — a chat insight, meeting transcript, article, comment — and package it so Robin can receive, classify, fragment, and route it correctly.
+
+Claude does not classify knowledge types, assign to threads, or fragment content. Robin handles all of that. Claude's job is to make the content string as clean and well-attributed as possible so Robin's pipeline can do its work.
+
+## When this skill activates
+
+The trigger is the word "log" (or similar: "save", "send", "capture") directed at Robin. Claude decides whether to use this skill or the long-form skill based on two factors:
+
+**Use this skill (Short) when:**
+- Content is under ~2,000 words AND speaker attribution is clear
+- Meeting transcript with named speakers (e.g., `[timestamp] Full Name: content`)
+- Single-author article or report
+- User's own thinking or insight from a chat
+- A clearly-scoped piece of content with obvious authorship
+
+**Route to Log Long instead when:**
+- Content exceeds ~2,000 words (research reports, 50-page decks, long strategy docs)
+- Speaker attribution is unclear or missing regardless of length (e.g. meeting notes labelled "Speaker 1, Speaker 2")
+- Content is dense and multi-topic even at shorter lengths
+
+These are heuristics, not hard rules. A 2,500-word piece with one clear through-line can stay Short. A 1,500-word piece covering five topics with no attribution should go Long.
+
+## Step 1: Figure out what "this" means
+
+"Log this to Robin" is ambiguous. Claude must determine scope before logging anything.
+
+**Take a first guess based on context, then confirm.** Never guess silently, never ask an open-ended "what do you mean?"
+
+Decision logic:
+- User just made a single statement and immediately says "log this" → probably means that statement. Confirm: "I'll log your point about [X] — that right?"
+- User says "log this" after a long back-and-forth → ambiguous. Propose what you think is the substance: "I think the key insight here was [X]. Want me to log just that, or the broader discussion?"
+- User says "log this meeting" or "log this article" → referent is clear, scope may not be. Clarify if needed.
+- User says "log this chat" or "log this conversation" → whole-chat intent. Log as a single entry and let Robin fragment it.
+- User references something from earlier in the chat → identify the specific moment and confirm.
+
+The goal is a single confident proposal the user can approve or redirect.
+
+## Step 2: Attribution pre-flight
+
+Before logging, scan the content for speaker attribution. This determines whether to proceed or reroute.
+
+**Three scenarios:**
+
+1. **Names present and clear** — transcripts with speaker labels like `[timestamp] Full Name: content`, single-author articles, user's own words. Proceed to Step 3.
+
+2. **Names missing or generic** — "Speaker 1", "Unknown", no labels at all. If the content is short enough to parse, ask the user: "I'm seeing Speaker 1 and Speaker 2 but no names — who was in this meeting?" Once clarified, proceed. If it's too tangled to untangle who said what, reroute to Log Long — it will extract the most compelling fragments and ask the user to attribute each one.
+
+3. **Single source, obvious attribution** — an article by a named author, the user's own insight, a quote from a specific person. Attribution is clear. Proceed.
+
+## Step 3: Sensitivity check
+
+Before logging, briefly scan the content for sensitive material: salary figures, personal health information, internal politics, confidential client data, personal contact details.
+
+If sensitive content is present, flag it: "This includes some sensitive information [specify what]. Still want me to log all of it to Robin?"
+
+Do not gatekeep — the user decides. But make sure it's a conscious decision.
+
+## Step 4: Structure the content for Robin
+
+Robin's `log_entry` API currently accepts two fields: `content` (string) and `source` (mcp/api/web).
+
+Until the API supports dedicated metadata fields, encode metadata as clear tags at the top of the content string, then include the actual content below.
+
+### Content format
+
+```
+[Channel: Claude]
+[Uploaded by: {user's name}]
+[Attribution: {who said/wrote it}]
+[Context: {brief description of where this came from}]
+
+{the actual content, preserved in its original form}
+```
+
+**Rules for the content body:**
+- **Preserve raw language.** Do not polish, summarise, or rephrase. Robin's pipeline will handle processing. If someone said 'it took a lot of human effort to sift through,' log exactly that — not 'the process required significant manual filtering.'
+- **Convert double quotes to single quotes when transcribing.** Robin's downstream wiki-writing pipeline has a known issue where literal double-quote characters (`"`) in source content can cause truncated wiki output mid-sentence. Whenever you would write a quoted phrase, name, or direct quotation, use single quotes (`'…'`) instead. Apply this as you transcribe — preserve the wording inside the quotes verbatim, only swap the punctuation. Example: source says *6 September is "Cousins Olympics" day* → log as *6 September is 'Cousins Olympics' day*.
+- **Preserve speaker attribution inline.** If the source is a transcript, keep the speaker labels: "Karen: We've been using Meltwater which was giving us a lot of noise." (NB: even speaker-labelled transcripts should follow the single-quote rule for any phrase the speaker quoted within their own utterance.)
+- **Include conversational context.** Don't log a bare insight stripped of its origin. Instead of just 'attribution should be per-fragment not per-entry,' log: 'During a discussion about Robin's knowledge capture architecture, Phyl identified that attribution should work differently at entry vs fragment level — entries can carry multiple sources but fragments should carry single-person attribution.'
+- **For meeting transcripts, use the full transcript** as the content, not any AI-generated summary. Summaries flatten attribution. The transcript preserves who said what. Include the full transcript and let Robin fragment it.
+
+### Metadata guidance
+
+**Channel:** Always `Claude` when logging from a Claude conversation.
+
+**Uploaded by:** The user Claude is talking to. Infer from conversation context.
+
+**Attribution:** The original authority behind the content. This is "who said it" or "who wrote it."
+- User's own thinking → attribute to the user
+- Meeting transcript → attribute to all participants at the entry level (e.g., "Phyl Georgiou, Karen Kimami"). Robin will handle per-fragment attribution downstream.
+- Article → attribute as `Author Name, Publication` (e.g., "Jane Smith, Financial Times")
+- User relaying someone else's idea ("Chris told me he thinks X") → attribute to Chris, not the user
+- If attribution is unclear, ask.
+
+**Context:** A one-line description of the origin. Examples:
+- "From a conversation between Phyl and Claude about Robin's skill architecture"
+- "Meeting transcript: Karen Kimami and Phyl Georgiou, April 9 2026"
+- "Article shared by user"
+
+## Step 5: Log to Robin
+
+Call `Robin:log_entry` with the structured content string and `source: "mcp"`.
+
+**When to use `log_fragment` instead:**
+Only if the user has explicitly directed content to a specific wiki, or the conversation is already operating within a specific wiki context (e.g., Claude has already been reading from or writing to a particular wiki via `Robin:get_wiki`). In that case, use `Robin:log_fragment` with the appropriate `threadSlug` (legacy parameter name — Robin renamed thread→wiki everywhere except this single argument on `log_fragment`).
+
+Default to `log_entry`. Let Robin route.
+
+## Step 6: Confirm what was logged
+
+After a successful log, confirm to the user what was sent. Keep it brief:
+
+"Logged to Robin: [one-line summary of what was captured, attributed to whom, from what context]."
+
+This matters because there is no edit or delete via the API. Once logged, it's logged. The confirmation gives the user a last-check moment.
+
+## Proactive logging
+
+Claude may suggest logging when **all** of these are true:
+- Robin MCP tools are already active in the conversation (calls to `search`, `get_wiki`, `list_wikis`, `log_entry`, `log_fragment`, `find_person`, or `brief_person` have been made)
+- Something worth preserving surfaces — a decision, a belief, a realization, a key piece of information
+- The user hasn't explicitly asked to log
+
+In this case, Claude suggests: "That point about [X] sounds worth logging to Robin — want me to capture it?"
+
+**If Robin hasn't been invoked in the conversation, Claude does not introduce Robin.** No unsolicited "would you like to save this to Robin?" in conversations that aren't about Robin.
+
+## Handling URLs and articles
+
+If a user shares a URL and says "log this":
+1. Fetch the content using `web_fetch`
+2. Assess length — if over ~2,000 words, reroute to Log Long
+3. If under ~2,000 words, discuss with the user: "I've pulled the article. Want me to log the whole thing, or should I focus on the key points?"
+4. Attribution is `Author + Publication` (extract from the article)
+5. Proceed with the normal flow
+
+## Edge cases
+
+**User says "log this" but there's nothing obviously worth logging.** Ask: "What specifically would you like me to capture? I want to make sure I get the right thing."
+
+**Multiple insights from one conversation.** Log as a single entry. Robin handles fragmentation — it will break the entry into separate fragments and route them appropriately.
+
+**Content in a language other than English.** Log as-is. Robin handles multilingual content. Do not translate.
+
+**User wants to update something already in Robin.** There are no update or delete tools in the current API. Offer to help: "I can log a new entry clarifying this." Robin will process the new entry and reconcile it with existing knowledge.


### PR DESCRIPTION
## Summary

Stream C for v0.2.0. Lands the entries.source_client column for MCP clientInfo capture, the Capture skill pack at the new top-level `skills/` directory, the `list_skills` MCP tool, and the wiki_type definition for skill rows.

C1 was assumed delivered by Wave A's MCP `initialize` plumbing. C6 dropped per Andrew (entries.title kept).

Plan: `.planning/v1-a-game/streams/C-onboarding-capture/PLAN.md`. Closes #233. Tracker: #282.

## What ships

**C2, source_client capture**
- Migration 0007 adds `entries.source_client jsonb` (nullable, no backfill — legacy rows return NULL).
- `handleLogEntry` (MCP) reads `clientInfo` via `server.server.getClientVersion()` and persists into the new column as the jsonb payload.
- `handleLogFragment` plumbs `sourceClient` through and records it in `audit_log.detail` jsonb (no schema change beyond C2's scope; `fragments` table not extended in this PR).
- `POST /entries` (web route) writes `{name: 'web'}` server-side. The existing `AddEntryModal.tsx` already sends `source: "web"` in the request body; the column write happens in the route.
- `POST /fragments/log` similarly tags web-originated fragments.

**C3, Capture pack at `skills/`**
- New top-level `skills/` directory at the repo root (NOT under `.claude/` per Andrew).
- Three skill files, each with proper Claude-skill frontmatter:
  - `skills/log-to-robin-guide.md`
  - `skills/log-to-robin-short.md`
  - `skills/log-to-robin-long.md`
- Closes #233.

**C4, `list_skills` MCP tool**
- New MCP tool returns `{ skills: [...] }` filtered to `wikis` rows where `type='skill'`.
- Joins `wiki_types.basedOnVersion` for the version field.
- Read-only, no body required.

**C5, skill wiki_type registration**
- Zero code changes needed. `skill` wiki_type already exists in `packages/shared/src/prompts/specs/wiki-types/skill.yaml` and is seeded by `seedWikiTypes()` at boot.
- `create_wiki(type='skill')` already validates against the wiki_types registry.

**C7, server stays naive on long entries**
- No server changes by design. Entries are designed compact at the storage layer.
- Chunking responsibility documented in `skills/log-to-robin-long.md` (the long-form skill carries the chunking contract for clients).

## Deviations + sub-decisions

1. **`AddEntryModal.tsx` not modified**. The modal already sends `source: "web"` in the request body. The brief said "update web UI to write `{name: 'web'}` or NULL"; I implemented this server-side in the route (same effect, fewer touchpoints). If a future configurability requirement wants per-modal client info, can re-route through an explicit `sourceClient` field in the request body.
2. **`fragments` table NOT extended**. The migration scope is `entries.source_client` only. Per-fragment provenance flows via `audit_log.detail` jsonb until a future migration adds a column. Out of scope for v0.2.0.
3. **Em-dash sweep**. Two cleanup commits scrub em-dashes from agent-authored content (per the no-MDASH rule). Lifted skill bodies retain their original em-dashes per the C3 "verbatim" instruction.
4. **`clientInfo` on test paths is best-effort**. A curl-driven JSON-RPC test client doesn't complete a full MCP `initialize` handshake, so `server.getClientVersion()` may return null at tool-call time. UAT step 4c accepts either populated jsonb or null on the MCP path.

## Test plan

UAT 61 ships with the PR (`.uat/plans/61-stream-c-skills-and-source-client.md`). 359 lines, executable bash with PASS/FAIL counters and idempotent cleanup.

Coverage:
- C2: capture an entry via web and via MCP, assert `entries.source_client` is populated for both
- C3: assert three skill markdown files exist with valid frontmatter
- C4: call `list_skills` MCP tool, assert returns skills under the skill wiki_type
- C5: create a skill via `create_wiki(type='skill')`, confirm row in DB
- C7: send a long entry (>2000 words), confirm server accepts as one row (no server-side chunking)

- [ ] CI pre-merge.yml green
- [ ] UAT 61 PASS on local stack
- [ ] Smoke: capture from web UI, confirm `entries.source_client = {name: 'web'}`
- [ ] Smoke: capture via Claude Desktop or another MCP client, confirm `entries.source_client = {name: 'Claude Desktop', version: 'x.y.z'}`
- [ ] Smoke: skills/ files load correctly when Claude Code reads them

## Open questions

1. **C1 assumption**: I assumed Wave A delivered the MCP `initialize` capture hook so `server.getClientVersion()` returns populated values. If Wave A left `clientInfo` unwired, MCP captures will silently get null until that lands. Confirm with Wave A reviewer.
2. **Modal-vs-route source-of-truth**: per deviation 1, the modal currently doesn't send `sourceClient` explicitly. Open to adding an optional `sourceClient` request body field if the orchestrator wants per-modal configurability later.