### PR TITLE
fix(regen): debounce active-ingest regen and add on-demand regen_now MCP tool

### DIFF
--- a/.uat/plans/70-regen-debounce-and-regen-now.md
+++ b/.uat/plans/70-regen-debounce-and-regen-now.md
@@ -1,0 +1,300 @@
+# 70 — Regen debounce and on-demand regen (QA Issue 6)
+
+## What it proves
+
+QA Issue 6 (2026-05-08): a 60-minute ingest of 89 entries (534 fragments)
+triggered 27 back-to-back regens because every fragment landing matched
+the regen-worker's "wiki has new edges since last_rebuilt_at" rule. Each
+regen was 70 to 180 seconds of LLM work, most superseded before its
+output mattered.
+
+This branch (`fix/regen-debounce-and-on-demand`) ships three coupled
+pieces:
+
+1. **Per-wiki debounce** (`core/src/queue/regen-debounce.ts`,
+   `core/src/queue/regen-worker.ts`). Reasons 1 and 2 in
+   `processRegenBatchJob` skip a wiki whose most-recent
+   FRAGMENT_IN_WIKI edge landed inside `REGEN_DEBOUNCE_MS` (default 5
+   min). Reasons 3 (stuck recovery) and 4 (midnight cron) bypass.
+2. **`regen_now` MCP tool** -- on-demand regen, bypasses debounce, same
+   auth as other write tools.
+3. **`regen_status` MCP tool** -- snapshot of in-flight, debounced, and
+   recent regens. The "regen happening now" indicator from Issue 6.
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`)
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`
+- `DATABASE_URL` reachable (`psql` for direct row inspection)
+- Worker process running (`pnpm -C core dev:worker` or equivalent),
+  otherwise enqueued regens never start
+- `MCP_TOKEN` for the test user (mint via `/api/users/mcp-token` once
+  signed in -- the script does this for you)
+- A wiki + at least one fragment seeded
+  (`pnpm -C core seed-fixture` if available)
+- `REGEN_DEBOUNCE_MS=60000` recommended in `core/.env` for the burst
+  test (1 min instead of 5 min so the script does not run for ages)
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email`              — cookie session
+- `POST /api/users/mcp-token`                  — mint MCP JWT
+- `POST /mcp/?token=$MCP_TOKEN` (JSON-RPC):
+  - `tools/list`             — assert `regen_now`, `regen_status` visible
+  - `tools/call regen_now`
+  - `tools/call regen_status`
+  - `tools/call log_fragment` (for the burst-ingest test)
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:8080}"
+DB_URL="${DATABASE_URL:-postgresql://robin:@localhost:5432/robin_dev}"
+DEBOUNCE_MS="${REGEN_DEBOUNCE_MS:-60000}"
+JAR=$(mktemp /tmp/uat-70-jar-XXXXXX.txt)
+trap 'rm -f "$JAR" /tmp/uat-70-*.json /tmp/uat-70-*.code' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  + $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ! $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  - $1"; }
+
+echo "70 — Regen debounce and on-demand regen (QA Issue 6)"
+echo "    REGEN_DEBOUNCE_MS=$DEBOUNCE_MS"
+echo ""
+
+# 1. Sign in (HTTP cookie session for HTTP assertions)
+curl -s -o /tmp/uat-70-signin.json -w "%{http_code}" \
+  -c "$JAR" -X POST -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "{\"email\":\"$INITIAL_USERNAME\",\"password\":\"$INITIAL_PASSWORD\"}" \
+  "$SERVER_URL/api/auth/sign-in/email" > /tmp/uat-70-signin.code
+if [ "$(cat /tmp/uat-70-signin.code)" = "200" ]; then pass "sign in"; else fail "sign in code $(cat /tmp/uat-70-signin.code)"; fi
+
+# 2. Mint an MCP token.
+curl -s -o /tmp/uat-70-token.json -w "%{http_code}" -b "$JAR" \
+  -X POST -H "Origin: $ORIGIN" \
+  "$SERVER_URL/api/users/mcp-token" > /tmp/uat-70-token.code || true
+MCP_TOKEN_VALUE=$(jq -r '.token // empty' /tmp/uat-70-token.json 2>/dev/null)
+MCP_TOKEN="${MCP_TOKEN:-$MCP_TOKEN_VALUE}"
+if [ -n "$MCP_TOKEN" ]; then pass "have MCP token"; else fail "no MCP token"; fi
+
+# 3. tools/list — confirm regen_now and regen_status present.
+TOOLS_LIST=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  "$SERVER_URL/mcp/?token=$MCP_TOKEN" | tr -d '\r')
+echo "$TOOLS_LIST" > /tmp/uat-70-tools.json
+for tool in regen_now regen_status; do
+  if echo "$TOOLS_LIST" | jq -e --arg n "$tool" '.result.tools[] | select(.name==$n)' >/dev/null 2>&1; then
+    pass "MCP exposes $tool"
+  else
+    fail "MCP missing $tool"
+  fi
+done
+
+# Pick a wiki to drive the burst test.
+WIKI_SLUG=$(curl -s -b "$JAR" "$SERVER_URL/wikis?limit=1" | jq -r '.wikis[0].slug // empty')
+WIKI_KEY=$(curl -s -b "$JAR" "$SERVER_URL/wikis?limit=1" | jq -r '.wikis[0].id // empty')
+if [ -z "$WIKI_SLUG" ] || [ -z "$WIKI_KEY" ]; then
+  fail "no wiki seeded; the burst test will be skipped"
+  WIKI_SLUG=""
+fi
+
+# 4. Burst-ingest test: 30 fragments into one wiki, wait for the
+#    debounce window, count regen events.
+if [ -n "$WIKI_SLUG" ]; then
+  # Snapshot regen completion count BEFORE the burst.
+  BEFORE_REGENS=$(psql -q "$DB_URL" -At -c "
+    SELECT count(*) FROM pipeline_events
+    WHERE stage='regen' AND status='completed'
+      AND (metadata->>'wikiKey') = '$WIKI_KEY';
+  " 2>/dev/null || echo "0")
+  pass "baseline regen count for $WIKI_SLUG = $BEFORE_REGENS"
+
+  echo "  · firing 30 log_fragment calls into $WIKI_SLUG..."
+  for i in $(seq 1 30); do
+    REQ=$(jq -nc --arg w "$WIKI_SLUG" --arg c "uat70 burst fragment $i $(date +%s%N)" '{
+      jsonrpc:"2.0", id:'$i', method:"tools/call",
+      params:{name:"log_fragment", arguments:{threadSlug:$w, content:$c}}
+    }')
+    curl -s -X POST -H "Content-Type: application/json" \
+      -d "$REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN" >/dev/null
+    # Tight loop -- mimic the live deployment scenario.
+    sleep 0.1
+  done
+  pass "30 fragments enqueued"
+
+  # Wait for the debounce window to elapse, plus a margin for the
+  # batch-cron tick + the regen worker LLM call to complete.
+  WAIT_MS=$((DEBOUNCE_MS + 120000))
+  echo "  · waiting ${WAIT_MS}ms for debounce + regen + batch-tick..."
+  # shellcheck disable=SC2059
+  sleep $((WAIT_MS / 1000))
+
+  AFTER_REGENS=$(psql -q "$DB_URL" -At -c "
+    SELECT count(*) FROM pipeline_events
+    WHERE stage='regen' AND status='completed'
+      AND (metadata->>'wikiKey') = '$WIKI_KEY';
+  " 2>/dev/null || echo "0")
+  DELTA=$((AFTER_REGENS - BEFORE_REGENS))
+  echo "  · regen completions during burst: $DELTA"
+
+  # Pre-fix: ~5-10 regens for a 30-fragment burst inside a single
+  # batch-cron interval. Post-fix: ~1 regen (debounce coalesces the
+  # burst into a single trailing regen).
+  if [ "$DELTA" -le 2 ]; then
+    pass "burst coalesced into <=2 regens (was ~5-10 pre-fix)"
+  else
+    fail "burst triggered $DELTA regens (expected <=2 with debounce)"
+  fi
+else
+  skip "burst-ingest test: no wiki to drive against"
+fi
+
+# 5. regen_now bypasses the debounce window. We just hammered the wiki
+#    with fragments above, so it MUST be inside the debounce window
+#    when this runs (we slept past it -- so re-trigger to make it dirty
+#    again).
+if [ -n "$WIKI_SLUG" ]; then
+  REQ=$(jq -nc --arg w "$WIKI_SLUG" --arg c "uat70 retrigger $(date +%s%N)" '{
+    jsonrpc:"2.0", id:80, method:"tools/call",
+    params:{name:"log_fragment", arguments:{threadSlug:$w, content:$c}}
+  }')
+  curl -s -X POST -H "Content-Type: application/json" \
+    -d "$REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN" >/dev/null
+  pass "wiki dirtied so debounce window is active"
+
+  # Snapshot regen count, fire regen_now, expect a NEW completion
+  # within seconds (assuming regen worker is up).
+  BEFORE_NOW=$(psql -q "$DB_URL" -At -c "
+    SELECT count(*) FROM pipeline_events
+    WHERE stage='regen' AND (metadata->>'wikiKey') = '$WIKI_KEY';
+  " 2>/dev/null || echo "0")
+
+  REQ=$(jq -nc --arg w "$WIKI_SLUG" '{
+    jsonrpc:"2.0", id:81, method:"tools/call",
+    params:{name:"regen_now", arguments:{wikiKey:$w}}
+  }')
+  RES=$(curl -s -X POST -H "Content-Type: application/json" \
+    -d "$REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN")
+  echo "$RES" > /tmp/uat-70-regennow.json
+  PAYLOAD=$(echo "$RES" | jq -r '.result.content[0].text // empty' | jq -c .)
+  JOB_ID=$(echo "$PAYLOAD" | jq -r '.jobId // empty')
+  if [ -n "$JOB_ID" ]; then pass "regen_now returned jobId=$JOB_ID"; else fail "regen_now did not return a jobId"; fi
+
+  # Expect at least one new pipeline_event row within 30s.
+  for _ in $(seq 1 30); do
+    AFTER_NOW=$(psql -q "$DB_URL" -At -c "
+      SELECT count(*) FROM pipeline_events
+      WHERE stage='regen' AND (metadata->>'wikiKey') = '$WIKI_KEY';
+    " 2>/dev/null || echo "0")
+    if [ "$AFTER_NOW" -gt "$BEFORE_NOW" ]; then break; fi
+    sleep 1
+  done
+  if [ "$AFTER_NOW" -gt "$BEFORE_NOW" ]; then
+    pass "regen_now produced a pipeline_event row inside the debounce window"
+  else
+    fail "regen_now did NOT produce a pipeline_event row (worker down? check core logs)"
+  fi
+else
+  skip "regen_now test: no wiki"
+fi
+
+# 6. regen_status returns sensible data.
+REQ='{"jsonrpc":"2.0","id":90,"method":"tools/call","params":{"name":"regen_status","arguments":{"recentLimit":5}}}'
+RES=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d "$REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN")
+echo "$RES" > /tmp/uat-70-status.json
+STATUS=$(echo "$RES" | jq -r '.result.content[0].text // empty' | jq -c .)
+if [ -n "$STATUS" ]; then pass "regen_status returned a payload"; else fail "regen_status returned nothing"; fi
+HAS_KEYS=$(echo "$STATUS" | jq -r '[has("inFlight"), has("debounced"), has("recent"), has("debounceMs")] | all')
+if [ "$HAS_KEYS" = "true" ]; then
+  pass "regen_status carries inFlight, debounced, recent, debounceMs"
+else
+  fail "regen_status missing required keys ($STATUS)"
+fi
+DEBOUNCE_FROM_STATUS=$(echo "$STATUS" | jq -r '.debounceMs // 0')
+if [ "$DEBOUNCE_FROM_STATUS" = "$DEBOUNCE_MS" ]; then
+  pass "regen_status reports debounceMs=$DEBOUNCE_FROM_STATUS"
+else
+  skip "regen_status debounceMs=$DEBOUNCE_FROM_STATUS (env was $DEBOUNCE_MS, server may have a different value)"
+fi
+
+# 7. Existing scheduled regen still works after the debounce window.
+#    Hands-off check: dirty a quiet wiki, wait past the debounce, the
+#    next batch-cron tick should enqueue. Caller can run this manually
+#    once they have a wiki that has been quiet for >5 min.
+if [ -n "$WIKI_SLUG" ]; then
+  # Force-attach a fragment well in the past to simulate "old activity".
+  # (Cannot actually time-travel; the script just dirties the wiki and
+  # asserts the regen does fire on the next batch tick beyond the
+  # debounce window.)
+  REQ=$(jq -nc --arg w "$WIKI_SLUG" --arg c "uat70 quiet $(date +%s%N)" '{
+    jsonrpc:"2.0", id:91, method:"tools/call",
+    params:{name:"log_fragment", arguments:{threadSlug:$w, content:$c}}
+  }')
+  curl -s -X POST -H "Content-Type: application/json" \
+    -d "$REQ" "$SERVER_URL/mcp/?token=$MCP_TOKEN" >/dev/null
+
+  BEFORE_QUIET=$(psql -q "$DB_URL" -At -c "
+    SELECT count(*) FROM pipeline_events
+    WHERE stage='regen' AND status='completed'
+      AND (metadata->>'wikiKey') = '$WIKI_KEY';
+  " 2>/dev/null || echo "0")
+
+  WAIT_S=$(((DEBOUNCE_MS / 1000) + 120))
+  echo "  · waiting ${WAIT_S}s for debounce window + a batch tick..."
+  sleep "$WAIT_S"
+
+  AFTER_QUIET=$(psql -q "$DB_URL" -At -c "
+    SELECT count(*) FROM pipeline_events
+    WHERE stage='regen' AND status='completed'
+      AND (metadata->>'wikiKey') = '$WIKI_KEY';
+  " 2>/dev/null || echo "0")
+  if [ "$AFTER_QUIET" -gt "$BEFORE_QUIET" ]; then
+    pass "scheduled regen still fires after the debounce elapses"
+  else
+    skip "no regen completion observed -- batch-cron tick may not have fired in window"
+  fi
+else
+  skip "scheduled-regen test: no wiki"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The script appends `uat70` fragments to the seed wiki. Manual cleanup:
+
+```bash
+psql "$DATABASE_URL" -c "
+  UPDATE fragments SET deleted_at = now()
+  WHERE content LIKE 'uat70 %' AND deleted_at IS NULL;
+"
+```
+
+## Expected pass/fail behavior
+
+All steps PASS on a clean local stack with the worker running and
+`REGEN_DEBOUNCE_MS=60000` set. Step 4 (burst → ≤2 regens) is the
+load-bearing assertion against QA Issue 6's symptom. Steps 5 + 6 prove
+the recovery surfaces (`regen_now`, `regen_status`) work. Step 7 SKIPS
+when the batch-cron tick does not fire inside the wait window; it is
+intentional belt-and-braces, not a hard gate.
+
+## Out of scope
+
+- The `regenerate` vs `auto_regen` flag confusion is deferred to v0.2.2
+  (per Andrew lock). This UAT does not assert on either flag.
+- Reason 3 (stuck-state recovery) bypass is exercised by the existing
+  unit tests in `core/src/queue/regen-debounce.test.ts`. Reproducing
+  that path live requires forcing `state != 'RESOLVED' AND state !=
+  'LINKING'` for >15 minutes, which is an operator-only scenario.

--- a/.uat/plans/70-regen-debounce-and-regen-now.md
+++ b/.uat/plans/70-regen-debounce-and-regen-now.md
@@ -1,4 +1,4 @@
-# 70 — Regen debounce and on-demand regen (QA Issue 6)
+# 70 - Regen debounce and on-demand regen (QA Issue 6)
 
 ## What it proves
 
@@ -37,10 +37,10 @@ pieces:
 
 ## Endpoint map
 
-- `POST /api/auth/sign-in/email`              — cookie session
-- `POST /api/users/mcp-token`                  — mint MCP JWT
+- `POST /api/auth/sign-in/email`              - cookie session
+- `POST /api/users/mcp-token`                  - mint MCP JWT
 - `POST /mcp/?token=$MCP_TOKEN` (JSON-RPC):
-  - `tools/list`             — assert `regen_now`, `regen_status` visible
+  - `tools/list`             - assert `regen_now`, `regen_status` visible
   - `tools/call regen_now`
   - `tools/call regen_status`
   - `tools/call log_fragment` (for the burst-ingest test)
@@ -65,7 +65,7 @@ pass() { PASS=$((PASS+1)); echo "  + $1"; }
 fail() { FAIL=$((FAIL+1)); echo "  ! $1"; }
 skip() { SKIP=$((SKIP+1)); echo "  - $1"; }
 
-echo "70 — Regen debounce and on-demand regen (QA Issue 6)"
+echo "70 - Regen debounce and on-demand regen (QA Issue 6)"
 echo "    REGEN_DEBOUNCE_MS=$DEBOUNCE_MS"
 echo ""
 
@@ -84,7 +84,7 @@ MCP_TOKEN_VALUE=$(jq -r '.token // empty' /tmp/uat-70-token.json 2>/dev/null)
 MCP_TOKEN="${MCP_TOKEN:-$MCP_TOKEN_VALUE}"
 if [ -n "$MCP_TOKEN" ]; then pass "have MCP token"; else fail "no MCP token"; fi
 
-# 3. tools/list — confirm regen_now and regen_status present.
+# 3. tools/list - confirm regen_now and regen_status present.
 TOOLS_LIST=$(curl -s -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
   "$SERVER_URL/mcp/?token=$MCP_TOKEN" | tr -d '\r')

--- a/core/.env.example
+++ b/core/.env.example
@@ -119,3 +119,11 @@ WIKI_ORIGIN=http://localhost:8080
 # The cron finds wikis with unfiled fragments, new fragments since last rebuild,
 # or stuck in non-RESOLVED state, and enqueues regen jobs.
 # ENABLE_BATCH_REGEN=true
+
+# [OPTIONAL] Per-wiki regen debounce window in milliseconds. Default: 300000 (5 min).
+# The batch regen worker skips a wiki when a fragment edge has landed inside
+# this window — a noisy ingest burst no longer triggers back-to-back regens
+# whose output gets superseded before it matters (QA Issue 6, 2026-05-08).
+# Recovery (stuck-state) and the midnight auto-regen cron bypass this.
+# Set to 0 to disable the debounce. Hard ceiling: 1 hour.
+# REGEN_DEBOUNCE_MS=300000

--- a/core/.env.example
+++ b/core/.env.example
@@ -1,5 +1,5 @@
 # ═══════════════════════════════════════════════════════════════════════
-# Robin Core — Environment Variables
+# Robin Core - Environment Variables
 # ═══════════════════════════════════════════════════════════════════════
 #
 # Copy this file to .env and fill in the values.
@@ -68,13 +68,13 @@ KEY_ENCRYPTION_SECRET=
 # Used ONLY by POST /auth/recover. Keep this separate from
 # BETTER_AUTH_SECRET so a session-secret leak does not also enable password
 # resets. Update the in-prod value via your secret manager and tell every
-# operator the rotated value out-of-band — there is no UI to read it.
+# operator the rotated value out-of-band - there is no UI to read it.
 RECOVERY_SECRET=
 
 # [REQUIRED in production] HMAC secret for BullMQ job payload signing. 32+ chars.
 # Generate: openssl rand -hex 32
 # Producer signs every job payload; worker verifies and rejects on mismatch.
-# Local dev falls back to a fixed sentinel when missing — see worker boot logs.
+# Local dev falls back to a fixed sentinel when missing - see worker boot logs.
 JOB_SIGNING_SECRET=
 
 # === Initial User (Single-Tenant) ===
@@ -93,7 +93,7 @@ INITIAL_PASSWORD=change-me
 # [REQUIRED] OpenRouter API key for LLM calls and embeddings.
 # Get one at: https://openrouter.ai/keys
 # Used by: extraction worker, wiki classifier, wiki regeneration, embedding generation.
-# This key is read from env at runtime — it is NOT stored in the database.
+# This key is read from env at runtime - it is NOT stored in the database.
 OPENROUTER_API_KEY=
 
 # === Frontend ===
@@ -122,7 +122,7 @@ WIKI_ORIGIN=http://localhost:8080
 
 # [OPTIONAL] Per-wiki regen debounce window in milliseconds. Default: 300000 (5 min).
 # The batch regen worker skips a wiki when a fragment edge has landed inside
-# this window — a noisy ingest burst no longer triggers back-to-back regens
+# this window - a noisy ingest burst no longer triggers back-to-back regens
 # whose output gets superseded before it matters (QA Issue 6, 2026-05-08).
 # Recovery (stuck-state) and the midnight auto-regen cron bypass this.
 # Set to 0 to disable the debounce. Hard ceiling: 1 hour.

--- a/core/src/mcp/handlers.regen-now.test.ts
+++ b/core/src/mcp/handlers.regen-now.test.ts
@@ -77,7 +77,7 @@ const fakeDeps = {
   loadUserPeople: async () => [],
 }
 
-describe('handleRegenNow — on-demand regen tool', () => {
+describe('handleRegenNow - on-demand regen tool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })

--- a/core/src/mcp/handlers.regen-now.test.ts
+++ b/core/src/mcp/handlers.regen-now.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+//
+// QA Issue 6 (2026-05-08): regen_now is the explicit "ignore the debounce"
+// affordance. Auth still applies; only the quiet-window heuristic is
+// skipped. These tests pin both halves -- the auth gate AND the bypass.
+
+const mockEnqueueWikiRegen = vi.fn()
+const mockResolveWikiForRegen = vi.fn()
+const mockEmitAuditEvent = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../queue/regen-debounce.js', () => ({
+  enqueueWikiRegen: (...args: unknown[]) => mockEnqueueWikiRegen(...args),
+  resolveWikiForRegen: (...args: unknown[]) => mockResolveWikiForRegen(...args),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: (...args: unknown[]) => mockEmitAuditEvent(...args),
+}))
+
+vi.mock('@robin/shared', () => ({
+  makeLookupKey: vi.fn(),
+  parseLookupKey: vi.fn(),
+  generateSlug: vi.fn(),
+  loadPeopleExtractionSpec: vi.fn(),
+}))
+
+vi.mock('@robin/agent', () => ({
+  resolvePerson: vi.fn(),
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+vi.mock('../db/slug.js', () => ({
+  resolveEntrySlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveWikiSlug: vi.fn(),
+}))
+
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: {},
+  wikiTypes: {},
+  edits: {},
+}))
+
+vi.mock('./resolvers.js', () => ({
+  resolveWikiBySlug: vi.fn(),
+}))
+
+vi.mock('../services/publish.js', () => ({
+  publishWiki: vi.fn(),
+  unpublishWiki: vi.fn(),
+}))
+
+vi.mock('../lib/openrouter-config.js', () => ({
+  loadOpenRouterConfig: vi.fn(),
+}))
+
+const { handleRegenNow } = await import('./handlers.js')
+
+const fakeDeps = {
+  db: {} as never,
+  producer: {} as never,
+  spawnWriteWorker: () => {},
+  entityExtractCall: async () => ({ people: [] }),
+  loadUserPeople: async () => [],
+}
+
+describe('handleRegenNow — on-demand regen tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects unauthenticated callers BEFORE consulting the queue', async () => {
+    const result = await handleRegenNow(fakeDeps, { wikiKey: 'wiki01abc' }, undefined)
+    expect(result.isError).toBe(true)
+    expect(mockEnqueueWikiRegen).not.toHaveBeenCalled()
+    expect(mockResolveWikiForRegen).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty wikiKey', async () => {
+    const result = await handleRegenNow(fakeDeps, { wikiKey: '   ' }, 'user-1')
+    expect(result.isError).toBe(true)
+    expect(mockEnqueueWikiRegen).not.toHaveBeenCalled()
+  })
+
+  it('returns a not-found error when the wiki does not resolve', async () => {
+    mockResolveWikiForRegen.mockResolvedValueOnce(null)
+    const result = await handleRegenNow(
+      fakeDeps,
+      { wikiKey: 'unknown-wiki' },
+      'user-1'
+    )
+    expect(result.isError).toBe(true)
+    expect(mockEnqueueWikiRegen).not.toHaveBeenCalled()
+  })
+
+  it('enqueues a manual regen via the shared helper and returns jobId/queuedAt', async () => {
+    mockResolveWikiForRegen.mockResolvedValueOnce({
+      lookupKey: 'wiki01abc',
+      slug: 'my-wiki',
+    })
+    mockEnqueueWikiRegen.mockResolvedValueOnce({
+      jobId: 'job-uuid-1',
+      queuedAt: '2026-05-08T12:00:00.000Z',
+    })
+
+    const result = await handleRegenNow(
+      fakeDeps,
+      { wikiKey: 'my-wiki' },
+      'user-1'
+    )
+
+    expect(result.isError).toBeUndefined()
+    expect(mockEnqueueWikiRegen).toHaveBeenCalledTimes(1)
+    const args = mockEnqueueWikiRegen.mock.calls[0]
+    expect(args[0]).toBe('wiki01abc')
+    expect(args[1]).toBe('manual')
+
+    const payload = JSON.parse(
+      (result.content as Array<{ type: string; text: string }>)[0].text
+    )
+    expect(payload).toMatchObject({
+      jobId: 'job-uuid-1',
+      queuedAt: '2026-05-08T12:00:00.000Z',
+      wikiKey: 'wiki01abc',
+      wikiSlug: 'my-wiki',
+    })
+  })
+
+  it('emits a regen_requested audit row keyed by wiki', async () => {
+    mockResolveWikiForRegen.mockResolvedValueOnce({
+      lookupKey: 'wiki01abc',
+      slug: 'my-wiki',
+    })
+    mockEnqueueWikiRegen.mockResolvedValueOnce({
+      jobId: 'job-uuid-2',
+      queuedAt: '2026-05-08T12:01:00.000Z',
+    })
+
+    await handleRegenNow(fakeDeps, { wikiKey: 'my-wiki' }, 'user-1')
+
+    expect(mockEmitAuditEvent).toHaveBeenCalledTimes(1)
+    const params = mockEmitAuditEvent.mock.calls[0][1] as {
+      entityType: string
+      entityId: string
+      eventType: string
+      detail?: Record<string, unknown>
+    }
+    expect(params.entityType).toBe('wiki')
+    expect(params.entityId).toBe('wiki01abc')
+    expect(params.eventType).toBe('regen_requested')
+    expect(params.detail).toMatchObject({
+      jobId: 'job-uuid-2',
+      triggeredBy: 'manual',
+    })
+  })
+})

--- a/core/src/mcp/handlers.regen-status.test.ts
+++ b/core/src/mcp/handlers.regen-status.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// QA Issue 6: regen_status is the "regen happening now" surface.
+// Auth check + delegation to getRegenStatus -- the snapshot logic is
+// covered separately in regen-debounce-status.test.ts.
+
+const mockGetRegenStatus = vi.fn()
+
+vi.mock('../queue/regen-debounce.js', () => ({
+  getRegenStatus: (...args: unknown[]) => mockGetRegenStatus(...args),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@robin/shared', () => ({
+  makeLookupKey: vi.fn(),
+  parseLookupKey: vi.fn(),
+  generateSlug: vi.fn(),
+  loadPeopleExtractionSpec: vi.fn(),
+}))
+
+vi.mock('@robin/agent', () => ({
+  resolvePerson: vi.fn(),
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+vi.mock('../db/slug.js', () => ({
+  resolveEntrySlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveWikiSlug: vi.fn(),
+}))
+
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: {},
+  wikiTypes: {},
+  edits: {},
+}))
+
+vi.mock('./resolvers.js', () => ({
+  resolveWikiBySlug: vi.fn(),
+}))
+
+vi.mock('../services/publish.js', () => ({
+  publishWiki: vi.fn(),
+  unpublishWiki: vi.fn(),
+}))
+
+vi.mock('../lib/openrouter-config.js', () => ({
+  loadOpenRouterConfig: vi.fn(),
+}))
+
+const { handleRegenStatus } = await import('./handlers.js')
+
+const fakeDeps = {
+  db: {} as never,
+  producer: {} as never,
+  spawnWriteWorker: () => {},
+  entityExtractCall: async () => ({ people: [] }),
+  loadUserPeople: async () => [],
+}
+
+describe('handleRegenStatus — observability tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects unauthenticated callers BEFORE consulting the queue', async () => {
+    const result = await handleRegenStatus(fakeDeps, {}, undefined)
+    expect(result.isError).toBe(true)
+    expect(mockGetRegenStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns the snapshot from getRegenStatus on the happy path', async () => {
+    mockGetRegenStatus.mockResolvedValueOnce({
+      inFlight: [{ jobId: 'j1', wikiKey: 'wiki01abc', startedAt: '2026-05-08T12:00:00.000Z', triggeredBy: 'manual' }],
+      debounced: [{ wikiKey: 'wiki01xyz', lastEdgeAt: '2026-05-08T11:58:00.000Z', etaToEligibleMs: 180_000 }],
+      recent: [{ wikiKey: 'wiki01abc', jobId: 'j0', status: 'completed', startedAt: '2026-05-08T11:50:00.000Z', durationMs: 92_000 }],
+      debounceMs: 300_000,
+    })
+
+    const result = await handleRegenStatus(fakeDeps, { recentLimit: 5 }, 'user-1')
+
+    expect(result.isError).toBeUndefined()
+    expect(mockGetRegenStatus).toHaveBeenCalledTimes(1)
+    expect(mockGetRegenStatus.mock.calls[0][1]).toEqual({ recentLimit: 5 })
+
+    const payload = JSON.parse(
+      (result.content as Array<{ type: string; text: string }>)[0].text
+    )
+    expect(payload.inFlight).toHaveLength(1)
+    expect(payload.debounced).toHaveLength(1)
+    expect(payload.recent).toHaveLength(1)
+    expect(payload.debounceMs).toBe(300_000)
+  })
+
+  it('surfaces snapshot errors as MCP-shaped errors instead of throwing', async () => {
+    mockGetRegenStatus.mockRejectedValueOnce(new Error('redis down'))
+    const result = await handleRegenStatus(fakeDeps, {}, 'user-1')
+    expect(result.isError).toBe(true)
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text
+    expect(text).toContain('redis down')
+  })
+})

--- a/core/src/mcp/handlers.regen-status.test.ts
+++ b/core/src/mcp/handlers.regen-status.test.ts
@@ -72,7 +72,7 @@ const fakeDeps = {
   loadUserPeople: async () => [],
 }
 
-describe('handleRegenStatus — observability tool', () => {
+describe('handleRegenStatus - observability tool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -1152,6 +1152,47 @@ export async function handleUnpublishWiki(
 }
 
 /**
+ * Handle the `regen_status` MCP tool call.
+ *
+ * @summary Read-only snapshot of the regen worker's live state. Pairs
+ * with the per-wiki debounce as the "regen happening now" indicator
+ * QA Issue 6 (2026-05-08) called for: without a surface like this the
+ * regen cost is invisible to the user.
+ *
+ * Returns three views:
+ *   - `inFlight`: BullMQ active/waiting/delayed regen jobs
+ *   - `debounced`: wikis the worker is currently holding off on,
+ *     with eta_to_eligible_ms
+ *   - `recent`: last N pipeline_events entries for stage='regen'
+ */
+export async function handleRegenStatus(
+  deps: McpServerDeps,
+  input: { recentLimit?: number },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  try {
+    const { getRegenStatus } = await import('../queue/regen-debounce.js')
+    const snapshot = await getRegenStatus(deps.db, { recentLimit: input.recentLimit })
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(snapshot) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp regen_status failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
  * Handle the `regen_now` MCP tool call.
  *
  * @summary On-demand regen for a single wiki, bypassing the per-wiki

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -1150,3 +1150,87 @@ export async function handleUnpublishWiki(
     }
   }
 }
+
+/**
+ * Handle the `regen_now` MCP tool call.
+ *
+ * @summary On-demand regen for a single wiki, bypassing the per-wiki
+ * debounce window. Same auth surface as other write tools (auth check
+ * via `userId`); only the debounce is skipped, never the auth.
+ *
+ * Surfaced for QA Issue 6 (2026-05-08): once the regen worker debounces
+ * during active ingest, callers need an explicit "regen this one now"
+ * affordance for the cases where waiting is wrong (manual review, demo
+ * prep, fixture sweeps). Routes through the same enqueue helper the
+ * batch worker uses so behavior on the queue side is identical.
+ */
+export async function handleRegenNow(
+  deps: McpServerDeps,
+  input: { wikiKey: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  if (!input.wikiKey?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: wikiKey is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const { resolveWikiForRegen, enqueueWikiRegen } = await import(
+      '../queue/regen-debounce.js'
+    )
+    const wiki = await resolveWikiForRegen(deps.db, input.wikiKey.trim())
+    if (!wiki) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: wiki "${input.wikiKey}" not found` }],
+        isError: true as const,
+      }
+    }
+
+    const { jobId, queuedAt } = await enqueueWikiRegen(wiki.lookupKey, 'manual')
+
+    const sourceClient = readSourceClient(deps)
+    await emitAuditEvent(deps.db, {
+      entityType: 'wiki',
+      entityId: wiki.lookupKey,
+      eventType: 'regen_requested',
+      source: 'mcp',
+      summary: `On-demand regen requested via MCP: ${wiki.slug}`,
+      detail: {
+        wikiKey: wiki.lookupKey,
+        wikiSlug: wiki.slug,
+        jobId,
+        triggeredBy: 'manual',
+        ...(sourceClient ? { source_client: sourceClient } : {}),
+      },
+    })
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            jobId,
+            queuedAt,
+            wikiKey: wiki.lookupKey,
+            wikiSlug: wiki.slug,
+          }),
+        },
+      ],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp regen_now failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -22,7 +22,7 @@ import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveWikiBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow, handleRegenStatus } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 import { wikis, wikiTypes, edges, auditLog, groups, groupWikis } from '../db/schema.js'
 import { hybridSearch } from '../lib/search.js'
@@ -263,6 +263,29 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     },
     async ({ wikiKey }, extra) => {
       return handleRegenNow(deps, { wikiKey }, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'regen_status',
+    {
+      description:
+        'Snapshot of the regen worker. Returns three views: ' +
+        '`inFlight` (regen jobs currently active/waiting in the queue, ' +
+        'with wikiKey and startedAt), `debounced` (wikis the scheduler ' +
+        'is holding off on while fragments are still arriving, with ' +
+        'etaToEligibleMs), and `recent` (last N pipeline events for ' +
+        'stage=regen, with durationMs when known). The "regen happening ' +
+        'now" indicator -- without it the LLM cost during ingest is ' +
+        'invisible.',
+      inputSchema: {
+        recentLimit: z.number().optional().describe(
+          'How many recent regen events to include (default 10, max 100)'
+        ),
+      },
+    },
+    async ({ recentLimit }, extra) => {
+      return handleRegenStatus(deps, { recentLimit }, extra.authInfo?.clientId as string)
     }
   )
 

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -22,7 +22,7 @@ import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveWikiBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 import { wikis, wikiTypes, edges, auditLog, groups, groupWikis } from '../db/schema.js'
 import { hybridSearch } from '../lib/search.js'
@@ -243,6 +243,26 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     },
     async ({ wikiSlug }, extra) => {
       return handleUnpublishWiki(deps, { wikiSlug }, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'regen_now',
+    {
+      description:
+        'Force an immediate regen of a single wiki, bypassing the ' +
+        'per-wiki debounce window. Use when the user explicitly asks for ' +
+        'a refresh during an active ingest burst (where the scheduler ' +
+        'would normally hold off until the wiki has been quiet for a few ' +
+        'minutes). Returns the queued job id and timestamp; the regen ' +
+        'itself runs asynchronously on the regen worker. Pass either the ' +
+        'wiki lookupKey or the slug.',
+      inputSchema: {
+        wikiKey: z.string().describe('Wiki lookupKey or slug (from list_wikis or get_wiki)'),
+      },
+    },
+    async ({ wikiKey }, extra) => {
+      return handleRegenNow(deps, { wikiKey }, extra.authInfo?.clientId as string)
     }
   )
 

--- a/core/src/queue/regen-debounce.test.ts
+++ b/core/src/queue/regen-debounce.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+//
+// Covers QA Issue 6 (2026-05-08): per-wiki debounce filters out wikis
+// that received a fragment edge inside the configured quiet window. The
+// batch worker's ingest-driven reasons (1, 2) consult this filter; the
+// recovery and explicit-cadence reasons (3, 4) bypass.
+
+const mockEnqueueRegen = vi.fn()
+const mockEmitAuditEvent = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../queue/producer.js', () => ({
+  producer: {
+    enqueueRegen: (...args: unknown[]) => mockEnqueueRegen(...args),
+  },
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: (...args: unknown[]) => mockEmitAuditEvent(...args),
+}))
+
+vi.mock('../lib/regen.js', () => ({
+  regenerateWiki: vi.fn(),
+}))
+
+const dbResponseQueue: unknown[][] = []
+
+function stageDbResponses(responses: unknown[][]) {
+  dbResponseQueue.length = 0
+  dbResponseQueue.push(...responses)
+}
+
+function popResponse(): unknown[] {
+  return dbResponseQueue.shift() ?? []
+}
+
+vi.mock('../db/client.js', () => {
+  function thenable() {
+    return {
+      // biome-ignore lint/suspicious/noThenProperty: drizzle thenable mock
+      then: (onFulfilled: (v: unknown[]) => unknown) =>
+        Promise.resolve(popResponse()).then(onFulfilled),
+    }
+  }
+  function selectChain() {
+    return {
+      from: () => ({
+        where: () => ({
+          ...thenable(),
+          groupBy: () => thenable(),
+          limit: () => thenable(),
+        }),
+        innerJoin: () => ({
+          where: () => ({
+            groupBy: () => thenable(),
+          }),
+        }),
+      }),
+    }
+  }
+  return {
+    db: {
+      select: () => selectChain(),
+    },
+  }
+})
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookupKey',
+    slug: 'wikis.slug',
+    deletedAt: 'wikis.deletedAt',
+    regenerate: 'wikis.regenerate',
+    autoRegen: 'wikis.autoRegen',
+    lifecycleState: 'wikis.lifecycleState',
+    state: 'wikis.state',
+    updatedAt: 'wikis.updatedAt',
+    lastRebuiltAt: 'wikis.lastRebuiltAt',
+  },
+  edges: {
+    dstId: 'edges.dstId',
+    srcId: 'edges.srcId',
+    edgeType: 'edges.edgeType',
+    deletedAt: 'edges.deletedAt',
+    createdAt: 'edges.createdAt',
+  },
+  fragments: {
+    lookupKey: 'fragments.lookupKey',
+    deletedAt: 'fragments.deletedAt',
+    embedding: 'fragments.embedding',
+  },
+}))
+
+const { processRegenBatchJob } = await import('./regen-worker.js')
+const { filterDebouncedWikiKeys, regenDebounceMs, DEFAULT_REGEN_DEBOUNCE_MS } =
+  await import('./regen-debounce.js')
+const { db: mockDb } = await import('../db/client.js')
+
+describe('regen-debounce: filterDebouncedWikiKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResponseQueue.length = 0
+    delete process.env.REGEN_DEBOUNCE_MS
+  })
+
+  afterEach(() => {
+    delete process.env.REGEN_DEBOUNCE_MS
+  })
+
+  it('marks a wiki as debounced when its last fragment edge is fresher than now - debounce', async () => {
+    process.env.REGEN_DEBOUNCE_MS = '300000' // 5 min
+    const now = new Date('2026-05-08T12:00:00.000Z')
+    const recentEdge = new Date(now.getTime() - 60_000) // 1 min ago
+    stageDbResponses([
+      [{ wikiKey: 'wiki-chatty', lastEdgeAt: recentEdge }],
+    ])
+    const { eligible, debounced } = await filterDebouncedWikiKeys(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      mockDb as any,
+      ['wiki-chatty'],
+      now
+    )
+    expect(eligible).toEqual([])
+    expect(debounced).toHaveLength(1)
+    expect(debounced[0].wikiKey).toBe('wiki-chatty')
+    expect(debounced[0].etaMs).toBeGreaterThan(0)
+  })
+
+  it('marks a wiki eligible when its last fragment edge is older than the window', async () => {
+    process.env.REGEN_DEBOUNCE_MS = '300000' // 5 min
+    const now = new Date('2026-05-08T12:00:00.000Z')
+    const oldEdge = new Date(now.getTime() - 600_000) // 10 min ago
+    stageDbResponses([
+      [{ wikiKey: 'wiki-quiet', lastEdgeAt: oldEdge }],
+    ])
+    const { eligible, debounced } = await filterDebouncedWikiKeys(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      mockDb as any,
+      ['wiki-quiet'],
+      now
+    )
+    expect(eligible).toEqual(['wiki-quiet'])
+    expect(debounced).toEqual([])
+  })
+
+  it('treats a wiki with no fragment edges as eligible (no last-edge to wait on)', async () => {
+    process.env.REGEN_DEBOUNCE_MS = '300000'
+    stageDbResponses([[]]) // edges query returns nothing
+    const { eligible, debounced } = await filterDebouncedWikiKeys(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      mockDb as any,
+      ['wiki-empty']
+    )
+    expect(eligible).toEqual(['wiki-empty'])
+    expect(debounced).toEqual([])
+  })
+
+  it('skips the DB call entirely when the candidate list is empty', async () => {
+    const { eligible, debounced } = await filterDebouncedWikiKeys(
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+      mockDb as any,
+      []
+    )
+    expect(eligible).toEqual([])
+    expect(debounced).toEqual([])
+  })
+
+  it('regenDebounceMs respects the env override and falls back to the default', () => {
+    expect(regenDebounceMs()).toBe(DEFAULT_REGEN_DEBOUNCE_MS)
+    process.env.REGEN_DEBOUNCE_MS = '60000'
+    expect(regenDebounceMs()).toBe(60_000)
+    process.env.REGEN_DEBOUNCE_MS = 'garbage'
+    expect(regenDebounceMs()).toBe(DEFAULT_REGEN_DEBOUNCE_MS)
+    process.env.REGEN_DEBOUNCE_MS = '-1'
+    expect(regenDebounceMs()).toBe(DEFAULT_REGEN_DEBOUNCE_MS)
+  })
+})
+
+describe('processRegenBatchJob honours the per-wiki debounce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResponseQueue.length = 0
+    process.env.REGEN_DEBOUNCE_MS = '300000'
+  })
+
+  afterEach(() => {
+    delete process.env.REGEN_DEBOUNCE_MS
+  })
+
+  it('does NOT enqueue a wiki whose last fragment edge landed inside the window', async () => {
+    const now = Date.now()
+    const fresh = new Date(now - 30_000) // 30s ago — well inside the 5min window
+    stageDbResponses([
+      [{ count: 0 }],                                    // unfiled count
+      [{ lookupKey: 'wiki-chatty' }],                    // new-fragment wikis (Reason 2, debounce-gated)
+      [],                                                // stuck wikis (Reason 3)
+      [],                                                // auto-regen wikis (Reason 4)
+      [{ wikiKey: 'wiki-chatty', lastEdgeAt: fresh }],   // debounce filter MAX(edges.created_at)
+    ])
+
+    const result = await processRegenBatchJob({
+      type: 'regen-batch',
+      jobId: 'batch-debounce-fresh',
+      enqueuedAt: new Date().toISOString(),
+    } as Parameters<typeof processRegenBatchJob>[0])
+
+    expect(result.success).toBe(true)
+    expect(mockEnqueueRegen).not.toHaveBeenCalled()
+  })
+
+  it('enqueues a wiki whose last fragment edge landed before the window', async () => {
+    const now = Date.now()
+    const old = new Date(now - 10 * 60_000) // 10 min ago
+    stageDbResponses([
+      [{ count: 0 }],
+      [{ lookupKey: 'wiki-quiet' }],
+      [],
+      [],
+      [{ wikiKey: 'wiki-quiet', lastEdgeAt: old }],
+    ])
+
+    await processRegenBatchJob({
+      type: 'regen-batch',
+      jobId: 'batch-debounce-old',
+      enqueuedAt: new Date().toISOString(),
+    } as Parameters<typeof processRegenBatchJob>[0])
+
+    expect(mockEnqueueRegen).toHaveBeenCalledTimes(1)
+    const arg = mockEnqueueRegen.mock.calls[0][0] as { objectKey: string; triggeredBy: string }
+    expect(arg.objectKey).toBe('wiki-quiet')
+    expect(arg.triggeredBy).toBe('scheduler')
+  })
+
+  it('bypasses debounce for stuck wikis (Reason 3) even when fragments are landing', async () => {
+    const fresh = new Date(Date.now() - 5_000)
+    stageDbResponses([
+      [{ count: 0 }],
+      [],                                                // no Reason 2 hits
+      [{ lookupKey: 'wiki-stuck' }],                     // Reason 3: stuck
+      [],                                                // Reason 4
+      // No debounce-filter call expected because debounceCandidates is empty.
+    ])
+
+    await processRegenBatchJob({
+      type: 'regen-batch',
+      jobId: 'batch-bypass-stuck',
+      enqueuedAt: new Date().toISOString(),
+    } as Parameters<typeof processRegenBatchJob>[0])
+
+    // wiki-stuck still enqueues even though we never even ran the debounce filter
+    expect(mockEnqueueRegen).toHaveBeenCalledTimes(1)
+    const arg = mockEnqueueRegen.mock.calls[0][0] as { objectKey: string }
+    expect(arg.objectKey).toBe('wiki-stuck')
+    // Asserting `fresh` is referenced — the bypass should NOT consult it.
+    void fresh
+  })
+})

--- a/core/src/queue/regen-debounce.test.ts
+++ b/core/src/queue/regen-debounce.test.ts
@@ -190,7 +190,7 @@ describe('processRegenBatchJob honours the per-wiki debounce', () => {
 
   it('does NOT enqueue a wiki whose last fragment edge landed inside the window', async () => {
     const now = Date.now()
-    const fresh = new Date(now - 30_000) // 30s ago — well inside the 5min window
+    const fresh = new Date(now - 30_000) // 30s ago - well inside the 5min window
     stageDbResponses([
       [{ count: 0 }],                                    // unfiled count
       [{ lookupKey: 'wiki-chatty' }],                    // new-fragment wikis (Reason 2, debounce-gated)
@@ -252,7 +252,7 @@ describe('processRegenBatchJob honours the per-wiki debounce', () => {
     expect(mockEnqueueRegen).toHaveBeenCalledTimes(1)
     const arg = mockEnqueueRegen.mock.calls[0][0] as { objectKey: string }
     expect(arg.objectKey).toBe('wiki-stuck')
-    // Asserting `fresh` is referenced — the bypass should NOT consult it.
+    // Asserting `fresh` is referenced - the bypass should NOT consult it.
     void fresh
   })
 })

--- a/core/src/queue/regen-debounce.ts
+++ b/core/src/queue/regen-debounce.ts
@@ -1,0 +1,165 @@
+/***********************************************************************
+ * @module queue/regen-debounce
+ *
+ * @summary Per-wiki regen debounce + shared enqueue helper.
+ *
+ * @remarks
+ * QA Issue 6 (2026-05-08): a 60-minute ingest of 89 entries / 534
+ * fragments triggered 27 back-to-back regens because every fragment
+ * landing a FRAGMENT_IN_WIKI edge immediately re-matched the regen
+ * batch worker's "wiki has new edges since last_rebuilt_at" rule.
+ *
+ * Each regen is 70 to 180 seconds of LLM work. Most runs were
+ * superseded by the next batch of fragment arrivals before the output
+ * mattered. Net effect: continuous LLM cost during active capture.
+ *
+ * Fix: gate the two ingest-driven trigger reasons (unfiled fragments,
+ * new fragment edges) behind a "wiki has been quiet for N minutes"
+ * check. Recovery (Reason 3, stuck state) and the explicit-cadence
+ * midnight cron (Reason 4) bypass the debounce.
+ *
+ * No migration: we read `MAX(edges.created_at)` per wiki to derive the
+ * last fragment-arrival time. `wikis.last_rebuilt_at` already exists.
+ *
+ * @see {@link processRegenBatchJob} -- the consumer
+ * @see {@link handleRegenNow} -- on-demand bypass for the MCP tool
+ ***********************************************************************/
+
+import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
+import type { DB } from '../db/client.js'
+import { wikis, edges } from '../db/schema.js'
+import { producer } from './producer.js'
+
+/**
+ * Default per-wiki quiet window before regen is eligible. Tunable via
+ * the `REGEN_DEBOUNCE_MS` env var. Five minutes was picked to outlast
+ * a typical conversational ingest burst (the QA scenario was 60 min
+ * of mixed ingest, with bursts clustered every few minutes) without
+ * starving the user of "I just dropped some thoughts, when does the
+ * wiki update?" feedback longer than feels natural.
+ */
+export const DEFAULT_REGEN_DEBOUNCE_MS = 5 * 60 * 1000
+
+/** Read the configured debounce window. Clamped to [0, 1 hour]. */
+export function regenDebounceMs(): number {
+  const raw = process.env.REGEN_DEBOUNCE_MS
+  if (!raw) return DEFAULT_REGEN_DEBOUNCE_MS
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_REGEN_DEBOUNCE_MS
+  // Hard ceiling so a typo cannot park regen indefinitely.
+  return Math.min(n, 60 * 60 * 1000)
+}
+
+/**
+ * Filter a candidate set down to wikis whose most-recent FRAGMENT_IN_WIKI
+ * edge is older than `now - REGEN_DEBOUNCE_MS`. Wikis with no edges yet
+ * (no fragments attached) are treated as eligible; the debounce only
+ * delays regen during active ingest.
+ *
+ * Reads `MAX(edges.created_at)` grouped by `dst_id` for the
+ * `FRAGMENT_IN_WIKI` edge type. Single query, indexed by `edges_dst_idx`.
+ */
+export async function filterDebouncedWikiKeys(
+  db: DB,
+  candidateKeys: string[],
+  now: Date = new Date()
+): Promise<{ eligible: string[]; debounced: { wikiKey: string; lastEdgeAt: Date; etaMs: number }[] }> {
+  if (candidateKeys.length === 0) return { eligible: [], debounced: [] }
+  const debounceMs = regenDebounceMs()
+  if (debounceMs === 0) return { eligible: [...candidateKeys], debounced: [] }
+
+  const rows = await db
+    .select({
+      wikiKey: edges.dstId,
+      lastEdgeAt: sql<Date>`MAX(${edges.createdAt})`,
+    })
+    .from(edges)
+    .where(
+      and(
+        inArray(edges.dstId, candidateKeys),
+        eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+        isNull(edges.deletedAt)
+      )
+    )
+    .groupBy(edges.dstId)
+
+  const lastEdgeByWiki = new Map<string, Date>()
+  for (const r of rows) {
+    if (r.lastEdgeAt) lastEdgeByWiki.set(r.wikiKey, new Date(r.lastEdgeAt))
+  }
+
+  const cutoff = now.getTime() - debounceMs
+  const eligible: string[] = []
+  const debounced: { wikiKey: string; lastEdgeAt: Date; etaMs: number }[] = []
+  for (const key of candidateKeys) {
+    const last = lastEdgeByWiki.get(key)
+    if (!last) {
+      // No fragment edges yet -- nothing to wait on.
+      eligible.push(key)
+      continue
+    }
+    if (last.getTime() <= cutoff) {
+      eligible.push(key)
+    } else {
+      debounced.push({
+        wikiKey: key,
+        lastEdgeAt: last,
+        etaMs: last.getTime() + debounceMs - now.getTime(),
+      })
+    }
+  }
+  return { eligible, debounced }
+}
+
+/**
+ * Shared helper: enqueue a regen job for a single wiki via the same
+ * BullMQ producer the batch worker uses. Used by both the batch worker
+ * (after debounce filtering) and the on-demand `regen_now` MCP tool
+ * (which bypasses debounce intentionally).
+ *
+ * Returns `{ jobId, queuedAt }`. BullMQ collapses duplicate
+ * `regen-${wikiKey}` job ids on the producer side, so calling this
+ * twice in quick succession is a no-op.
+ */
+export async function enqueueWikiRegen(
+  wikiKey: string,
+  triggeredBy: 'scheduler' | 'manual'
+): Promise<{ jobId: string; queuedAt: string }> {
+  const jobId = crypto.randomUUID()
+  const queuedAt = new Date().toISOString()
+  await producer.enqueueRegen({
+    type: 'regen',
+    jobId,
+    objectKey: wikiKey,
+    objectType: 'wiki',
+    triggeredBy,
+    enqueuedAt: queuedAt,
+  })
+  return { jobId, queuedAt }
+}
+
+/**
+ * Validate a wikiKey or slug exists and is not soft-deleted. Returns
+ * the wiki's lookupKey + slug on hit, or null on miss. Used by the
+ * `regen_now` MCP tool for caller-friendly errors.
+ */
+export async function resolveWikiForRegen(
+  db: DB,
+  keyOrSlug: string
+): Promise<{ lookupKey: string; slug: string } | null> {
+  const trimmed = keyOrSlug.trim()
+  if (!trimmed) return null
+  // Try lookupKey first (exact), then slug.
+  const [byKey] = await db
+    .select({ lookupKey: wikis.lookupKey, slug: wikis.slug })
+    .from(wikis)
+    .where(and(eq(wikis.lookupKey, trimmed), isNull(wikis.deletedAt)))
+    .limit(1)
+  if (byKey) return byKey
+  const [bySlug] = await db
+    .select({ lookupKey: wikis.lookupKey, slug: wikis.slug })
+    .from(wikis)
+    .where(and(eq(wikis.slug, trimmed), isNull(wikis.deletedAt)))
+    .limit(1)
+  return bySlug ?? null
+}

--- a/core/src/queue/regen-debounce.ts
+++ b/core/src/queue/regen-debounce.ts
@@ -25,9 +25,10 @@
  * @see {@link handleRegenNow} -- on-demand bypass for the MCP tool
  ***********************************************************************/
 
-import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
+import { eq, and, isNull, inArray, sql, desc } from 'drizzle-orm'
+import { QUEUE_NAMES } from '@robin/queue'
 import type { DB } from '../db/client.js'
-import { wikis, edges } from '../db/schema.js'
+import { wikis, edges, fragments, pipelineEvents } from '../db/schema.js'
 import { producer } from './producer.js'
 
 /**
@@ -162,4 +163,179 @@ export async function resolveWikiForRegen(
     .where(and(eq(wikis.slug, trimmed), isNull(wikis.deletedAt)))
     .limit(1)
   return bySlug ?? null
+}
+
+/**
+ * Snapshot of the regen worker's current state, surfaced via the
+ * `regen_status` MCP tool. QA Issue 6's closing line: "add a 'regen
+ * happening now' indicator". Without this surface the user only
+ * notices regen via UI chip flicker; the cost is otherwise invisible.
+ */
+export interface RegenStatusSnapshot {
+  inFlight: { jobId: string; wikiKey: string; startedAt: string | null; triggeredBy: 'scheduler' | 'manual' | null }[]
+  debounced: { wikiKey: string; lastEdgeAt: string; etaToEligibleMs: number }[]
+  recent: { wikiKey: string | null; jobId: string; status: 'started' | 'completed' | 'failed'; startedAt: string; durationMs: number | null }[]
+  debounceMs: number
+}
+
+interface RegenJobPayload {
+  __sig?: string
+  type?: string
+  jobId?: string
+  objectKey?: string
+  triggeredBy?: 'scheduler' | 'manual'
+}
+
+/**
+ * Build a regen-status snapshot. Reads:
+ *   1. BullMQ active + waiting jobs on the regen queue (in-flight).
+ *   2. Wikis whose most-recent fragment edge falls inside the debounce
+ *      window (deferred regen candidates).
+ *   3. Recent `pipeline_events` rows scoped to `stage='regen'` for the
+ *      success-rate / latency view.
+ *
+ * No expensive aggregations -- this is a status pull, not a report.
+ */
+export async function getRegenStatus(
+  db: DB,
+  options: { recentLimit?: number } = {}
+): Promise<RegenStatusSnapshot> {
+  const recentLimit = Math.max(1, Math.min(options.recentLimit ?? 10, 100))
+
+  // ── 1. In-flight regen jobs (BullMQ) ─────────────────────────────────
+  // `getJobs` over active+waiting+delayed gives the live picture without
+  // needing any persistence layer. Failures here log-and-continue so
+  // status pulls degrade gracefully when redis blips.
+  const inFlight: RegenStatusSnapshot['inFlight'] = []
+  try {
+    const queue = producer.getQueue(QUEUE_NAMES.regen)
+    const jobs = await queue.getJobs(['active', 'waiting', 'delayed'], 0, 50)
+    for (const job of jobs) {
+      const data = job.data as RegenJobPayload
+      const wikiKey = data?.objectKey ?? ''
+      const jobId = (job.id as string) ?? data?.jobId ?? ''
+      const startedAt = job.processedOn ? new Date(job.processedOn).toISOString() : null
+      inFlight.push({
+        jobId,
+        wikiKey,
+        startedAt,
+        triggeredBy: data?.triggeredBy ?? null,
+      })
+    }
+  } catch {
+    // Redis unreachable -- inFlight stays empty. Caller can still use
+    // the rest of the snapshot.
+  }
+
+  // ── 2. Debounced wikis ───────────────────────────────────────────────
+  // Mirror the batch worker's Reason 1 + 2 candidate set, then run it
+  // through filterDebouncedWikiKeys. The user-visible "what's it waiting
+  // on?" view.
+  const debounced: RegenStatusSnapshot['debounced'] = []
+  try {
+    const debounceCandidates = new Set<string>()
+
+    const [unfiledCount] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(fragments)
+      .where(
+        and(
+          isNull(fragments.deletedAt),
+          sql`${fragments.embedding} IS NOT NULL`,
+          sql`${fragments.lookupKey} NOT IN (
+            SELECT src_id FROM edges
+            WHERE edge_type = 'FRAGMENT_IN_WIKI' AND deleted_at IS NULL
+          )`
+        )
+      )
+    if ((unfiledCount?.count ?? 0) > 0) {
+      const rows = await db
+        .select({ lookupKey: wikis.lookupKey })
+        .from(wikis)
+        .where(and(isNull(wikis.deletedAt), eq(wikis.regenerate, true)))
+      for (const r of rows) debounceCandidates.add(r.lookupKey)
+    }
+
+    const wikisWithNewFragments = await db
+      .select({ lookupKey: wikis.lookupKey })
+      .from(wikis)
+      .innerJoin(
+        edges,
+        and(
+          eq(edges.dstId, wikis.lookupKey),
+          eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+          isNull(edges.deletedAt)
+        )
+      )
+      .where(
+        and(
+          isNull(wikis.deletedAt),
+          eq(wikis.regenerate, true),
+          sql`${edges.createdAt} > COALESCE(${wikis.lastRebuiltAt}, '1970-01-01'::timestamptz)`
+        )
+      )
+      .groupBy(wikis.lookupKey)
+    for (const r of wikisWithNewFragments) debounceCandidates.add(r.lookupKey)
+
+    const { debounced: deferred } = await filterDebouncedWikiKeys(
+      db,
+      Array.from(debounceCandidates)
+    )
+    for (const d of deferred) {
+      debounced.push({
+        wikiKey: d.wikiKey,
+        lastEdgeAt: d.lastEdgeAt.toISOString(),
+        etaToEligibleMs: d.etaMs,
+      })
+    }
+  } catch {
+    // DB blip -- debounced stays empty rather than failing the whole call.
+  }
+
+  // ── 3. Recent regen events ───────────────────────────────────────────
+  // Pull the last N completed/failed/started rows for stage='regen'.
+  // The existing index `pipeline_events_status_stage_idx` makes this
+  // cheap. Pair started + completed by jobId for duration display.
+  const recent: RegenStatusSnapshot['recent'] = []
+  try {
+    const rows = await db
+      .select({
+        jobId: pipelineEvents.jobId,
+        status: pipelineEvents.status,
+        createdAt: pipelineEvents.createdAt,
+        metadata: pipelineEvents.metadata,
+      })
+      .from(pipelineEvents)
+      .where(eq(pipelineEvents.stage, 'regen'))
+      .orderBy(desc(pipelineEvents.createdAt))
+      .limit(recentLimit * 4)
+
+    // Group by jobId, keep the latest status for each (rows already
+    // ordered desc).
+    const seen = new Map<string, typeof rows[number]>()
+    for (const r of rows) {
+      if (!seen.has(r.jobId)) seen.set(r.jobId, r)
+      if (seen.size >= recentLimit) break
+    }
+    for (const r of seen.values()) {
+      const meta = (r.metadata ?? {}) as { wikiKey?: string; durationMs?: number }
+      const status = r.status as 'started' | 'completed' | 'failed'
+      recent.push({
+        wikiKey: meta.wikiKey ?? null,
+        jobId: r.jobId,
+        status,
+        startedAt: r.createdAt.toISOString(),
+        durationMs: typeof meta.durationMs === 'number' ? meta.durationMs : null,
+      })
+    }
+  } catch {
+    // Same fail-open posture.
+  }
+
+  return {
+    inFlight,
+    debounced,
+    recent,
+    debounceMs: regenDebounceMs(),
+  }
 }

--- a/core/src/queue/regen-status.test.ts
+++ b/core/src/queue/regen-status.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// QA Issue 6: getRegenStatus assembles the snapshot from BullMQ +
+// pipeline_events + the debounce filter. This test pins the wiring
+// shape -- not the BullMQ internals.
+
+const mockGetJobs = vi.fn()
+const mockGetQueue = vi.fn(() => ({ getJobs: mockGetJobs }))
+
+vi.mock('../queue/producer.js', () => ({
+  producer: {
+    getQueue: (...args: unknown[]) => mockGetQueue(...args),
+  },
+}))
+
+vi.mock('@robin/queue', () => ({
+  QUEUE_NAMES: {
+    regen: 'regen-queue',
+  },
+}))
+
+const dbResponseQueue: unknown[][] = []
+
+function stageDbResponses(responses: unknown[][]) {
+  dbResponseQueue.length = 0
+  dbResponseQueue.push(...responses)
+}
+
+function popResponse(): unknown[] {
+  return dbResponseQueue.shift() ?? []
+}
+
+vi.mock('../db/client.js', () => {
+  function thenable() {
+    return {
+      // biome-ignore lint/suspicious/noThenProperty: drizzle thenable mock
+      then: (onFulfilled: (v: unknown[]) => unknown) =>
+        Promise.resolve(popResponse()).then(onFulfilled),
+    }
+  }
+  function selectChain() {
+    return {
+      from: () => ({
+        where: () => ({
+          ...thenable(),
+          groupBy: () => thenable(),
+          orderBy: () => ({
+            limit: () => thenable(),
+          }),
+          limit: () => thenable(),
+        }),
+        innerJoin: () => ({
+          where: () => ({
+            groupBy: () => thenable(),
+          }),
+        }),
+      }),
+    }
+  }
+  return {
+    db: {
+      select: () => selectChain(),
+    },
+  }
+})
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookupKey',
+    slug: 'wikis.slug',
+    deletedAt: 'wikis.deletedAt',
+    regenerate: 'wikis.regenerate',
+    state: 'wikis.state',
+    updatedAt: 'wikis.updatedAt',
+    lastRebuiltAt: 'wikis.lastRebuiltAt',
+    autoRegen: 'wikis.autoRegen',
+    lifecycleState: 'wikis.lifecycleState',
+  },
+  edges: {
+    dstId: 'edges.dstId',
+    srcId: 'edges.srcId',
+    edgeType: 'edges.edgeType',
+    deletedAt: 'edges.deletedAt',
+    createdAt: 'edges.createdAt',
+  },
+  fragments: {
+    lookupKey: 'fragments.lookupKey',
+    deletedAt: 'fragments.deletedAt',
+    embedding: 'fragments.embedding',
+  },
+  pipelineEvents: {
+    jobId: 'pipeline_events.job_id',
+    status: 'pipeline_events.status',
+    stage: 'pipeline_events.stage',
+    createdAt: 'pipeline_events.created_at',
+    metadata: 'pipeline_events.metadata',
+  },
+}))
+
+const { getRegenStatus } = await import('./regen-debounce.js')
+const { db: mockDb } = await import('../db/client.js')
+
+describe('getRegenStatus — snapshot assembly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbResponseQueue.length = 0
+    delete process.env.REGEN_DEBOUNCE_MS
+  })
+
+  it('returns inFlight, debounced, and recent in the documented shape', async () => {
+    process.env.REGEN_DEBOUNCE_MS = '300000'
+
+    // Active BullMQ regen jobs.
+    mockGetJobs.mockResolvedValueOnce([
+      {
+        id: 'regen-wiki01abc',
+        data: { type: 'regen', jobId: 'j-1', objectKey: 'wiki01abc', triggeredBy: 'manual' },
+        processedOn: 1_700_000_000_000,
+      },
+    ])
+
+    const now = Date.now()
+    const fresh = new Date(now - 30_000) // inside 5min window
+    stageDbResponses([
+      // unfiled count
+      [{ count: 0 }],
+      // wikis with new fragments (innerJoin path)
+      [{ lookupKey: 'wiki-debounced' }],
+      // filterDebouncedWikiKeys edges query
+      [{ wikiKey: 'wiki-debounced', lastEdgeAt: fresh }],
+      // pipelineEvents.recent
+      [
+        {
+          jobId: 'past-1',
+          status: 'completed',
+          createdAt: new Date('2026-05-08T11:50:00.000Z'),
+          metadata: { wikiKey: 'wiki-recent', durationMs: 92_000 },
+        },
+      ],
+    ])
+
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+    const snap = await getRegenStatus(mockDb as any, { recentLimit: 5 })
+
+    expect(snap.debounceMs).toBe(300_000)
+    expect(snap.inFlight).toHaveLength(1)
+    expect(snap.inFlight[0].wikiKey).toBe('wiki01abc')
+    expect(snap.inFlight[0].triggeredBy).toBe('manual')
+    expect(snap.inFlight[0].startedAt).toBe(new Date(1_700_000_000_000).toISOString())
+
+    expect(snap.debounced).toHaveLength(1)
+    expect(snap.debounced[0].wikiKey).toBe('wiki-debounced')
+    expect(snap.debounced[0].etaToEligibleMs).toBeGreaterThan(0)
+
+    expect(snap.recent).toHaveLength(1)
+    expect(snap.recent[0]).toMatchObject({
+      jobId: 'past-1',
+      status: 'completed',
+      wikiKey: 'wiki-recent',
+      durationMs: 92_000,
+    })
+  })
+
+  it('degrades gracefully when redis is unreachable (inFlight empty, others still populated)', async () => {
+    process.env.REGEN_DEBOUNCE_MS = '300000'
+    mockGetJobs.mockRejectedValueOnce(new Error('redis EOF'))
+
+    stageDbResponses([
+      [{ count: 0 }],
+      [],
+      [],
+    ])
+
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle stub
+    const snap = await getRegenStatus(mockDb as any)
+    expect(snap.inFlight).toEqual([])
+    expect(Array.isArray(snap.debounced)).toBe(true)
+    expect(Array.isArray(snap.recent)).toBe(true)
+  })
+})

--- a/core/src/queue/regen-status.test.ts
+++ b/core/src/queue/regen-status.test.ts
@@ -100,7 +100,7 @@ vi.mock('../db/schema.js', () => ({
 const { getRegenStatus } = await import('./regen-debounce.js')
 const { db: mockDb } = await import('../db/client.js')
 
-describe('getRegenStatus — snapshot assembly', () => {
+describe('getRegenStatus - snapshot assembly', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     dbResponseQueue.length = 0

--- a/core/src/queue/regen-worker.audit.test.ts
+++ b/core/src/queue/regen-worker.audit.test.ts
@@ -40,23 +40,24 @@ function popResponse(): unknown[] {
 }
 
 vi.mock('../db/client.js', () => {
+  function thenable() {
+    return {
+      // biome-ignore lint/suspicious/noThenProperty: drizzle thenable mock
+      then: (onFulfilled: (v: unknown[]) => unknown) =>
+        Promise.resolve(popResponse()).then(onFulfilled),
+    }
+  }
   function selectChain() {
     return {
       from: () => ({
         where: () => ({
-          // batch processor calls .where() (thenable) and .where().groupBy() — both
-          // pop one queue entry.
-          // biome-ignore lint/suspicious/noThenProperty: drizzle thenable mock
-          then: (onFulfilled: (v: unknown[]) => unknown) =>
-            Promise.resolve(popResponse()).then(onFulfilled),
+          ...thenable(),
+          // The debounce helper appends `.groupBy(...)` after `.where(...)`.
+          groupBy: () => thenable(),
         }),
         innerJoin: () => ({
           where: () => ({
-            groupBy: () => ({
-              // biome-ignore lint/suspicious/noThenProperty: drizzle thenable mock
-              then: (onFulfilled: (v: unknown[]) => unknown) =>
-                Promise.resolve(popResponse()).then(onFulfilled),
-            }),
+            groupBy: () => thenable(),
           }),
         }),
       }),

--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -3,10 +3,10 @@ import { eq, and, isNull, sql } from 'drizzle-orm'
 import { db } from '../db/client.js'
 import { wikis, edges, fragments } from '../db/schema.js'
 import { regenerateWiki } from '../lib/regen.js'
-import { producer } from './producer.js'
 import { logger } from '../lib/logger.js'
 import { emitAuditEvent } from '../db/audit.js'
 import { emitPipelineEvent } from '../db/pipeline-events.js'
+import { enqueueWikiRegen, filterDebouncedWikiKeys, regenDebounceMs } from './regen-debounce.js'
 
 const log = logger.child({ component: 'regen-worker' })
 
@@ -85,7 +85,12 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
   log.info({ jobId: job.jobId }, 'processing regen batch job')
 
   try {
-    const candidateKeys = new Set<string>()
+    // Reasons 1 and 2 are ingest-driven and pay LLM cost for ground that
+    // shifts under them when fragments are still arriving -- gate via
+    // the per-wiki debounce (#QA Issue 6, 2026-05-08). Reasons 3 and 4
+    // are recovery and explicit-cadence paths, so they bypass.
+    const debounceCandidates = new Set<string>()
+    const bypassCandidates = new Set<string>()
 
     // ── Reason 1: Unfiled fragments exist → regen ALL wikis (mechanism #1 classifies them) ──
     const [unfiledCount] = await db
@@ -109,7 +114,7 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
         .select({ lookupKey: wikis.lookupKey })
         .from(wikis)
         .where(and(isNull(wikis.deletedAt), eq(wikis.regenerate, true)))
-      for (const r of rows) candidateKeys.add(r.lookupKey)
+      for (const r of rows) debounceCandidates.add(r.lookupKey)
       log.info({ unfiled: unfiledCount?.count, wikis: rows.length }, 'batch: unfiled fragments → regen-enabled wikis')
     }
 
@@ -133,7 +138,7 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
         )
       )
       .groupBy(wikis.lookupKey)
-    for (const r of wikisWithNewFragments) candidateKeys.add(r.lookupKey)
+    for (const r of wikisWithNewFragments) debounceCandidates.add(r.lookupKey)
     if (wikisWithNewFragments.length > 0) {
       log.info({ count: wikisWithNewFragments.length }, 'batch: wikis with new fragments since last rebuild')
     }
@@ -141,6 +146,8 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
     // ── Reason 3: Wikis stuck in non-RESOLVED state ──
     // Respect the LINKING lock: only pick up LINKING wikis if they've been
     // stuck for over 15 minutes (stale lock from a crashed worker).
+    // Recovery path -- bypasses debounce; a stuck wiki should not wait
+    // on quiet-window heuristics.
     const stuckWikis = await db
       .select({ lookupKey: wikis.lookupKey })
       .from(wikis)
@@ -151,7 +158,7 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
           sql`(${wikis.state} != 'LINKING' OR ${wikis.updatedAt} < NOW() - INTERVAL '15 minutes')`,
         )
       )
-    for (const r of stuckWikis) candidateKeys.add(r.lookupKey)
+    for (const r of stuckWikis) bypassCandidates.add(r.lookupKey)
     if (stuckWikis.length > 0) {
       log.info({ count: stuckWikis.length }, 'batch: wikis in non-RESOLVED state')
     }
@@ -160,6 +167,8 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
     // Andrew lock #259: midnight cron sweeps wikis the user has explicitly
     // opted into auto-regen for, where new fragments have landed since the
     // last regen (lifecycle_state='learning' is the dirty-state tag from E8).
+    // Explicit-cadence path -- bypasses debounce; the cron firing is the
+    // intended trigger.
     const autoRegenWikis = await db
       .select({ lookupKey: wikis.lookupKey })
       .from(wikis)
@@ -170,10 +179,29 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
           eq(wikis.lifecycleState, 'learning')
         )
       )
-    for (const r of autoRegenWikis) candidateKeys.add(r.lookupKey)
+    for (const r of autoRegenWikis) bypassCandidates.add(r.lookupKey)
     if (autoRegenWikis.length > 0) {
       log.info({ count: autoRegenWikis.length }, 'batch: auto-regen wikis with learning state')
     }
+
+    // Filter ingest-driven candidates against the per-wiki quiet window.
+    // Anything still chatty drops out -- the next batch tick re-evaluates.
+    const debounceCandidateList = Array.from(debounceCandidates)
+    const { eligible: debouncePassed, debounced } = await filterDebouncedWikiKeys(
+      db,
+      debounceCandidateList
+    )
+
+    if (debounced.length > 0) {
+      log.info(
+        { count: debounced.length, debounceMs: regenDebounceMs() },
+        'batch: wikis still inside debounce window, deferring regen'
+      )
+    }
+
+    // Bypass set wins: a wiki that is also stuck or auto-regen-due
+    // should not be silenced by the debounce on the same row.
+    const candidateKeys = new Set<string>([...debouncePassed, ...bypassCandidates])
 
     // ── Enqueue individual regen jobs (capped at BATCH_LIMIT) ──
     // Per-item failures previously logged a warn and disappeared (#273) — the
@@ -185,14 +213,7 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
     let failed = 0
     for (const wikiKey of wikiKeysToRegen) {
       try {
-        await producer.enqueueRegen({
-          type: 'regen',
-          jobId: crypto.randomUUID(),
-          objectKey: wikiKey,
-          objectType: 'wiki',
-          triggeredBy: 'scheduler',
-          enqueuedAt: new Date().toISOString(),
-        })
+        await enqueueWikiRegen(wikiKey, 'scheduler')
         enqueued++
       } catch (err) {
         failed++
@@ -210,7 +231,17 @@ export async function processRegenBatchJob(job: RegenBatchJob): Promise<JobResul
     }
 
     log.info(
-      { jobId: job.jobId, enqueued, failed, hasUnfiled, candidates: candidateKeys.size, capped: wikiKeysToRegen.length },
+      {
+        jobId: job.jobId,
+        enqueued,
+        failed,
+        hasUnfiled,
+        debounceCandidates: debounceCandidates.size,
+        debouncePassed: debouncePassed.length,
+        debounced: debounced.length,
+        bypass: bypassCandidates.size,
+        capped: wikiKeysToRegen.length,
+      },
       'regen batch completed'
     )
 


### PR DESCRIPTION
## Summary
- Per-wiki regen debounce (5-minute default, env-tunable via `REGEN_DEBOUNCE_MS`) collapses bursts of fragment arrivals into ~1 regen instead of ~5 to 10
- New MCP tool `regen_now(wikiKey)` triggers regen on demand, bypassing debounce, with audit trail
- New MCP tool `regen_status` exposes in-flight, debounced, and recent regens for cost visibility
- No migration; debounce is computed from `MAX(edges.created_at)` per wiki + existing `last_rebuilt_at`

## What changed for the user
Active ingest sessions no longer trigger a regen storm. A wiki whose newest FRAGMENT_IN_WIKI edge landed within the last 5 minutes drops out of automatic regen Reasons 1 and 2 (unfiled-fragments, new-edges). Reasons 3 (state-recovery) and 4 (midnight cron) bypass the debounce since those are recovery and explicit-cadence paths. AI agents and operators can call `regen_now(wikiKey)` to force a regen regardless of debounce. `regen_status` returns `{ inFlight, debounced, recent, debounceMs }` so cost is observable instead of invisible.

## What was true before
On a live deployment 2026-05-08, ingesting 89 entries (534 fragments) triggered 27 back-to-back regen jobs over ~45 minutes. Each was ~70 to 180 seconds of LLM work, often superseded by the next batch of fragment arrivals before the output mattered. Three of the four trigger reasons fired continuously during active ingest. Net cost surface: 27 regens for one ingest session, with no on-demand surface for the cases where regen was actually wanted.

## Operational notes
- No migration. Debounce derived from existing columns + `last_rebuilt_at`.
- Env var: `REGEN_DEBOUNCE_MS` (default 300000 = 5 min). Documented in `core/.env.example`.
- Flag semantics for `regenerate` and `auto_regen` are unchanged. v0.2.2 Stream T4 will reconcile them per Option C: drop `regenerate`, make `auto_regen` the sole gate, default false (BREAKING; opt-in everywhere).
- Pairs with v0.2.2 Stream U (settings UI for per-wiki regen toggles).

## Test plan
- [ ] UAT plan: `.uat/plans/70-regen-debounce-and-regen-now.md`
- [ ] Burst-ingest 30 fragments produces ~1 regen instead of ~5 to 10
- [ ] `regen_now` triggers regen even within debounce window
- [ ] `regen_status` returns sensible payload
- [ ] Quiet wiki regens normally after debounce window elapses