### PR TITLE
fix: validate OpenRouter API key during onboarding and at boot

### DIFF
--- a/core/src/bootstrap/__tests__/check-openrouter-key.test.ts
+++ b/core/src/bootstrap/__tests__/check-openrouter-key.test.ts
@@ -52,6 +52,11 @@ vi.mock('@robin/agent', () => ({
   probeEmbeddingReachable: vi.fn(),
 }))
 
+const validateMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+vi.mock('../../lib/validate-openrouter-key.js', () => ({
+  validateOpenRouterKey: (...args: unknown[]) => validateMock(...args),
+}))
+
 const logInfoMock = vi.fn()
 const logWarnMock = vi.fn()
 const logErrorMock = vi.fn()

--- a/core/src/bootstrap/check-openrouter-key.ts
+++ b/core/src/bootstrap/check-openrouter-key.ts
@@ -5,6 +5,7 @@ import { configs, users } from '../db/schema.js'
 import { setConfig } from '../lib/config.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { logger } from '../lib/logger.js'
+import { validateOpenRouterKey } from '../lib/validate-openrouter-key.js'
 
 const log = logger.child({ component: 'bootstrap' })
 
@@ -20,6 +21,25 @@ export async function checkOpenRouterKey(): Promise<void> {
     .from(configs)
     .where(and(eq(configs.kind, 'llm_key'), eq(configs.key, 'openrouter')))
     .limit(1)
+
+  // If the env var is set, ping OpenRouter once at boot so a typo'd or
+  // revoked key surfaces in the logs instead of silently breaking the
+  // first ingest job. Non-fatal: non-LLM traffic still works.
+  const envKey = process.env.OPENROUTER_API_KEY
+  if (envKey) {
+    const result = await validateOpenRouterKey(envKey).catch((err) => ({
+      ok: false as const,
+      error: err instanceof Error ? err.message : String(err),
+    }))
+    if (result.ok) {
+      log.info('OPENROUTER_API_KEY validated against OpenRouter')
+    } else {
+      log.warn(
+        { status: 'status' in result ? result.status : undefined, error: result.error },
+        'OPENROUTER_API_KEY failed live validation, ingest will fail until fixed',
+      )
+    }
+  }
 
   if (rows.length === 0) {
     const apiKey = process.env.OPENROUTER_API_KEY

--- a/core/src/lib/validate-openrouter-key.test.ts
+++ b/core/src/lib/validate-openrouter-key.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { validateOpenRouterKey } from './validate-openrouter-key.js'
+
+describe('validateOpenRouterKey', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('returns ok:false for empty key without calling fetch', async () => {
+    const result = await validateOpenRouterKey('')
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/empty or too short/)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:false for too-short key without calling fetch', async () => {
+    const result = await validateOpenRouterKey('abc')
+    expect(result.ok).toBe(false)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:true on 200', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('{}', { status: 200 }),
+    )
+    const result = await validateOpenRouterKey('sk-or-v1-validkey')
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe(200)
+  })
+
+  it('returns ok:false with Invalid API key on 401', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('{"error":"unauthorized"}', { status: 401 }),
+    )
+    const result = await validateOpenRouterKey('sk-or-v1-invalid')
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(401)
+    expect(result.error).toBe('Invalid API key')
+  })
+
+  it('returns ok:false with generic error on 500', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response('boom', { status: 500 }),
+    )
+    const result = await validateOpenRouterKey('sk-or-v1-validkey')
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(500)
+    expect(result.error).toMatch(/OpenRouter returned 500/)
+  })
+
+  it('returns ok:false on network error', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('ECONNRESET'),
+    )
+    const result = await validateOpenRouterKey('sk-or-v1-validkey')
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/Network or timeout: ECONNRESET/)
+  })
+})

--- a/core/src/lib/validate-openrouter-key.ts
+++ b/core/src/lib/validate-openrouter-key.ts
@@ -1,0 +1,36 @@
+/**
+ * Validate an OpenRouter API key by calling GET /api/v1/models.
+ * 200 means the key is accepted; 401 means invalid.
+ *
+ * Uses a 5s timeout so a network blip doesn't block onboarding forever.
+ */
+export interface OpenRouterValidationResult {
+  ok: boolean
+  status?: number
+  error?: string
+}
+
+export async function validateOpenRouterKey(
+  key: string,
+  signal?: AbortSignal,
+): Promise<OpenRouterValidationResult> {
+  if (!key || key.length < 10) {
+    return { ok: false, error: 'Key is empty or too short' }
+  }
+  try {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), 5_000)
+    const res = await fetch('https://openrouter.ai/api/v1/models', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${key}` },
+      signal: signal ?? ctrl.signal,
+    })
+    clearTimeout(timer)
+    if (res.ok) return { ok: true, status: res.status }
+    if (res.status === 401) return { ok: false, status: 401, error: 'Invalid API key' }
+    return { ok: false, status: res.status, error: `OpenRouter returned ${res.status}` }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: `Network or timeout: ${msg}` }
+  }
+}

--- a/core/src/routes/users.openrouter-validate.test.ts
+++ b/core/src/routes/users.openrouter-validate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+// ── Mocks (must come before dynamic import) ────────────────────────────────
+
+const mockValidate = vi.fn()
+
+vi.mock('../db/client.js', () => ({ db: {} }))
+vi.mock('../db/audit.js', () => ({ emitAuditEvent: vi.fn() }))
+vi.mock('../lib/config.js', () => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+}))
+vi.mock('../lib/validate-openrouter-key.js', () => ({
+  validateOpenRouterKey: (...args: unknown[]) => mockValidate(...args),
+}))
+vi.mock('../middleware/session.js', () => ({
+  sessionMiddleware: vi.fn().mockImplementation(async (c: any, next: any) => {
+    c.set('userId', 'test-user')
+    await next()
+  }),
+}))
+vi.mock('../keypair.js', () => ({ decryptPrivateKey: vi.fn() }))
+vi.mock('../mcp/jwt.js', () => ({
+  signMcpToken: vi.fn().mockResolvedValue('mock-token'),
+  clearKidCache: vi.fn(),
+}))
+
+const { users } = await import('./users.js')
+
+function post(path: string, body?: unknown) {
+  return users.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+describe('POST /users/openrouter-key/validate', () => {
+  const originalEnv = process.env.OPENROUTER_API_KEY
+
+  beforeEach(() => {
+    mockValidate.mockReset()
+    delete process.env.OPENROUTER_API_KEY
+  })
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.OPENROUTER_API_KEY
+    else process.env.OPENROUTER_API_KEY = originalEnv
+  })
+
+  it('returns ok:true when validator succeeds (explicit body key)', async () => {
+    mockValidate.mockResolvedValue({ ok: true, status: 200 })
+    const res = await post('/openrouter-key/validate', { key: 'sk-or-v1-good' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockValidate).toHaveBeenCalledWith('sk-or-v1-good')
+  })
+
+  it('returns Invalid API key on 401', async () => {
+    mockValidate.mockResolvedValue({ ok: false, status: 401, error: 'Invalid API key' })
+    const res = await post('/openrouter-key/validate', { key: 'sk-or-v1-bad' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: false, error: 'Invalid API key' })
+  })
+
+  it('returns generic error for non-401 failures (no leak)', async () => {
+    mockValidate.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: 'OpenRouter returned 500: rate limit token=abc',
+    })
+    const res = await post('/openrouter-key/validate', { key: 'sk-or-v1-good' })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(body.error).toBe('Could not reach OpenRouter')
+    expect(JSON.stringify(body)).not.toContain('token=abc')
+  })
+
+  it('falls back to env var when body has no key', async () => {
+    process.env.OPENROUTER_API_KEY = 'sk-or-v1-fromenv'
+    mockValidate.mockResolvedValue({ ok: true, status: 200 })
+    const res = await post('/openrouter-key/validate', {})
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(mockValidate).toHaveBeenCalledWith('sk-or-v1-fromenv')
+  })
+
+  it('returns ok:false with no-key error when nothing is configured', async () => {
+    const res = await post('/openrouter-key/validate', {})
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      ok: false,
+      error: 'No OpenRouter key configured',
+    })
+    expect(mockValidate).not.toHaveBeenCalled()
+  })
+})

--- a/core/src/routes/users.ts
+++ b/core/src/routes/users.ts
@@ -22,6 +22,7 @@ import { signMcpToken, clearKidCache } from '../mcp/jwt.js'
 import { validationHook } from '../lib/validation.js'
 import { getConfig, setConfig } from '../lib/config.js'
 import { logger } from '../lib/logger.js'
+import { validateOpenRouterKey } from '../lib/validate-openrouter-key.js'
 import { emitAuditEvent } from '../db/audit.js'
 import { buildExportZip } from '../lib/export-zip.js'
 import { stream } from 'hono/streaming'
@@ -111,6 +112,36 @@ usersRouter.get('/profile', async (c) => {
       onboardedAt: user.onboardedAt?.toISOString() ?? null,
     })
   )
+})
+
+// POST /users/openrouter-key/validate — verify a key against the real
+// OpenRouter API. Body may be { key: string } to validate an explicit key,
+// or omitted to validate the currently-configured OPENROUTER_API_KEY env var.
+//
+// Response shape is intentionally generic. We never echo OpenRouter's raw
+// error body to the client because it can include rate-limit or token
+// metadata that we don't want to leak.
+usersRouter.post('/openrouter-key/validate', async (c) => {
+  let candidate: string | undefined
+  try {
+    const body = (await c.req.json().catch(() => null)) as
+      | { key?: unknown }
+      | null
+    if (body && typeof body.key === 'string') candidate = body.key
+  } catch {
+    // ignore, fall back to env var
+  }
+  const key = candidate ?? process.env.OPENROUTER_API_KEY ?? ''
+  if (!key) {
+    return c.json({ ok: false, error: 'No OpenRouter key configured' }, 200)
+  }
+  const result = await validateOpenRouterKey(key)
+  if (result.ok) return c.json({ ok: true })
+  if (result.status === 401) return c.json({ ok: false, error: 'Invalid API key' })
+  if (result.error?.startsWith('Key is empty')) {
+    return c.json({ ok: false, error: 'Key is empty or too short' })
+  }
+  return c.json({ ok: false, error: 'Could not reach OpenRouter' })
 })
 
 // PATCH /users/onboard — mark onboarding complete (skip button)

--- a/wiki/src/components/onboarding/CompleteStep.tsx
+++ b/wiki/src/components/onboarding/CompleteStep.tsx
@@ -34,6 +34,7 @@ export default function CompleteStep() {
   const { data: profile, isLoading: profileLoading } = useProfile();
   const [copied, setCopied] = useState(false);
   const [completing, setCompleting] = useState(false);
+  const [validateError, setValidateError] = useState<string | null>(null);
   const mcpEndpoint = profile?.mcpEndpointUrl ?? "";
 
   // Poll for MCP endpoint until it becomes available (keypair may still be generating)
@@ -194,26 +195,65 @@ export default function CompleteStep() {
         </CardContent>
       </Card>
 
+      {validateError && (
+        <p
+          className="text-center"
+          style={{
+            ...T.micro,
+            marginTop: 16,
+            color: "var(--destructive)",
+            maxWidth: 320,
+          }}
+        >
+          {validateError}
+        </p>
+      )}
+
       {/* GO TO WIKI BUTTON */}
       <ActionButton
         type="button"
         onClick={async () => {
           setCompleting(true);
+          setValidateError(null);
           try {
+            // Gate completion on a real OpenRouter API check so a typo'd
+            // or revoked key surfaces here rather than silently breaking
+            // the user's first ingest.
+            const res = await fetch("/api/users/openrouter-key/validate", {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({}),
+            });
+            const result = (await res.json().catch(() => null)) as
+              | { ok?: boolean; error?: string }
+              | null;
+            if (!result?.ok) {
+              setValidateError(
+                result?.error ??
+                  "Could not validate your OpenRouter API key. Check OPENROUTER_API_KEY and try again.",
+              );
+              setCompleting(false);
+              return;
+            }
             await fetch("/api/users/onboard", {
               method: "PATCH",
               credentials: "include",
             });
             await queryClient.invalidateQueries({ queryKey: ["profile"] });
           } catch {
-            // proceed even if onboard call fails -- user can retry
+            setValidateError(
+              "Could not reach the server to validate your key. Try again.",
+            );
+            setCompleting(false);
+            return;
           }
           router.push("/wiki");
         }}
         disabled={completing}
         className="mt-10"
       >
-        {completing ? "Finishing..." : "Go to your wiki"}
+        {completing ? "Validating..." : "Go to your wiki"}
       </ActionButton>
     </div>
   );


### PR DESCRIPTION
Closes #339.

## Summary
- New `validateOpenRouterKey` helper in `core/src/lib/` that calls `GET https://openrouter.ai/api/v1/models` with a 5s abort timeout and maps 200/401/other into a small typed result.
- New `POST /users/openrouter-key/validate` route, mounted under the existing session middleware. Body is `{ key?: string }`; falls back to the `OPENROUTER_API_KEY` env var when omitted. Response is intentionally generic (`{ ok, error? }`), never echoing OpenRouter's raw error body.
- Boot check (`checkOpenRouterKey`) now performs a live validation when the env var is set. Failures log a warn and do not block startup, so non-LLM traffic still works.
- Onboarding `CompleteStep` calls the validate endpoint before flipping `onboardedAt`. On failure the user sees the inline error and the button stays enabled for a retry; on success the existing `PATCH /users/onboard` runs and the user lands on `/wiki`.

## Test plan
- [x] `pnpm --filter @robin/core run typecheck` clean
- [x] `npx vitest run validate-openrouter` passes (6 tests)
- [x] `npx vitest run users.openrouter-validate` passes (5 tests)
- [x] `npx vitest run check-openrouter-key` still passes (5 tests)
- [x] `cd wiki && npx tsc --noEmit` clean
- [x] `pnpm --filter @robin/wiki build` succeeds
- [ ] Manual: real OpenRouter key returns ok during onboarding
- [ ] Manual: typo'd or revoked key surfaces "Invalid API key" inline