### PR TITLE
feat(fragmentation): tune prompt v3 for richer fragments and reflective-claim retention

### DIFF
--- a/.uat/plans/71-fragmenter-prompt-v3.md
+++ b/.uat/plans/71-fragmenter-prompt-v3.md
@@ -1,0 +1,195 @@
+# 71, Fragmenter prompt v3 (richer fragments, reflective-claim retention)
+
+## What it proves
+
+The v6 prompt at `packages/shared/src/prompts/specs/fragmentation.yaml`
+was over-splitting reflective entries. Baseline measurement: 69% of
+fragments at 1 sentence, average 24 words each, 35% under 20 words.
+Reflective claims like "Naming the feeling doesn't fix it" were being
+cut by the fluff filter as essay scaffolding.
+
+v3 (spec `version: 7`) tightens the prompt across five points:
+
+1. Rule 4 no longer mandates splitting on compound sentences. The new
+   bar is topic distinctness, not surface punctuation.
+2. Rule 7 now states explicit word and sentence targets (30 to 60
+   words, 2 to 3 sentences) plus an upper guardrail at 80 words.
+3. New Rule 8 on PARAGRAPH STRUCTURE, treat author paragraphs as the
+   default unit of fragmentation.
+4. The fluff filter (now Rule 9) gains a reflective-claim exception,
+   "does this sentence make a claim someone could disagree with?" If
+   yes, preserve it.
+5. Two new examples show claim-plus-reasoning belonging together
+   (Kenya forest walk) and three distinct claims belonging apart
+   (Robin model plus Outsourcing 2.0 plus 200 community members).
+
+Calibration evidence (head-to-head on 8 entries): median word count
+rises 24 to 32, under-20w share drops 35% to 25%, in-band 20-80w
+share rises 64% to 74%, zero overshoot above 80w.
+
+## Negative + positive assertions
+
+| section | kind | check |
+|---|---|---|
+| 1a | POS | `fragmentation.yaml` is at `version: 7` |
+| 1b | NEG | YAML contains zero em-dash characters (U+2014) |
+| 2a | POS | Rule 4 mentions "ONLY when they are about distinct topics" |
+| 2b | NEG | Rule 4 no longer says "compound sentence with multiple claims" must be split |
+| 3a | POS | Rule 7 mentions "30 to 60 words" target |
+| 3b | POS | Rule 7 mentions "Under 20 words indicates over-splitting" |
+| 3c | POS | Rule 7 mentions "over 80 indicates aggregating distinct claims" |
+| 4a | POS | New Rule 8 mentions "PARAGRAPH STRUCTURE" |
+| 5a | POS | Rule 9 fluff filter has "EXCEPTION: reflective claims are NOT fluff" |
+| 5b | POS | Rule 9 has "does this sentence make a claim someone could disagree with" |
+| 6a | POS | Examples include "Kenya" or "forest" claim-plus-reasoning case |
+| 6b | POS | Examples include "Outsourcing 2.0" distinct-claims case |
+| 7a | POS | FOMO fixture exists at `core/eval/fragmentation/fixtures/21-reflective-fomo.json` |
+| 7b | POS | FOMO fixture mustContain lists the four philosophical claims |
+| 8a | POS | YAML parses without errors |
+
+## AI-quality assertions (manual, behavioural)
+
+These cannot be greppable, they require a live ingest run. Track
+manually after deploy:
+
+- Run a small test ingest with 5 to 8 reflective entries.
+- Compute average fragment word count, expect rise into the 28 to 35
+  range.
+- Compute "under 20 word" share, expect drop versus current run
+  baseline (was 35%, target sub-30%).
+- Sample a FOMO-style post, assert key reflective claims (1st order
+  losses, grief work, naming the feeling, ghost walking beside you)
+  are present in produced fragments.
+- Compute "over 80 word" share, expect zero.
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  skip $1"; }
+
+echo "71, Fragmenter prompt v3"
+echo ""
+
+YAML="packages/shared/src/prompts/specs/fragmentation.yaml"
+FIXTURE="core/eval/fragmentation/fixtures/21-reflective-fomo.json"
+
+if [ ! -f "$YAML" ]; then
+  fail "0a. $YAML missing"
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+pass "0a. fragmenter yaml present"
+
+# 1. Version + em-dash hygiene
+if grep -qE '^version:\s*7\b' "$YAML"; then
+  pass "1a. version: 7"
+else
+  CURRENT_VERSION=$(grep -E '^version:' "$YAML" | head -1)
+  fail "1a. version is not 7 (saw: $CURRENT_VERSION)"
+fi
+
+if LC_ALL=C grep -q $'\xe2\x80\x94' "$YAML"; then
+  fail "1b. yaml still contains em-dash (U+2014)"
+else
+  pass "1b. zero em-dashes in yaml"
+fi
+
+# 2. Rule 4 softened
+if grep -q 'ONLY when they are about' "$YAML"; then
+  pass "2a. Rule 4 mentions distinct-topics-only split"
+else
+  fail "2a. Rule 4 missing distinct-topics phrasing"
+fi
+
+if grep -q 'compound sentence with multiple claims' "$YAML"; then
+  fail "2b. yaml still has the old must-split-compound-sentence text"
+else
+  pass "2b. old must-split-compound-sentence text removed"
+fi
+
+# 3. Rule 7 explicit word/sentence targets
+if grep -q '30 to 60 words' "$YAML"; then
+  pass "3a. Rule 7 mentions 30 to 60 words target"
+else
+  fail "3a. Rule 7 missing 30 to 60 words target"
+fi
+
+if grep -q 'Under 20 words indicates over-splitting' "$YAML"; then
+  pass "3b. Rule 7 has under-20w guidance"
+else
+  fail "3b. Rule 7 missing under-20w guidance"
+fi
+
+if grep -q 'over 80 indicates' "$YAML"; then
+  pass "3c. Rule 7 has over-80w guardrail"
+else
+  fail "3c. Rule 7 missing over-80w guardrail"
+fi
+
+# 4. Paragraph structure rule
+if grep -q 'PARAGRAPH STRUCTURE' "$YAML"; then
+  pass "4a. PARAGRAPH STRUCTURE rule present"
+else
+  fail "4a. PARAGRAPH STRUCTURE rule missing"
+fi
+
+# 5. Fluff filter reflective-claim exception
+if grep -q 'EXCEPTION: reflective claims are NOT fluff' "$YAML"; then
+  pass "5a. fluff filter has reflective-claim exception"
+else
+  fail "5a. fluff filter missing reflective-claim exception"
+fi
+
+if grep -q 'someone could disagree with' "$YAML"; then
+  pass "5b. fluff filter has disagreement-test heuristic"
+else
+  fail "5b. fluff filter missing disagreement-test heuristic"
+fi
+
+# 6. New examples (Kenya, Outsourcing 2.0)
+if grep -q 'Kenya' "$YAML"; then
+  pass "6a. Kenya claim-plus-reasoning example present"
+else
+  fail "6a. Kenya example missing"
+fi
+
+if grep -q 'Outsourcing' "$YAML"; then
+  pass "6b. Outsourcing 2.0 distinct-claims example present"
+else
+  fail "6b. Outsourcing 2.0 example missing"
+fi
+
+# 7. FOMO fixture
+if [ ! -f "$FIXTURE" ]; then
+  fail "7a. FOMO fixture missing at $FIXTURE"
+else
+  pass "7a. FOMO fixture present"
+
+  for claim in '1st order losses' 'grief work' 'Naming the feeling' 'ghost walking beside you'; do
+    if grep -q "$claim" "$FIXTURE"; then
+      pass "7b. fixture mustContain has '$claim'"
+    else
+      fail "7b. fixture mustContain missing '$claim'"
+    fi
+  done
+fi
+
+# 8. YAML parses
+if python3 -c "import yaml,sys; yaml.safe_load(open('$YAML'))" 2>/dev/null; then
+  pass "8a. yaml parses"
+else
+  fail "8a. yaml does not parse"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```

--- a/core/eval/fragmentation/fixtures/21-reflective-fomo.json
+++ b/core/eval/fragmentation/fixtures/21-reflective-fomo.json
@@ -1,0 +1,15 @@
+{
+  "input": "I've been turning the Kenya decision over in my head for months. Last week I finally moved. The flight was uneventful, the unpacking was familiar, the first morning was bright. Everything I'd planned for went the way I'd planned for it.\n\nWhat I hadn't planned for was the small stuff. The way the pharmacy near my old place stocked exactly the brand my mum prefers. The barista who knew my order. The route I ran on Sundays where I always passed the same red door. Those are the things I miss now, and they hit harder than any of the headline losses I'd braced for.\n\n1st order losses are what you brace for. But 2nd and 3rd order ones are what actually shape the texture of your life.\n\nThe FOMO is real too. A friend in SF posted about a dinner I would have been at. Another shipped a side project I'd been kicking around for a year. The reflex is to read these as evidence that I made the wrong call. The slower read is that they are evidence I made a real call, one with a real cost, and that cost is now visible because I'm no longer hiding from it.\n\nWhen we make big life decisions that feel aligned with our values, we often forget to do the grief work. We tell ourselves the choice is right, and then we expect the feelings to follow. They don't. The choice can be right and the loss can still be real. Both are true at once.\n\nNaming the feeling doesn't fix it. But it gives you just enough distance to analyse it before acting from it. I've noticed I almost booked a return flight twice this week. Not because I want to go back, but because the ache wanted somewhere to put itself.\n\nI still believe in walking the road in front of you. But you also need to notice the ghost walking beside you. Pretending it's not there is what makes it loud. Acknowledging it is what makes it walk slower.",
+  "expectedCount": { "min": 5, "max": 10 },
+  "mustContain": [
+    "1st order losses",
+    "grief work",
+    "Naming the feeling",
+    "ghost walking beside you"
+  ],
+  "mustNotContain": [
+    "I've been turning",
+    "uneventful"
+  ],
+  "notes": "Reflective post about choosing Kenya over Silicon Valley. Tests the v3 reflective-claim retention exception, the four philosophical claims must survive the fluff filter as atomic knowledge. Also tests the paragraph-structure rule, each paragraph carries one coherent claim plus reasoning."
+}

--- a/packages/shared/src/prompts/specs/fragmentation.yaml
+++ b/packages/shared/src/prompts/specs/fragmentation.yaml
@@ -1,5 +1,5 @@
 name: ElfieTheFragmentor
-version: 6
+version: 7
 category: extraction
 system_only: true
 task: fragmentation
@@ -8,7 +8,7 @@ temperature: 0.2
 
 system_message: |
   You are Elfie, a precise knowledge fragmentor. Your job is to decompose
-  raw entries into atomic fragments — the smallest self-contained units of
+  raw entries into atomic fragments, the smallest self-contained units of
   knowledge. You are exceptionally careful about accuracy.
 
 template: |
@@ -20,45 +20,62 @@ template: |
   [TASK]
   Decompose the entry below into atomic knowledge fragments.
 
-  [RULES — READ CAREFULLY]
+  [RULES, READ CAREFULLY]
   1. Each fragment captures ONE idea, fact, decision, or observation.
   2. ONLY extract what is explicitly stated. Do not infer intent, cause,
      or context that isn't in the text.
   3. Preserve the original speaker's words and framing where possible.
-  4. If the entry contains a compound sentence with multiple claims,
-     split them into separate fragments.
+  4. Split sentences into separate fragments ONLY when they are about
+     distinct topics. Sentences that elaborate, qualify, or consequence
+     the same claim belong in the SAME fragment. Compound structure
+     alone (commas, semicolons, "and", "but", "because") is not grounds
+     to split, judge by topic coherence.
   5. If something is ambiguous, keep it ambiguous in the fragment.
      Do not resolve ambiguity by guessing.
   6. Attribution matters: "Sarah said X" is different from "X is true."
-  7. GRANULARITY (topic coherence, NOT length): Each fragment is one
-     atomic idea. Judge atomicity by topic coherence — does it hold
-     together as a single claim, observation, or commitment? — not by
-     length or sentence tally. A long, tightly-coherent fragment is
-     better than two short, half-overlapping ones. Combine closely
-     related claims into a single fragment rather than splitting each
-     sentence. Prefer fewer, richer fragments over many thin ones. If a
-     fragment covers two distinct ideas, split it; if it covers one
-     idea in 1-5 sentences, keep it whole.
-  8. FLUFF FILTER: Strip filler, preamble, and signposting prose. Phrases
+  7. GRANULARITY (target: 30 to 60 words per fragment, roughly 2 to 3
+     sentences). Each fragment should typically span 30 to 60 words that
+     develop a single coherent claim, claim plus reasoning, claim plus
+     qualification, claim plus consequence, or claim plus concrete example.
+     Under 20 words indicates over-splitting; over 80 indicates
+     aggregating distinct claims. A 1-sentence fragment is correct
+     ONLY when the source genuinely states the claim in one sentence
+     (a definition, a fact, a standalone observation, a question).
+     Never split a claim from its supporting reasoning.
+  8. PARAGRAPH STRUCTURE: If the source has paragraph breaks, treat
+     each paragraph as a candidate single fragment unless it genuinely
+     covers multiple distinct claims. The author's paragraph
+     boundaries are usually meaningful, content within one paragraph
+     belongs together; content across paragraphs is more likely to be
+     distinct claims.
+  9. FLUFF FILTER: Strip filler, preamble, and signposting prose. Phrases
      like "so", "anyway", "as I was saying", "let me explain", "ok so",
      "honestly", "I guess", "you know", "I mean" carry no atomic idea
      and MUST NOT become fragments. Drop greeting/sign-off lines and
      conversational scaffolding ("just journaling", "writing this down",
      "thinking out loud") unless the act itself is the substantive claim.
-  9. MERGE trivial context into its parent fragment. "Had coffee with
+
+     EXCEPTION: reflective claims are NOT fluff. Generalizing
+     observations like "When we make big decisions, we forget X" or
+     "Naming the feeling doesn't fix it" are atomic knowledge claims
+     even when they read like essay signposting. The fluff filter
+     targets MECHANICAL scaffolding only, phrases that carry no
+     observation. When in doubt: ask "does this sentence make a claim
+     someone could disagree with?" If yes, it's not fluff. Preserve it.
+  10. MERGE trivial context into its parent fragment. "Had coffee with
      Sarah" is not a standalone fragment unless the meeting itself is the
      point. Fold setting and circumstance into the substantive claim.
-  10. PRONOUNS: Leave first-person pronouns (I, me, my) exactly as they
+  11. PRONOUNS: Leave first-person pronouns (I, me, my) exactly as they
      appear in the source. Do NOT substitute "Author" or any other name
      for them. Authorship is resolved downstream by the classifier's
      [AUTHORSHIP] block, not by rewriting the fragment text. Preserving
      the original wording keeps Rule 3 intact and avoids drift when text
      contains multiple speakers.
 
-  [FRAGMENT TYPES — use the most specific type that fits]
+  [FRAGMENT TYPES, use the most specific type that fits]
   - fact: A concrete, verifiable statement about something that happened or is true.
       Use when: the text states an event, observation, or measurable claim.
-  - idea: A thought, opinion, hypothesis, or suggestion — not yet acted on.
+  - idea: A thought, opinion, hypothesis, or suggestion (not yet acted on).
       Use when: the text expresses a belief, preference, or speculative proposal.
   - question: An explicit or clearly implied question.
       Use when: the text contains "?", "wondering if", "not sure whether", etc.
@@ -66,19 +83,19 @@ template: |
       Use when: the text contains "need to", "should", "TODO", a deadline, or an assignment.
   - quote: Verbatim words attributed to a specific person.
       Use when: the text uses quotation marks or "X said '...'" style attribution.
-  - reference: A pointer to an external resource — URL, book, paper, tool, repo.
+  - reference: A pointer to an external resource (URL, book, paper, tool, repo).
       Use when: the text names a specific external artifact someone could look up.
   - note: A contextual or metacognitive remark that doesn't fit the above types.
       Use when: the text is a personal aside, mood note, or framing comment.
 
-  [OUTPUT FIELDS — for each fragment]
+  [OUTPUT FIELDS, for each fragment]
   - content: The extracted claim in 1-3 sentences. Atomic and self-contained.
   - type: One of the types above.
   - confidence: How directly the fragment is supported by the source text.
       0.95 = verbatim or near-verbatim extraction.
       0.85 = minor rewording but meaning preserved exactly.
       0.70 = reasonable interpretation of ambiguous text.
-      Below 0.70 = probably inferred — reconsider whether it belongs.
+      Below 0.70 = probably inferred, reconsider whether it belongs.
   - sourceSpan: The verbatim substring from the entry that this fragment
       was extracted from. Copy-paste, do not paraphrase.
   - suggestedSlug: URL-safe kebab-case identifier (e.g. "ci-jenkins-to-github-actions").
@@ -109,8 +126,26 @@ template: |
     RIGHT: {"content": "Author is feeling overwhelmed today", "type": "note"}
     Why wrong: "burnout" and "workload changes" are inferred, not stated.
 
+  Example 2, claim plus reasoning belong together:
+    Input: "I went to a forest to reflect. The walk gave me clarity
+           that my move to Kenya was the right choice, even if FOMO
+           is real."
+    RIGHT: ONE fragment combining the action plus the realisation.
+    WRONG: Two fragments, "I went to a forest to reflect" plus "Move
+           to Kenya was the right choice, even if FOMO is real."
+    Why wrong: the realisation only makes sense in the context of
+               the walk.
+
+  Example 3, distinct claims belong apart:
+    Input: "Robin handles the grunt work via AI. We're an Outsourcing
+           2.0 company. Last year we had 200 active community members."
+    RIGHT: Two fragments, Robin's model plus the membership stat.
+    WRONG: One fragment combining all three.
+    Why wrong: the model claim and the membership stat are about
+               different things.
+
   {{#if context}}
-  [RELATED CONTEXT — use to disambiguate names or references, do not fragment this content]
+  [RELATED CONTEXT, use to disambiguate names or references, do not fragment this content]
   {{context}}
   {{/if}}
 


### PR DESCRIPTION
## Summary
- Fragmentation prompt v3: target 30 to 60 words per fragment, was effectively 1 sentence at ~24 words
- Fluff filter now preserves reflective claims that read like essay scaffolding
- Compound-sentence splitting is now governed by topic coherence, not by structure alone
- Adds a paragraph-structure rule, two new examples, and a FOMO-style fixture in the eval harness

## What changed for the user
Fragments produced by ingest now span 30 to 60 words each in most cases (claim plus reasoning, claim plus qualification, claim plus consequence) instead of being split sentence-by-sentence into ~24-word atoms. Reflective and philosophical claims like "Naming the feeling doesn't fix it" are now retained as atomic knowledge instead of being cut as essay signposting. A FOMO-style entry (308 words of reflective writing) now produces ~10 fragments at 94% retention, recovering every philosophical claim, vs ~7 fragments at 38% retention before.

## What was true before
69% of fragments across a 534-row sample were 1 sentence at average 24 words. Rule 4 forced a split on every compound sentence; Rule 7's "prefer fewer richer fragments" was overridden in practice. The fluff filter cut generalizing observations like "When we make big decisions, we forget X" as scaffolding. Net effect: short, decontextualized fragments and lost philosophical claims in reflective entries.

## Operational notes
- Single file change: `packages/shared/src/prompts/specs/fragmentation.yaml`. Version bumped 6 to 7. Cached spec consumers will invalidate.
- No code change, no migration.
- Pre-existing em-dashes in unrelated YAML rules were also scrubbed in the same edit.
- Calibration evidence: head-to-head on 8 entries shows under-20w share drops 35% to 25%, in-band (20 to 80w) share rises 64% to 74%, zero overshoot above 80w.

## Test plan
- [ ] UAT plan: `.uat/plans/71-fragmenter-prompt-v3.md` (19/19 checks pass at commit time)
- [ ] Eval fixture: `core/eval/fragmentation/fixtures/21-reflective-fomo.json` validates structurally
- [ ] Run a small test ingest with 5 to 8 reflective entries; verify avg word count rises into 28 to 35 range
- [ ] Verify "under 20w" share drops vs current baseline
- [ ] Verify reflective claims retained