### PR TITLE
chore(cleanup): close v0.2.0 loose ends

### DIFF
--- a/.uat/plans/65-v0.2.1-cleanup-batch.md
+++ b/.uat/plans/65-v0.2.1-cleanup-batch.md
@@ -1,0 +1,247 @@
+# 65 - v0.2.1 Cleanup Batch
+
+## What it proves
+
+Cluster branch `chore/v0.2.1-cleanup-batch` ships three small follow-ups
+queued behind the v0.2.0 release:
+
+1. **source_client column write** - `handleLogEntry` (MCP) no longer
+   stamps `source_client` into `audit_log.detail`. The dedicated
+   `entries.source_client` jsonb column is the only source of truth for
+   raw_source ingest. Other entity types (fragment, wiki, wiki_type,
+   group) keep the `detail.source_client` stamp because they have no
+   dedicated column.
+2. **wiki SDK regen** - `core/openapi.json` now publishes
+   `publishedOrigin` on every wiki shape. The wiki frontend's typed SDK
+   (`pnpm -C wiki manifest`) carries the field, and
+   `wiki/src/app/(shell)/wiki/[id]/page.tsx` reads
+   `wiki.publishedOrigin` directly instead of casting through `unknown`.
+3. **AddWiki canonical-trigger comments** - comments in
+   `AddWikiContext.tsx`, `Header.tsx`, and `Sidebar.tsx` now describe
+   the Header dropdown as the canonical Add Wiki trigger. Behaviour
+   unchanged.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- Wiki dev server on `WIKI_URL` (default `http://localhost:8080`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+- `DATABASE_URL` reachable for direct row inspection (postgres
+  `robinwiki`), redis up
+- A wiki + at least one fragment seeded (`pnpm -C core seed-fixture`)
+- A valid MCP JWT (`MCP_TOKEN`) for the test user. Generate via the
+  /settings page or `core/scripts/mint-mcp-token.ts` if available.
+- `pnpm` and `psql` on PATH
+
+## Endpoint map
+
+- `POST /mcp/?token=$MCP_TOKEN`         - MCP JSON-RPC `tools/call log_entry`
+- `GET  /openapi.json`                   - served from `core/openapi.json`
+- `GET  /wiki/<id>` (frontend)           - exercises the publishedOrigin path
+- `psql $DATABASE_URL`                   - direct row inspection
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+WIKI_URL="${WIKI_URL:-http://localhost:8080}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-$WIKI_URL}"
+DB_URL="${DATABASE_URL:-postgresql://postgres@127.0.0.1:5432/robinwiki}"
+JAR=$(mktemp /tmp/uat-65-jar-XXXXXX.txt)
+trap 'rm -f "$JAR" /tmp/uat-65-*.json /tmp/uat-65-*.code /tmp/uat-65-*.out' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  + $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ! $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  - $1"; }
+
+echo "65 - v0.2.1 cleanup batch"
+echo ""
+
+# 1. Sign in (HTTP cookie session for HTTP assertions).
+curl -s -o /tmp/uat-65-signin.json -w "%{http_code}" \
+  -c "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" > /tmp/uat-65-signin.code
+if [ "$(cat /tmp/uat-65-signin.code)" = "200" ]; then pass "sign in"; else fail "sign in code $(cat /tmp/uat-65-signin.code)"; fi
+
+# 2. Mint an MCP token (requires the user signed in via #1 above).
+curl -s -o /tmp/uat-65-token.json -w "%{http_code}" -b "$JAR" \
+  -X POST -H "Origin: $ORIGIN" \
+  "$SERVER_URL/api/users/mcp-token" > /tmp/uat-65-token.code || true
+MCP_TOKEN_VALUE=$(jq -r '.token // empty' /tmp/uat-65-token.json 2>/dev/null)
+MCP_TOKEN="${MCP_TOKEN:-$MCP_TOKEN_VALUE}"
+if [ -n "$MCP_TOKEN" ]; then pass "have MCP token"; else fail "no MCP token (set MCP_TOKEN env or fix mint endpoint)"; fi
+
+# ── Task 1: source_client written to entries column, NOT to audit detail ──
+#
+# Capture the current row count for entries first so we can isolate the
+# row our log_entry call inserts.
+PRE_COUNT=$(psql -q "$DB_URL" -At -c "SELECT count(*) FROM raw_sources;" 2>/dev/null || echo "")
+
+# 3. log_entry via MCP -- the clientInfo handshake stamps the
+#    raw_sources.source_client column on insert.
+LOG_REQ=$(jq -nc '{
+  jsonrpc:"2.0", id:1, method:"tools/call",
+  params:{name:"log_entry", arguments:{content:"uat65 source_client probe", source:"mcp"}}
+}')
+LOG_RES=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d "$LOG_REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN")
+echo "$LOG_RES" > /tmp/uat-65-log.json
+if echo "$LOG_RES" | jq -e '.result.content[0].text | contains("Entry queued")' >/dev/null 2>&1; then
+  pass "log_entry returned Entry queued"
+else
+  fail "log_entry did not return Entry queued"
+fi
+
+ENTRY_KEY=$(echo "$LOG_RES" | jq -r '.result.content[0].text' | sed -nE 's/^Entry queued: (.+)$/\1/p')
+
+# Give the insert a beat to settle.
+sleep 1
+
+# 4. The newly-inserted entries row carries source_client on the column.
+if [ -n "$ENTRY_KEY" ]; then
+  COL_VAL=$(psql -q "$DB_URL" -At -c "SELECT source_client FROM raw_sources WHERE lookup_key='$ENTRY_KEY';" 2>/dev/null || echo "")
+  if [ -n "$COL_VAL" ] && [ "$COL_VAL" != "null" ]; then
+    pass "raw_sources.source_client populated for $ENTRY_KEY"
+  else
+    fail "raw_sources.source_client missing for $ENTRY_KEY (got '$COL_VAL')"
+  fi
+
+  # 5. The audit_log row for this entry has detail WITHOUT source_client.
+  AUDIT_DETAIL=$(psql -q "$DB_URL" -At -c "SELECT detail::text FROM audit_log WHERE entity_type='raw_source' AND entity_id='$ENTRY_KEY' AND event_type='ingested' LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$AUDIT_DETAIL" ]; then
+    fail "no audit_log row for entry $ENTRY_KEY"
+  elif echo "$AUDIT_DETAIL" | grep -q '"source_client"'; then
+    fail "audit_log.detail still carries source_client (expected dropped): $AUDIT_DETAIL"
+  else
+    pass "audit_log.detail has no source_client key (column-only)"
+  fi
+else
+  skip "no entry key parsed; downstream column / audit checks skipped"
+fi
+
+# 6. Audit emitter is unchanged for non-entry surfaces -- a fragment
+#    audit row still carries source_client in detail. Read the latest
+#    fragment-create audit row (if any) and look for the key.
+FRAG_DETAIL=$(psql -q "$DB_URL" -At -c "SELECT detail::text FROM audit_log WHERE entity_type='fragment' AND event_type='created' ORDER BY created_at DESC LIMIT 1;" 2>/dev/null || echo "")
+if [ -z "$FRAG_DETAIL" ]; then
+  skip "no fragment 'created' audit row to inspect"
+elif echo "$FRAG_DETAIL" | grep -q '"sourceClient"\|"source_client"'; then
+  pass "fragment audit detail still stamps clientInfo (unchanged)"
+else
+  skip "fragment audit detail has no clientInfo key (caller may have omitted)"
+fi
+
+# ── Task 2: wiki SDK + openapi.json carry publishedOrigin ──
+#
+# 7. core/openapi.json publishes publishedOrigin on every wiki shape.
+for schema in threadResponseSchema threadWithWikiResponseSchema wikiDetailResponseSchema publishWikiResponseSchema; do
+  if jq -e ".components.schemas[\"$schema\"].properties.publishedOrigin" core/openapi.json >/dev/null 2>&1; then
+    pass "openapi.json $schema.properties.publishedOrigin present"
+  else
+    fail "openapi.json $schema missing publishedOrigin"
+  fi
+done
+
+# 8. The generated wiki SDK has the publishedOrigin field as well.
+if grep -q "publishedOrigin" wiki/src/lib/generated/types.gen.ts; then
+  pass "wiki SDK types.gen.ts carries publishedOrigin"
+else
+  fail "wiki SDK types.gen.ts missing publishedOrigin (regen not applied?)"
+fi
+
+# 9. The wiki page no longer casts through unknown for publishedOrigin.
+if grep -nE "as unknown as \{ publishedOrigin" "wiki/src/app/(shell)/wiki/[id]/page.tsx"; then
+  fail "publishedOrigin cast still present in wiki page"
+else
+  pass "publishedOrigin cast removed from wiki page"
+fi
+
+# 10. wiki typecheck still passes (no DB / runtime needed).
+( cd wiki && npx tsc --noEmit ) >/tmp/uat-65-tsc.out 2>&1
+if [ "$?" = "0" ]; then pass "pnpm -C wiki typecheck clean"; else fail "wiki typecheck failed; see /tmp/uat-65-tsc.out"; fi
+
+# 11. core typecheck still passes.
+pnpm -C core typecheck >/tmp/uat-65-core-tsc.out 2>&1
+if [ "$?" = "0" ]; then pass "pnpm -C core typecheck clean"; else fail "core typecheck failed; see /tmp/uat-65-core-tsc.out"; fi
+
+# ── Task 3: AddWiki header dropdown still opens the modal ──
+#
+# 12. The Header trigger code path lives in Header.tsx; comments now
+#     mark it canonical. Verify by grep.
+if grep -q "canonical trigger" wiki/src/components/layout/Header.tsx; then
+  pass "Header.tsx comment marks dropdown as canonical"
+else
+  fail "Header.tsx comment did not pick up the canonical-trigger update"
+fi
+
+# 13. Sidebar comment no longer claims to be canonical.
+if grep -q "Header dropdown" wiki/src/components/layout/Sidebar.tsx; then
+  pass "Sidebar.tsx comment defers to Header dropdown as canonical"
+else
+  fail "Sidebar.tsx comment did not pick up the deference update"
+fi
+
+# 14. None of the stale phrases survive anywhere in wiki/.
+STALE=$(grep -rln "ship-cycle\|A-game canonical\|preserved for one" wiki/ 2>/dev/null | grep -v node_modules || true)
+if [ -z "$STALE" ]; then
+  pass "no stale ship-cycle / canonical / preserved phrases in wiki/"
+else
+  fail "stale phrases survive in: $STALE"
+fi
+
+# 15. Smoke: hit the wiki dev server's main page so we know the dropdown
+#     route is actually rendering. Not a click test, but proves the page
+#     compiles + serves under Next dev.
+WIKI_HEAD=$(curl -s -o /dev/null -w "%{http_code}" "$WIKI_URL/wiki" || echo "")
+if [ "$WIKI_HEAD" = "200" ] || [ "$WIKI_HEAD" = "302" ] || [ "$WIKI_HEAD" = "307" ]; then
+  pass "wiki dev server responds at /wiki ($WIKI_HEAD)"
+else
+  skip "wiki dev server not running on $WIKI_URL (got '$WIKI_HEAD')"
+fi
+
+# ── Cleanup ──
+#
+# Soft-delete the probe entry so re-runs don't pile up. Idempotent.
+if [ -n "$ENTRY_KEY" ]; then
+  psql -q "$DB_URL" -c "UPDATE raw_sources SET deleted_at=now() WHERE lookup_key='$ENTRY_KEY' AND deleted_at IS NULL;" >/dev/null 2>&1 || true
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The script soft-deletes the `uat65 source_client probe` entry it
+inserts. Manual cleanup if desired:
+
+```bash
+psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE content='uat65 source_client probe';"
+psql "$DATABASE_URL" -c "DELETE FROM audit_log WHERE summary LIKE 'Entry ingested: uat65 source_client probe%';"
+```
+
+## Expected pass/fail behavior
+
+All steps PASS on a clean local stack (postgres `robinwiki`, redis,
+core on :3000, wiki on :8080) with the v0.2.1 cleanup batch applied.
+
+- Step 4: PASS when the MCP handshake delivers `clientInfo` (real MCP
+  client). FAIL when null suggests the column-write path did not pick
+  up the handshake.
+- Step 5: PASS when `audit_log.detail` for the new ingest carries no
+  `source_client` key. This is the regression guard for Task 1.
+- Step 6: SKIP if no fragments have been logged through MCP recently.
+  Stamping behaviour for non-entry types is unchanged on purpose.
+- Steps 7 to 9: PASS for the SDK regen. Step 9 is the regression
+  guard for the dropped `as unknown as` cast.
+- Steps 12 to 14: comment-only assertions for Task 3. The wiki
+  smoke at step 15 SKIPs cleanly when the frontend dev server is
+  offline.

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -3435,6 +3435,11 @@
             "nullable": true,
             "default": null
           },
+          "publishedOrigin": {
+            "type": "string",
+            "nullable": true,
+            "default": null
+          },
           "collections": {
             "type": "array",
             "items": {
@@ -3574,6 +3579,11 @@
             "default": false
           },
           "publishedSlug": {
+            "type": "string",
+            "nullable": true,
+            "default": null
+          },
+          "publishedOrigin": {
             "type": "string",
             "nullable": true,
             "default": null
@@ -3730,6 +3740,11 @@
                   "nullable": true,
                   "default": null
                 },
+                "publishedOrigin": {
+                  "type": "string",
+                  "nullable": true,
+                  "default": null
+                },
                 "collections": {
                   "type": "array",
                   "items": {
@@ -3880,6 +3895,11 @@
             "nullable": true,
             "default": null
           },
+          "publishedOrigin": {
+            "type": "string",
+            "nullable": true,
+            "default": null
+          },
           "collections": {
             "type": "array",
             "items": {
@@ -4025,6 +4045,11 @@
             "type": "string",
             "nullable": true
           },
+          "publishedOrigin": {
+            "type": "string",
+            "nullable": true,
+            "default": null
+          },
           "publishedAt": {
             "type": "string",
             "format": "date-time",
@@ -4038,7 +4063,8 @@
           "published",
           "publishedSlug",
           "publishedAt",
-          "regenerate"
+          "regenerate",
+          "publishedOrigin"
         ],
         "additionalProperties": false
       },

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -64,10 +64,14 @@ const log = logger.child({ component: 'mcp' })
 
 /**
  * Read the MCP `clientInfo` snapshot off the deps and shape it for
- * `auditLog.detail.source_client`. Returns `undefined` if the deps don't
- * carry the accessor (legacy callers, tests) or if the handshake has not
- * yet populated client info. The caller spreads the result into the audit
- * detail object -- keeping the field absent (vs `null`) means non-MCP
+ * `auditLog.detail.source_client` on entity types that have no dedicated
+ * column (fragment, wiki, wiki_type, group). For raw_source entries the
+ * value lands on `entries.source_client` directly via the row insert, so
+ * the audit detail does not carry it.
+ *
+ * Returns `undefined` if the deps don't carry the accessor (legacy
+ * callers, tests) or if the handshake has not yet populated client info.
+ * The caller spreads the result into the audit detail object so non-MCP
  * writes don't pick up a junk-drawer key.
  */
 function readSourceClient(deps: McpServerDeps): McpClientInfo | undefined {
@@ -117,8 +121,10 @@ export interface McpServerDeps {
   /**
    * Lazy accessor for the MCP `clientInfo` handshake. Returns `undefined`
    * before the transport handshake completes (or for non-MCP callers in
-   * tests). Persisted into audit-event `detail.source_client` and -- once
-   * Stream C2 lands the schema migration -- onto `entries.source_client`.
+   * tests). Persisted onto `entries.source_client` for raw_source rows
+   * (column write), and onto `audit_log.detail.source_client` for entity
+   * types that have no dedicated column (fragment, wiki, wiki_type,
+   * group).
    */
   getClientInfo?: () => McpClientInfo | undefined
 }
@@ -202,7 +208,11 @@ export async function handleLogEntry(
     }
     await deps.producer.enqueueExtraction(job)
 
-    const sourceClient = readSourceClient(deps)
+    // v0.2.1: client-info now lives on `entries.source_client` (jsonb),
+    // written by the insert above. The audit-log row no longer duplicates
+    // it in `detail` -- one source of truth for "which client logged this
+    // entry". Other entity types (fragment, wiki, wiki_type, group) keep
+    // the detail stamp because no dedicated column exists for them.
     await emitAuditEvent(deps.db, {
       entityType: 'raw_source',
       entityId: entryKey,
@@ -212,7 +222,6 @@ export async function handleLogEntry(
       detail: {
         entryKey,
         source: entrySource,
-        ...(sourceClient ? { source_client: sourceClient } : {}),
       },
     })
 

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -303,9 +303,7 @@ export default function WikiDetailPage() {
       bouncerMode={wiki.bouncerMode as 'auto' | 'review' | undefined}
       published={wiki.published === true}
       publishedSlug={wiki.publishedSlug ?? null}
-      // Generated types lag the publish-origin column (#stream-I Phase 4);
-      // cast through unknown until openapi:generate gets re-run.
-      publishedOrigin={(wiki as unknown as { publishedOrigin?: string | null }).publishedOrigin ?? null}
+      publishedOrigin={wiki.publishedOrigin ?? null}
       collections={wiki.collections ?? []}
       infobox={{ kind: "simple", typeLabel, lastUpdated: wiki.updatedAt, showSettings: true }}
       renderCustomInfobox={

--- a/wiki/src/components/layout/AddWikiContext.tsx
+++ b/wiki/src/components/layout/AddWikiContext.tsx
@@ -10,13 +10,12 @@ import {
 } from "react";
 
 /**
- * Shared state for the "Add Wiki" creation modal. Both the Header dropdown
- * (legacy trigger, kept for one ship-cycle for muscle memory) and the
- * Sidebar "+ Add Wiki" trigger (A-game canonical location, line 421)
- * dispatch to the same modal via {@link useAddWiki}.
+ * Shared state for the "Add Wiki" creation modal. The Header dropdown is
+ * the canonical trigger; any other surfaces (e.g. the Sidebar) dispatch
+ * into the same modal via {@link useAddWiki}.
  *
- * The modal itself is mounted once by `(shell)/layout.tsx`, so the Header
- * and Sidebar never mount their own `<AddWikiModal>` instances.
+ * The modal itself is mounted once by `(shell)/layout.tsx`, so triggers
+ * never mount their own `<AddWikiModal>` instances.
  */
 interface AddWikiContextValue {
   open: boolean;

--- a/wiki/src/components/layout/Header.tsx
+++ b/wiki/src/components/layout/Header.tsx
@@ -18,10 +18,9 @@ interface HeaderProps {
 
 export default function Header({ onMenuToggle }: HeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  // H1: the Header dropdown's "Wiki" entry is the LEGACY trigger for Add
-  // Wiki. The canonical A-game location is the Sidebar (#H1). This trigger
-  // stays for one ship-cycle so muscle memory doesn't break, then gets
-  // removed in a follow-up issue once telemetry shows sidebar adoption.
+  // The Header dropdown's "Wiki" entry is the canonical trigger for the
+  // Add Wiki modal. Any other surface (e.g. the sidebar) opens the same
+  // modal via the shared `AddWikiContext`.
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const { openModal: openAddWikiModal } = useAddWiki();
   const [addEntryOpen, setAddEntryOpen] = useState(false);

--- a/wiki/src/components/layout/Sidebar.tsx
+++ b/wiki/src/components/layout/Sidebar.tsx
@@ -471,10 +471,9 @@ function SidebarSection({
   );
 }
 
-// H1: the canonical A-game (line 421) trigger for opening the Add Wiki
-// modal lives in the sidebar. The Header dropdown trigger is preserved
-// for one ship-cycle (see Header.tsx) so existing muscle memory doesn't
-// break. Both dispatch into the same AddWikiContext.
+// Sidebar shortcut for opening the Add Wiki modal. The canonical trigger
+// is the Header dropdown (see Header.tsx); this entry just dispatches into
+// the same shared AddWikiContext for users who reach for the sidebar.
 function AddWikiTrigger() {
   const { openModal } = useAddWiki();
   return (

--- a/wiki/src/lib/generated/types.gen.ts
+++ b/wiki/src/lib/generated/types.gen.ts
@@ -272,6 +272,7 @@ export type ThreadResponseSchema = {
     bouncerMode?: 'auto' | 'review';
     published?: boolean;
     publishedSlug?: string;
+    publishedOrigin?: string;
     collections?: Array<WikiCollectionSchema>;
 };
 
@@ -301,6 +302,7 @@ export type ThreadWithWikiResponseSchema = {
     bouncerMode?: 'auto' | 'review';
     published?: boolean;
     publishedSlug?: string;
+    publishedOrigin?: string;
     collections?: Array<WikiCollectionSchema>;
     wikiContent: string;
 };
@@ -332,6 +334,7 @@ export type ThreadListResponseSchema = {
         bouncerMode?: 'auto' | 'review';
         published?: boolean;
         publishedSlug?: string;
+        publishedOrigin?: string;
         collections?: Array<WikiCollectionSchema>;
     }>;
 };
@@ -362,6 +365,7 @@ export type WikiDetailResponseSchema = {
     bouncerMode?: 'auto' | 'review';
     published?: boolean;
     publishedSlug?: string;
+    publishedOrigin?: string;
     collections?: Array<WikiCollectionSchema>;
     wikiContent: string;
     fragments: Array<{
@@ -392,6 +396,7 @@ export type BouncerModeResponseSchema = {
 export type PublishWikiResponseSchema = {
     published: boolean;
     publishedSlug: string;
+    publishedOrigin: string;
     publishedAt: string;
     regenerate: boolean;
 };


### PR DESCRIPTION
## Summary
- `entries.source_client` column now receives writes for raw_source ingest events (was being stamped into `audit_log.detail` JSON despite the column existing)
- Wiki SDK regenerated against current OpenAPI manifest; the `as unknown as` cast on `publishedOrigin` is gone
- AddWiki canonical-trigger comments updated to reflect the header dropdown after the sidebar trigger was removed in a prior session

## What changed for the user
For operators querying ingest source attribution, `entries.source_client` is now a first-class queryable column for raw_source events. Audit detail stamps continue for fragment, wiki, wiki_type, and group rows because those tables don't have a dedicated column. The wiki frontend's `publishedOrigin` field is now correctly typed end-to-end. Layout-component comments no longer misdescribe the AddWiki trigger ownership.

## What was true before
The C2 work in v0.2.0 added the `source_client` column to `entries` but writers continued stamping the value into `audit_log.detail.source_client` JSON only. The wiki SDK lagged the `wikis.published_origin` migration so the wiki page used `as unknown as` to satisfy TypeScript. Multiple components claimed the sidebar AddWiki trigger was canonical even after the sidebar trigger was removed.

## Operational notes
- No migration. No breaking change.
- The `getClientInfo` helper is still in active use because fragment, wiki, wiki_type, and group audit rows have no dedicated column. Doc comments now explain the column-vs-detail split.

## Test plan
- [ ] UAT plan: `.uat/plans/65-v0.2.1-cleanup-batch.md`
- [ ] `pnpm -C core typecheck` clean (verified)
- [ ] `pnpm -C wiki typecheck` clean (verified)
- [ ] After a logged ingest event: `SELECT source_client FROM entries WHERE source_client IS NOT NULL LIMIT 5` returns rows