### PR TITLE
fix(wiki): explorer collection filter now matches the rows it counts

### DIFF
--- a/wiki/src/app/(shell)/explorer/page.tsx
+++ b/wiki/src/app/(shell)/explorer/page.tsx
@@ -360,7 +360,11 @@ function ExplorerInner() {
               </li>
             ) : (
               visibleItems.map((item) => (
-                <ExplorerRow key={item.id} item={item} />
+                <ExplorerRow
+                  key={item.id}
+                  item={item}
+                  activeCollectionId={filters.collection}
+                />
               ))
             )}
           </ul>
@@ -373,8 +377,20 @@ function ExplorerInner() {
   );
 }
 
-function ExplorerRow({ item }: { item: ExplorerItem }) {
+function ExplorerRow({
+  item,
+  activeCollectionId,
+}: {
+  item: ExplorerItem;
+  activeCollectionId: string | null;
+}) {
   const Icon = getWikiTypeIcon(item.subtype ?? item.type);
+  // When a collection filter is active, prefer surfacing the matching one;
+  // otherwise show the first membership.
+  const surfacedCollection =
+    (activeCollectionId
+      ? item.collections.find((c) => c.id === activeCollectionId)
+      : null) ?? item.collections[0] ?? null;
 
   return (
     <li
@@ -437,20 +453,20 @@ function ExplorerRow({ item }: { item: ExplorerItem }) {
           type={item.subtype ?? (item.type.charAt(0).toUpperCase() + item.type.slice(1))}
         />
 
-        {item.collectionColor && item.collectionName && (
+        {surfacedCollection && (
           <div
             style={{ display: "flex", alignItems: "center", gap: 6 }}
           >
             <span
               className="inline-block h-2.5 w-2.5 rounded-full"
-              style={{ backgroundColor: item.collectionColor }}
+              style={{ backgroundColor: surfacedCollection.color }}
               aria-hidden
             />
             <span
               className="hidden sm:inline"
               style={{ ...T.micro, color: "var(--wiki-count)" }}
             >
-              {item.collectionName}
+              {surfacedCollection.name}
             </span>
           </div>
         )}

--- a/wiki/src/hooks/useExplorerData.ts
+++ b/wiki/src/hooks/useExplorerData.ts
@@ -9,15 +9,19 @@ import { useCollections, type Collection } from '@/hooks/useCollections'
 import type { ExplorerFilters } from '@/hooks/useExplorerFilters'
 import { ROUTES } from '@/lib/routes'
 
+export interface ExplorerItemCollection {
+  id: string
+  name: string
+  color: string
+}
+
 export interface ExplorerItem {
   id: string
   lookupKey: string
   type: 'fragment' | 'wiki' | 'person' | 'entry'
   subtype: string | null
   title: string
-  collectionId: string | null
-  collectionName: string | null
-  collectionColor: string | null
+  collections: ExplorerItemCollection[]
   date: string
   href: string
 }
@@ -42,24 +46,28 @@ export function useExplorerData(filters: ExplorerFilters) {
   const items = useMemo(() => {
     const result: ExplorerItem[] = []
 
-    // Wikis (threads)
+    // Wikis (threads). The list endpoint returns wiki.collections; previously
+    // dropped here, which caused the collection filter to match nothing.
     for (const wiki of wikisQuery.data?.wikis ?? []) {
-      // TODO: resolve collection membership when API supports it
       result.push({
         id: wiki.id,
         lookupKey: wiki.lookupKey,
         type: 'wiki',
         subtype: capitalize(wiki.type),
         title: wiki.name,
-        collectionId: null,
-        collectionName: null,
-        collectionColor: null,
+        collections: (wiki.collections ?? []).map((c) => ({
+          id: c.id,
+          name: c.name,
+          color: c.color,
+        })),
         date: wiki.updatedAt,
         href: `/wiki/${wiki.lookupKey}`,
       })
     }
 
-    // Fragments
+    // Fragments, people, entries do not carry collection memberships in the
+    // data model (collections attach to wikis only via group_wikis), so an
+    // empty list correctly excludes them under a collection filter.
     for (const frag of fragmentsQuery.data?.fragments ?? []) {
       result.push({
         id: frag.id,
@@ -67,15 +75,12 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'fragment',
         subtype: capitalize(frag.type),
         title: frag.title,
-        collectionId: null,
-        collectionName: null,
-        collectionColor: null,
+        collections: [],
         date: frag.updatedAt,
         href: ROUTES.fragment(frag.lookupKey),
       })
     }
 
-    // People
     for (const person of peopleQuery.data?.people ?? []) {
       result.push({
         id: person.id,
@@ -83,15 +88,12 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'person',
         subtype: null,
         title: person.name,
-        collectionId: null,
-        collectionName: null,
-        collectionColor: null,
+        collections: [],
         date: person.updatedAt,
         href: ROUTES.person(person.lookupKey),
       })
     }
 
-    // Entries
     for (const entry of entriesQuery.data?.entries ?? []) {
       result.push({
         id: entry.id,
@@ -99,9 +101,7 @@ export function useExplorerData(filters: ExplorerFilters) {
         type: 'entry',
         subtype: null,
         title: entry.title,
-        collectionId: null,
-        collectionName: null,
-        collectionColor: null,
+        collections: [],
         date: entry.createdAt,
         href: ROUTES.entry(entry.lookupKey),
       })
@@ -115,7 +115,10 @@ export function useExplorerData(filters: ExplorerFilters) {
 
     // Apply collection filter
     if (filters.collection) {
-      filtered = filtered.filter((item) => item.collectionId === filters.collection)
+      const collectionId = filters.collection
+      filtered = filtered.filter((item) =>
+        item.collections.some((c) => c.id === collectionId),
+      )
     }
 
     // Apply sort


### PR DESCRIPTION
## Summary

- Sidebar shows collection counts (e.g. "Recent: 3"), clicking the collection navigates to \`/explorer?collection=<id>\`, but the explorer reported zero results because every item carried \`collectionId: null\`.
- Root cause: \`useExplorerData.ts:46\` had a TODO comment and dropped \`wiki.collections\` from the API payload. The wiki list endpoint already returns it via \`wikiResponseSchema.collections\`.
- Fix: \`ExplorerItem\` now carries an array of \`{ id, name, color }\`. Filter uses \`Array.some\`. Row picks the matching collection when a filter is active, otherwise the first membership.
- Fragments, people, entries get \`collections: []\` so they correctly drop out under collection filters (collections only attach to wikis via \`group_wikis\`).

Closes #356.

## Test plan

- [ ] Sidebar shows non-zero count for at least one collection.
- [ ] Click that collection in the sidebar -> URL becomes \`/explorer?collection=<id>\`, list renders the wikis in it.
- [ ] Each row shows the collection chip on the right.
- [ ] Switching to "All collections" or clearing filters returns the full list.
- [ ] Type filters still work alongside the collection filter.