### PR TITLE
feat(regen): drop legacy USER EDITS block and align Quill prompt partition headers

### DIFF
--- a/.uat/plans/82-regen-partition-and-user-edits-drop.md
+++ b/.uat/plans/82-regen-partition-and-user-edits-drop.md
@@ -1,0 +1,201 @@
+# 82, Regen partition headers and [USER EDITS] block drop
+
+## What it proves
+
+Stream R closes the gap between v0.2.0 E1 partition logic in
+`core/src/lib/regen.ts` and the wiki-type Quill prompts in
+`packages/shared/src/prompts/specs/wiki-types/`. Three pieces ship
+together:
+
+1. A contract test at `core/src/lib/regen.partition.test.ts`
+   captures the Quill prompt and asserts it carries the partition
+   headers (`[NEW FRAGMENTS`, `[UPDATED FRAGMENTS`, `[REMOVED
+   FRAGMENTS`) without leaking a flat `[FRAGMENTS]` wrapper or a
+   legacy `[USER EDITS]` block.
+2. The legacy `[USER EDITS]` block is removed from all ten
+   wiki-type YAMLs (agent, belief, decision, log, objective,
+   principle, project, research, skill, voice). Phyl flagged the
+   block as dead context in v0.2.0 review, fragment-edit history
+   already feeds the UPDATED partition the worker emits.
+3. The `[FRAGMENTS]` wrapper line above `{{fragments}}` is dropped
+   from every wiki-type YAML so the partition headers Quill sees
+   match the keystone partition shape exactly. Inline references to
+   `[FRAGMENTS]` in the slug rule and the citations rule are
+   updated to point at "fragment inputs" instead, since there is
+   no longer a `[FRAGMENTS]` header to anchor them.
+
+Every wiki-type spec bumps version 3 to 4 so cached overrides
+re-fetch the disk default.
+
+## Negative + positive assertions
+
+| section | kind | check |
+|---|---|---|
+| 1a | POS | All ten wiki-type yamls are at `version: 4` |
+| 1b | NEG | No yaml under `wiki-types/` contains `[USER EDITS` |
+| 1c | NEG | No yaml under `wiki-types/` contains a `[FRAGMENTS]` line on its own |
+| 1d | NEG | No yaml under `wiki-types/` declares `name: edits` in input_variables |
+| 1e | POS | Each wiki-type yaml still substitutes `{{fragments}}` |
+| 2a | POS | regen.ts emits `[NEW FRAGMENTS` header for the NEW partition |
+| 2b | POS | regen.ts emits `[UPDATED FRAGMENTS` header for the UPDATED partition |
+| 2c | POS | regen.ts emits `[REMOVED FRAGMENTS` header for the REMOVED partition |
+| 3a | POS | Contract test file `core/src/lib/regen.partition.test.ts` exists |
+| 3b | POS | Vitest runs the contract test green |
+| 3c | POS | The full `pnpm -C core test regen` suite is green |
+| 4a | POS | All wiki-type yamls parse via `yaml.safe_load` |
+
+## AI-quality assertions (manual, behavioural)
+
+These cannot be greppable, they require a running stack with a
+real OpenRouter key. Track manually after deploy:
+
+- Boot the core stack and the wiki UI. Pick a wiki with at least
+  one prior regen so `last_rebuilt_at` is populated.
+- Attach a fresh fragment so the NEW partition is non-empty, edit
+  one existing fragment so the UPDATED partition is non-empty,
+  detach one existing fragment so the REMOVED partition is
+  non-empty.
+- Trigger regen via the wiki "regen now" control or by waiting on
+  the scheduler. Capture the prompt sent to Quill via the
+  prompt-logging telemetry, or by tailing `core` stdout if the
+  prompt-logging shim is enabled in dev.
+- Confirm the captured user prompt contains all three partition
+  headers, contains no `[USER EDITS` substring, and contains no
+  `[FRAGMENTS]` line on its own.
+- Repeat the trigger on each of the ten wiki types (one wiki per
+  type). Confirm every type regenerates without an LLM error.
+- Spot-read the regenerated body for one Belief, one Project, and
+  one Log wiki. Quality should track v0.2.0 baseline (no missing
+  sections, citations still emit, infobox still emits when
+  applicable).
+
+---
+
+## Test Steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-/home/me/apps/robin}"
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ok $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  skip $1"; }
+
+echo "82, Regen partition headers and [USER EDITS] block drop"
+echo ""
+
+YAML_DIR="packages/shared/src/prompts/specs/wiki-types"
+REGEN_TS="core/src/lib/regen.ts"
+TEST_FILE="core/src/lib/regen.partition.test.ts"
+
+WIKI_TYPES=(agent belief decision log objective principle project research skill voice)
+
+if [ ! -d "$YAML_DIR" ]; then
+  fail "0a. $YAML_DIR missing"
+  echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+pass "0a. wiki-types yaml dir present"
+
+# 1. Per-yaml content checks
+for wt in "${WIKI_TYPES[@]}"; do
+  YAML="$YAML_DIR/$wt.yaml"
+  if [ ! -f "$YAML" ]; then
+    fail "1.$wt yaml missing"
+    continue
+  fi
+
+  if grep -qE '^version:\s*4\b' "$YAML"; then
+    pass "1a.$wt version: 4"
+  else
+    CURRENT=$(grep -E '^version:' "$YAML" | head -1)
+    fail "1a.$wt version is not 4 (saw: $CURRENT)"
+  fi
+
+  if grep -q '\[USER EDITS' "$YAML"; then
+    fail "1b.$wt still contains [USER EDITS"
+  else
+    pass "1b.$wt no [USER EDITS"
+  fi
+
+  if grep -qE '^\s*\[FRAGMENTS\]\s*$' "$YAML"; then
+    fail "1c.$wt still has standalone [FRAGMENTS] header"
+  else
+    pass "1c.$wt no standalone [FRAGMENTS] header"
+  fi
+
+  # input_variables: name: edits should be gone
+  if grep -qE '^\s*-\s*name:\s*edits\b' "$YAML"; then
+    fail "1d.$wt still declares input_variable name: edits"
+  else
+    pass "1d.$wt no edits input_variable"
+  fi
+
+  if grep -q '{{fragments}}' "$YAML"; then
+    pass "1e.$wt template still substitutes {{fragments}}"
+  else
+    fail "1e.$wt template missing {{fragments}} substitution"
+  fi
+done
+
+# 2. regen.ts emits the new partition headers
+if [ ! -f "$REGEN_TS" ]; then
+  fail "2.0 $REGEN_TS missing"
+else
+  if grep -q '\[NEW FRAGMENTS' "$REGEN_TS"; then
+    pass "2a. regen.ts emits [NEW FRAGMENTS header"
+  else
+    fail "2a. regen.ts missing [NEW FRAGMENTS header"
+  fi
+
+  if grep -q '\[UPDATED FRAGMENTS' "$REGEN_TS"; then
+    pass "2b. regen.ts emits [UPDATED FRAGMENTS header"
+  else
+    fail "2b. regen.ts missing [UPDATED FRAGMENTS header"
+  fi
+
+  if grep -q '\[REMOVED FRAGMENTS' "$REGEN_TS"; then
+    pass "2c. regen.ts emits [REMOVED FRAGMENTS header"
+  else
+    fail "2c. regen.ts missing [REMOVED FRAGMENTS header"
+  fi
+fi
+
+# 3. Contract test exists and runs
+if [ ! -f "$TEST_FILE" ]; then
+  fail "3a. $TEST_FILE missing"
+else
+  pass "3a. partition contract test file present"
+
+  if pnpm -C core test regen.partition --reporter=basic >/tmp/uat-82-partition.log 2>&1; then
+    pass "3b. partition contract test green"
+  else
+    fail "3b. partition contract test red (see /tmp/uat-82-partition.log)"
+  fi
+
+  if pnpm -C core test regen --reporter=basic >/tmp/uat-82-regen.log 2>&1; then
+    pass "3c. full regen test suite green"
+  else
+    fail "3c. full regen test suite red (see /tmp/uat-82-regen.log)"
+  fi
+fi
+
+# 4. YAML parse
+for wt in "${WIKI_TYPES[@]}"; do
+  YAML="$YAML_DIR/$wt.yaml"
+  [ -f "$YAML" ] || continue
+  if python3 -c "import yaml,sys; yaml.safe_load(open('$YAML'))" 2>/dev/null; then
+    pass "4a.$wt yaml parses"
+  else
+    fail "4a.$wt yaml does not parse"
+  fi
+done
+
+# Cleanup: remove temporary log files. Tests left no DB or queue state behind.
+rm -f /tmp/uat-82-partition.log /tmp/uat-82-regen.log
+
+echo ""
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]
+```

--- a/core/src/lib/regen.partition.test.ts
+++ b/core/src/lib/regen.partition.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Stream E1 partition contract: post-first-regen, the prompt Quill sees must
+// describe fragments through the NEW / UPDATED / REMOVED partition headers.
+// No flat list, no [USER EDITS] block. This spec is the load-bearing assertion
+// behind v0.2.1's prompt rewrite (Phyl PO feedback): if any of those legacy
+// shapes leaks back in, this test fails before users notice.
+
+const llmCalls: Array<{ system: string; user: string }> = []
+const llmResponse = {
+  markdown: '# Fake regenerated markdown',
+  infobox: null as unknown,
+  citations: [] as unknown[],
+}
+const fakeCallLlm = vi.fn(async (system: string, user: string) => {
+  llmCalls.push({ system, user })
+  return llmResponse
+})
+
+vi.mock('@robin/agent', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@robin/agent')>()
+  return {
+    ...original,
+    createIngestAgents: vi.fn(() => ({
+      wikiClassifier: {},
+      fragmenter: {},
+      entityExtractor: {},
+      fragScorer: {},
+      wikiWriter: {},
+    })),
+    createTypedCaller: vi.fn(() => fakeCallLlm),
+    withTypedUsage: vi.fn(() => fakeCallLlm),
+    embedText: vi.fn(async () => null),
+  }
+})
+
+vi.mock('./openrouter-config.js', () => ({
+  loadOpenRouterConfig: vi.fn(async () => ({
+    apiKey: 'test-key',
+    models: {
+      extraction: 'test/model',
+      classification: 'test/model',
+      wikiGeneration: 'test/model',
+      embedding: 'test/model',
+    },
+  })),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+const dbResponseQueue: unknown[][] = []
+const dbUpdates: Array<Record<string, unknown>> = []
+
+function stageDbResponses(responses: unknown[][]) {
+  dbResponseQueue.length = 0
+  dbResponseQueue.push(...responses)
+}
+
+function popResponse(): unknown[] {
+  return dbResponseQueue.shift() ?? []
+}
+
+vi.mock('../db/client.js', () => {
+  function selectChain() {
+    return {
+      from: () => ({
+        where: (..._args: unknown[]) => {
+          let deferred: Promise<unknown[]> | null = null
+          const ensureDeferred = () => {
+            if (!deferred) deferred = Promise.resolve(popResponse())
+            return deferred
+          }
+          return {
+            // biome-ignore lint/suspicious/noThenProperty: Drizzle thenable mock
+            then: (onFulfilled: (v: unknown[]) => unknown, onRejected?: (r: unknown) => unknown) =>
+              ensureDeferred().then(onFulfilled, onRejected),
+            limit: async () => popResponse(),
+            orderBy: () => ({
+              limit: async () => popResponse(),
+            }),
+            groupBy: () => ({
+              // biome-ignore lint/suspicious/noThenProperty: Drizzle thenable mock
+              then: (onFulfilled: (v: unknown[]) => unknown) =>
+                Promise.resolve(popResponse()).then(onFulfilled),
+            }),
+          }
+        },
+      }),
+    }
+  }
+  const fakeDb = {
+    select: (..._args: unknown[]) => selectChain(),
+    update: () => ({
+      set: (data: Record<string, unknown>) => ({
+        where: (..._args: unknown[]) => {
+          dbUpdates.push(data)
+          return {
+            // biome-ignore lint/suspicious/noThenProperty: Drizzle thenable mock
+            then: (onFulfilled: (v: unknown) => unknown, onRejected?: (r: unknown) => unknown) =>
+              Promise.resolve(undefined).then(onFulfilled, onRejected),
+            returning: async () => [{ lookupKey: 'wiki-key-1', state: 'LINKING' }],
+          }
+        },
+      }),
+    }),
+    insert: () => ({
+      values: async () => undefined,
+    }),
+  }
+  return { db: fakeDb }
+})
+
+vi.mock('../db/schema.js', () => ({
+  wikis: {
+    lookupKey: 'wikis.lookupKey',
+    name: 'wikis.name',
+    type: 'wikis.type',
+    prompt: 'wikis.prompt',
+    description: 'wikis.description',
+    slug: 'wikis.slug',
+    state: 'wikis.state',
+    content: 'wikis.content',
+    metadata: 'wikis.metadata',
+    citationDeclarations: 'wikis.citationDeclarations',
+    embedding: 'wikis.embedding',
+    searchVector: 'wikis.searchVector',
+    updatedAt: 'wikis.updatedAt',
+    deletedAt: 'wikis.deletedAt',
+  },
+  wikiTypes: {
+    slug: 'wikiTypes.slug',
+    prompt: 'wikiTypes.prompt',
+    userModified: 'wikiTypes.userModified',
+  },
+  edges: {
+    srcId: 'edges.srcId',
+    dstId: 'edges.dstId',
+    edgeType: 'edges.edgeType',
+    attrs: 'edges.attrs',
+    deletedAt: 'edges.deletedAt',
+  },
+  fragments: {
+    lookupKey: 'fragments.lookupKey',
+    slug: 'fragments.slug',
+    title: 'fragments.title',
+    content: 'fragments.content',
+    embedding: 'fragments.embedding',
+    searchVector: 'fragments.searchVector',
+    createdAt: 'fragments.createdAt',
+    deletedAt: 'fragments.deletedAt',
+  },
+  edits: {
+    objectType: 'edits.objectType',
+    objectId: 'edits.objectId',
+    source: 'edits.source',
+    timestamp: 'edits.timestamp',
+    content: 'edits.content',
+  },
+  people: {
+    lookupKey: 'people.lookupKey',
+    name: 'people.name',
+    content: 'people.content',
+    embedding: 'people.embedding',
+    searchVector: 'people.searchVector',
+    deletedAt: 'people.deletedAt',
+  },
+}))
+
+const { regenerateWiki } = await import('./regen.js')
+const { db: mockDb } = await import('../db/client.js')
+
+function baseWiki(overrides: Record<string, unknown> = {}) {
+  return {
+    lookupKey: 'wiki-key-1',
+    name: 'Mixed-state wiki',
+    type: 'log',
+    slug: 'mixed-state-wiki',
+    content: 'previous body',
+    prompt: null,
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+// ── Contract test ─────────────────────────────────────────────────────────
+//
+// Setup mirrors the existing E1 partition tests in regen.test.ts: a wiki with
+// last_rebuilt_at set (post-first-regen) and a partition that exercises both
+// NEW and REMOVED fragments. We trigger regen, capture the assembled prompt,
+// and assert:
+//   1. The partition headers Quill sees match the keystone partition shape
+//      (`[NEW FRAGMENTS` and `[REMOVED FRAGMENTS` for this scenario; the
+//      UPDATED-only path is covered by the second case below).
+//   2. NO `[USER EDITS` block, even when the edits table has rows. The
+//      legacy block was Phyl's PO feedback target for v0.2.1 — if any
+//      wiki-type YAML reintroduces it the assertion fires here first.
+//   3. NO legacy `[FRAGMENTS]` flat-list wrapper bracketing the partitioned
+//      content (the v0.2.1 YAML rewrite drops that wrapper since the
+//      partition variable carries its own headers).
+
+describe('regenerateWiki — partition contract (Quill never sees flat fragment lists or [USER EDITS] post-first-regen)', () => {
+  beforeEach(() => {
+    llmCalls.length = 0
+    dbUpdates.length = 0
+    dbResponseQueue.length = 0
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the NEW + REMOVED partition with no [USER EDITS] block and no legacy [FRAGMENTS] wrapper', async () => {
+    const lastRebuiltAt = new Date('2026-04-01T00:00:00Z')
+
+    const newEdge = {
+      srcId: 'frag-new',
+      attrs: null,
+      createdAt: new Date('2026-04-15T00:00:00Z'),
+    }
+    const newFrag = {
+      lookupKey: 'frag-new',
+      slug: 'frag-new',
+      title: 'Newly attached fragment',
+      content: 'NEW_CONTENT_MARKER body for the new fragment',
+      createdAt: new Date('2026-04-15T00:00:00Z'),
+      updatedAt: new Date('2026-04-15T00:00:00Z'),
+    }
+    const removedEdgeRow = { srcId: 'frag-removed' }
+    const removedFragRow = {
+      lookupKey: 'frag-removed',
+      slug: 'frag-removed',
+      title: 'Detached fragment',
+    }
+
+    // A user-edit row is staged so the [USER EDITS] block would render under
+    // the legacy template. After the v0.2.1 rewrite the YAML drops the block
+    // and the assertion below (no `[USER EDITS]` substring) holds.
+    const userEditRow = { content: 'A note the user typed into the wiki body.' }
+
+    stageDbResponses([
+      [baseWiki({ lastRebuiltAt, content: 'previous body' })], // 1. wikis select (outer)
+      [],                                  // 2. classifyUnfiledFragments wiki lookup
+      [newEdge],                           // 3. active fragment edges
+      [removedEdgeRow],                    // 4. REMOVED edge query
+      [removedFragRow],                    // 5. REMOVED fragments hydrate
+      [newFrag],                           // 6. live fragments hydrate
+      [userEditRow],                       // 7. edits query (user-source)
+      [],                                  // 8. wikiTypes select (no userModified row)
+    ])
+
+    const result = await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
+
+    expect(result.skipped).toBeFalsy()
+    expect(llmCalls).toHaveLength(1)
+
+    const userPrompt = llmCalls[0].user
+
+    // Partition headers Quill sees.
+    expect(userPrompt).toContain('[NEW FRAGMENTS')
+    expect(userPrompt).toContain('[REMOVED FRAGMENTS')
+
+    // The new fragment's content and the removed fragment's slug both surface.
+    expect(userPrompt).toContain('NEW_CONTENT_MARKER')
+    expect(userPrompt).toContain('frag-removed')
+
+    // The legacy [USER EDITS] block must not surface anywhere in the prompt,
+    // even though the edits table returned a row.
+    expect(userPrompt).not.toContain('[USER EDITS')
+    expect(userPrompt).not.toContain('USER EDITS --')
+
+    // The legacy `[FRAGMENTS]` wrapper header must not double up on top of
+    // the partition headers. The v0.2.1 YAML drops the wrapper so the
+    // {{fragments}} substitution renders directly.
+    expect(userPrompt).not.toMatch(/^\[FRAGMENTS\]$/m)
+
+    // Triggering-fragments partition matches the prompt shape so audit rows
+    // and the prompt content stay in lockstep.
+    expect(result.triggeringFragments?.new).toHaveLength(1)
+    expect(result.triggeringFragments?.removed).toHaveLength(1)
+    expect(result.triggeringFragments?.updated).toEqual([])
+  })
+
+  it('renders the UPDATED-only partition with no [USER EDITS] block', async () => {
+    const lastRebuiltAt = new Date('2026-04-01T00:00:00Z')
+
+    const updatedEdge = {
+      srcId: 'frag-updated',
+      attrs: null,
+      // edge createdAt before last_rebuilt_at → not NEW
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+    }
+    const updatedFrag = {
+      lookupKey: 'frag-updated',
+      slug: 'frag-updated',
+      title: 'Edited fragment',
+      content: 'UPDATED_CONTENT_MARKER body for the edited fragment',
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      // updated_at after last_rebuilt_at puts this in the UPDATED partition
+      updatedAt: new Date('2026-04-20T00:00:00Z'),
+    }
+    const userEditRow = { content: 'Stale user-edit row that must not surface.' }
+
+    stageDbResponses([
+      [baseWiki({ lastRebuiltAt, content: 'previous body' })], // 1. wikis select (outer)
+      [],                                  // 2. classifyUnfiledFragments wiki lookup
+      [updatedEdge],                       // 3. active fragment edges
+      [],                                  // 4. REMOVED edge query (empty)
+      [updatedFrag],                       // 5. live fragments hydrate
+      [userEditRow],                       // 6. edits query
+      [],                                  // 7. wikiTypes select
+    ])
+
+    const result = await regenerateWiki(mockDb, 'wiki-key-1', { skipEmbedding: true })
+
+    expect(result.skipped).toBeFalsy()
+    expect(llmCalls).toHaveLength(1)
+
+    const userPrompt = llmCalls[0].user
+
+    expect(userPrompt).toContain('[UPDATED FRAGMENTS')
+    expect(userPrompt).toContain('UPDATED_CONTENT_MARKER')
+
+    // Legacy [USER EDITS] block must not surface.
+    expect(userPrompt).not.toContain('[USER EDITS')
+    expect(userPrompt).not.toContain('USER EDITS --')
+
+    // No legacy [FRAGMENTS] wrapper header on its own line.
+    expect(userPrompt).not.toMatch(/^\[FRAGMENTS\]$/m)
+
+    expect(result.triggeringFragments?.updated).toHaveLength(1)
+    expect(result.triggeringFragments?.new).toEqual([])
+    expect(result.triggeringFragments?.removed).toEqual([])
+  })
+})

--- a/packages/shared/src/prompts/fixtures/wiki-type-preview.yaml
+++ b/packages/shared/src/prompts/fixtures/wiki-type-preview.yaml
@@ -8,9 +8,12 @@
 # Per-slug specialization is additive: drop `${slug}.yaml` alongside this file
 # and the loader will pick it up. See loader.ts for the fall-through logic.
 #
-# All optional variables (timeline, people, existingWiki, edits, relatedWikis)
-# are populated so every `{{#if ...}}` branch in each wiki-type template
-# fires, making the preview demonstrate the richest output the user will see.
+# All optional variables (timeline, people, existingWiki, relatedWikis) are
+# populated so every `{{#if ...}}` branch in each wiki-type template fires,
+# making the preview demonstrate the richest output the user will see.
+# `edits` is retained as a no-op field so the loader's PromptPreviewVars
+# interface keeps a non-empty default; the wiki-type templates dropped the
+# legacy [USER EDITS] block in v0.2.1 so the value never renders.
 #
 # `count` is an integer (wiki-generation.ts: `count: z.coerce.number()`).
 # Quoted because the fixture loader runs js-yaml under FAILSAFE_SCHEMA (SEC-L3)

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Agent"
 display_description: "Documentation for a configured AI assistant's purpose, behavior, and capabilities"
@@ -55,14 +55,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -141,7 +140,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Agent"
 display_description: "Documentation for a configured AI assistant's purpose, behavior, and capabilities"
@@ -80,15 +80,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -117,21 +108,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -209,9 +197,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Belief"
 display_description: "A synthesis of a held position, mental model, or worldview with supporting evidence"
@@ -55,14 +55,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -141,7 +140,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Belief"
 display_description: "A synthesis of a held position, mental model, or worldview with supporting evidence"
@@ -80,15 +80,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -117,21 +108,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -209,9 +197,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Decision"
 display_description: "A record of a discrete choice, its context, alternatives considered, and reasoning"
@@ -58,14 +58,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -144,7 +143,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Decision"
 display_description: "A record of a discrete choice, its context, alternatives considered, and reasoning"
@@ -83,15 +83,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -120,21 +111,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -213,9 +201,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Log"
 display_description: "A chronological synthesis of events, observations, and activities over time"
@@ -55,14 +55,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -141,7 +140,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Log"
 display_description: "A chronological synthesis of events, observations, and activities over time"
@@ -80,15 +80,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -117,21 +108,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -209,9 +197,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Objective"
 display_description: "A high-level objective with measurable milestones and progress tracking"
@@ -81,15 +81,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -118,21 +109,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -211,9 +199,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Objective"
 display_description: "A high-level objective with measurable milestones and progress tracking"
@@ -56,14 +56,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -142,7 +141,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Principle"
 display_description: "A document of an operating rule, value, or commitment that guides behavior"
@@ -55,14 +55,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -141,7 +140,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Principle"
 display_description: "A document of an operating rule, value, or commitment that guides behavior"
@@ -80,15 +80,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -117,21 +108,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -209,9 +197,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Project"
 display_description: "A living document tracking an active initiative, its goals, progress, and status"
@@ -61,14 +61,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -147,7 +146,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Project"
 display_description: "A living document tracking an active initiative, its goals, progress, and status"
@@ -86,15 +86,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -123,21 +114,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -217,9 +205,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Research"
 display_description: "A curated library of references, sources, and findings on a topic"
@@ -77,15 +77,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -114,21 +105,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -206,9 +194,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Research"
 display_description: "A curated library of references, sources, and findings on a topic"
@@ -52,14 +52,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -138,7 +137,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Skill"
 display_description: "A knowledge base documenting a capability being developed or maintained"
@@ -86,15 +86,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -123,21 +114,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -215,9 +203,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Skill"
 display_description: "A knowledge base documenting a capability being developed or maintained"
@@ -61,14 +61,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -147,7 +146,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 2
+version: 3
 category: generation
 display_label: "Voice"
 display_description: "A style guide capturing communication patterns, tone preferences, and voice identity"
@@ -80,15 +80,6 @@ template: |
   {{existingWiki}}
   {{/if}}
 
-  {{#if edits}}
-  [USER EDITS -- preserve these in the new summary]
-  The user has manually edited this wiki. Their additions below MUST be
-  preserved in the regenerated document. Incorporate them naturally into
-  the appropriate sections rather than appending them as a separate block.
-
-  {{edits}}
-  {{/if}}
-
   {{#if relatedWikis}}
   [RELATED WIKIS]
   The following wikis exist in the knowledge base. If this document
@@ -117,21 +108,18 @@ template: |
      regenerating from scratch.
   8. Do not add conclusions, recommendations, or analysis beyond what
      the fragments state.
-  9. If user edits are provided, preserve them faithfully in the output.
-     Integrate user additions into the relevant sections. Never discard
-     user edits even if they seem to contradict fragment content.
-  10. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
-      present in the provided inputs. Use plain text only when no matching
-      slug exists. Never use plain Markdown links ([text](url)) for internal
-      references.
-  11. Emit the infobox as a structured field (see [INFOBOX]). Do not
+  9. Use [[kind:slug]] tokens for any person/fragment/wiki/entry reference
+     present in the provided inputs. Use plain text only when no matching
+     slug exists. Never use plain Markdown links ([text](url)) for internal
+     references.
+  10. Emit the infobox as a structured field (see [INFOBOX]). Do not
       duplicate any infobox value — title, status, owner, dates — as a
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  12. Emit citations as a structured field (see [CITATIONS]); never add
+  11. Emit citations as a structured field (see [CITATIONS]); never add
       inline [^cite:...] markers in the markdown.
-  13. Typography — never emit straight ASCII double-quote characters
+  12. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
@@ -208,9 +196,6 @@ input_variables:
     required: false
   - name: existingWiki
     description: Current wiki content for incremental updates
-    required: false
-  - name: edits
-    description: User edit log entries to preserve across regeneration
     required: false
   - name: relatedWikis
     description: Other wikis in the knowledge base for cross-linking

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 3
+version: 4
 category: generation
 display_label: "Voice"
 display_description: "A style guide capturing communication patterns, tone preferences, and voice identity"
@@ -55,14 +55,13 @@ template: |
   - Related wiki: [[wiki:<slug>]]         e.g. [[wiki:my-project]]
   - Entry:        [[entry:<slug>]]
 
-  Slugs MUST be present in the [PEOPLE], [FRAGMENTS], [ENTRIES], or
+  Slugs MUST be present in the [PEOPLE], fragment inputs, [ENTRIES], or
   [RELATED WIKIS] inputs provided below. If no slug exists for the
   entity, write its name in plain text. Do not invent slugs.
 
   [DOCUMENT STRUCTURE]
   {{structure}}
 
-  [FRAGMENTS]
   {{fragments}}
 
   {{#if timeline}}
@@ -141,7 +140,7 @@ template: |
     ]
 
   Rules:
-  - fragmentIds MUST be drawn from the [FRAGMENTS] input. Do not invent.
+  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
   - sectionAnchor MUST correspond to a heading you wrote. Slugify
     by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
   - Omit a section from citations if no fragment grounds it.


### PR DESCRIPTION
## Summary
- New contract test asserts Quill's prompt uses `[NEW FRAGMENTS]` / `[UPDATED FRAGMENTS]` / `[REMOVED FRAGMENTS]` partitions exclusively, with no flat list and no legacy `[USER EDITS]` block
- All 10 wiki-type regen YAMLs drop the legacy `[USER EDITS]` block; the partitions render the same intent more cleanly
- YAML headers now align with the partition assembly in `core/src/lib/regen.ts`

Closes #337. Closes #327.

This bundle was originally v0.2.1 Agent D, deferred to v0.2.2 Stream R per the planning record.

## What changed for the user
Quill's wiki-regen prompt no longer includes a separate `[USER EDITS]` block. Fragment edit history is now communicated through the `[UPDATED FRAGMENTS]` partition, which already carries the same information in a cleaner shape. Operators viewing logged Quill prompts will see three partition headers (NEW, UPDATED, REMOVED) and only those. Output quality is unchanged; the partitions render the same intent.

## What was true before
The Quill prompt template carried a legacy `[USER EDITS]` block from before fragment-edit history existed. That block predated the E1 partition logic that v0.2.0 shipped. YAML headers in the wiki-type prompt specs did not match the partition headers used by `regen.ts`'s assembly code, so the prompt that hit Quill carried both representations of the same fragments. Half-finished partition state would have lingered if test, drop, and YAML rewrite shipped separately, so this PR ships them together as three atomic commits.

## Operational notes
- No migration. No breaking change.
- All 10 wiki-type YAMLs bumped to `version: 4`. Cached spec consumers will invalidate on next read.
- `core/src/lib/regen.ts` partition assembly is unchanged; this PR aligns the YAML side to match.

## Test plan
- [ ] UAT plan: `.uat/plans/82-regen-partition-and-user-edits-drop.md` (67/67 PASS)
- [ ] `pnpm -C core test regen` 44/44 across 9 files
- [ ] `pnpm -C core typecheck` clean
- [ ] All 10 wiki-type prompt YAMLs validate via js-yaml and python yaml.safe_load
- [ ] Manual: trigger regen on a wiki with mixed fragments; capture the prompt sent to Quill; confirm `[USER EDITS]` is absent and `[NEW FRAGMENTS]` / `[UPDATED FRAGMENTS]` / `[REMOVED FRAGMENTS]` are present