### PR TITLE
feat(wiki): split AddWiki override into Document Format and Wiki Style

### DIFF
--- a/core/openapi-manifest.json
+++ b/core/openapi-manifest.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "generatedAt": "2026-05-09T09:20:37.521Z",
+    "generatedAt": "2026-05-09T13:50:09.424Z",
     "description": "Route + JSON Schema manifest for OpenAPI generation. Feed to /apidoc.",
     "schemaCount": 64,
     "routeCount": 58
@@ -2194,6 +2194,9 @@
             },
             "prompt": {
               "type": "string"
+            },
+            "structure": {
+              "type": "string"
             }
           },
           "required": [
@@ -2219,6 +2222,9 @@
               "type": "string"
             },
             "prompt": {
+              "type": "string"
+            },
+            "structure": {
               "type": "string"
             },
             "autoregen": {
@@ -2257,6 +2263,10 @@
             },
             "prompt": {
               "type": "string"
+            },
+            "structure": {
+              "type": "string",
+              "default": ""
             },
             "state": {
               "type": "string",
@@ -2450,6 +2460,10 @@
             },
             "prompt": {
               "type": "string"
+            },
+            "structure": {
+              "type": "string",
+              "default": ""
             },
             "state": {
               "type": "string",
@@ -2653,6 +2667,10 @@
                   "prompt": {
                     "type": "string"
                   },
+                  "structure": {
+                    "type": "string",
+                    "default": ""
+                  },
                   "state": {
                     "type": "string",
                     "enum": [
@@ -2852,6 +2870,10 @@
             },
             "prompt": {
               "type": "string"
+            },
+            "structure": {
+              "type": "string",
+              "default": ""
             },
             "state": {
               "type": "string",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -3334,6 +3334,10 @@
           "prompt": {
             "type": "string"
           },
+          "structure": {
+            "type": "string",
+            "default": ""
+          },
           "state": {
             "type": "string",
             "enum": [
@@ -3495,6 +3499,10 @@
           },
           "prompt": {
             "type": "string"
+          },
+          "structure": {
+            "type": "string",
+            "default": ""
           },
           "state": {
             "type": "string",
@@ -3835,6 +3843,10 @@
           },
           "prompt": {
             "type": "string"
+          },
+          "structure": {
+            "type": "string",
+            "default": ""
           },
           "state": {
             "type": "string",

--- a/core/src/routes/wiki-types.ts
+++ b/core/src/routes/wiki-types.ts
@@ -63,6 +63,8 @@ type WikiTypeListItem = {
   displayOrder: number
   promptYaml: string
   defaultYaml: string
+  defaultStructure: string
+  defaultSystemMessage: string
   userModified: boolean
   basedOnVersion: number
   inputVariables: Array<{ name: string; description: string; required: boolean }>
@@ -111,6 +113,8 @@ wikiTypesRouter.get('/', async (c) => {
         displayOrder: 999,
         promptYaml: row.prompt,
         defaultYaml: '',
+        defaultStructure: '',
+        defaultSystemMessage: '',
         userModified: row.userModified,
         basedOnVersion: row.basedOnVersion,
         inputVariables: [],
@@ -129,6 +133,8 @@ wikiTypesRouter.get('/', async (c) => {
         displayOrder: spec.display_order ?? 999,
         promptYaml: row.prompt,
         defaultYaml,
+        defaultStructure: spec.default_structure ?? '',
+        defaultSystemMessage: spec.system_message ?? '',
         userModified: row.userModified,
         basedOnVersion: row.basedOnVersion,
         inputVariables: spec.input_variables.map((v) => ({
@@ -150,6 +156,8 @@ wikiTypesRouter.get('/', async (c) => {
         displayOrder: 999,
         promptYaml: row.prompt,
         defaultYaml,
+        defaultStructure: '',
+        defaultSystemMessage: '',
         userModified: row.userModified,
         basedOnVersion: row.basedOnVersion,
         inputVariables: [],

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -180,6 +180,7 @@ wikisRouter.post('/', zValidator('json', createWikiBodySchema, validationHook), 
       type: wikiType,
       state: 'PENDING',
       prompt: body.prompt ?? '',
+      structure: body.structure ?? '',
       // Stream V (migration 0015): web-UI captures stamp the wiki row
       // with `source_client = 'web'` so retrospective queries can break
       // creates down by surface without unpacking audit_log.detail.
@@ -560,6 +561,12 @@ wikisRouter.put('/:id', zValidator('json', updateWikiBodySchema, validationHook)
     updates.prompt = body.prompt
     // Prompt change affects wiki generation — mark PENDING so regen rebuilds with new prompt
     if (body.prompt !== existing.prompt) updates.state = 'PENDING'
+  }
+  // Document-structure override (#244). Sibling of `prompt`; same PENDING
+  // semantics on change so the next regen rebuilds against the new skeleton.
+  if (body.structure != null) {
+    updates.structure = body.structure
+    if (body.structure !== existing.structure) updates.state = 'PENDING'
   }
   // T4-bundle (v0.2.2): autoregen flag now editable via the unified PUT body.
   if (body.autoregen != null) updates.autoregen = body.autoregen

--- a/core/src/schemas/wiki-types.schema.ts
+++ b/core/src/schemas/wiki-types.schema.ts
@@ -42,6 +42,12 @@ export const wikiTypeItemResponseSchema = z.object({
   displayOrder: z.number().int(),
   promptYaml: z.string(),
   defaultYaml: z.string(),
+  // Surfaced so the AddWiki settings modal can render the type's structure
+  // as the placeholder, showing the user what they would be overriding
+  // instead of a generic structure example. Pairs with defaultSystemMessage
+  // for the Tone & Voice field.
+  defaultStructure: z.string().default(''),
+  defaultSystemMessage: z.string().default(''),
   userModified: z.boolean(),
   basedOnVersion: z.number().int(),
   inputVariables: z.array(

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -41,6 +41,10 @@ export const wikiResponseSchema = z.object({
   description: z.string().default(''),
   type: z.string(),
   prompt: z.string(),
+  // Document-structure override (#244). Sibling of `prompt`. Empty string
+  // means "use the type's default_structure". Surfaced as a first-class
+  // field on settings UI alongside Tone & Voice (which edits `prompt`).
+  structure: z.string().default(''),
   state: objectStateSchema,
   lastRebuiltAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
@@ -106,6 +110,7 @@ export const createWikiBodySchema = z.object({
   type: z.string().optional(),
   description: z.string().optional(),
   prompt: z.string().optional(),
+  structure: z.string().optional(),
 })
 
 export const updateWikiBodySchema = z
@@ -114,6 +119,7 @@ export const updateWikiBodySchema = z
     description: z.string().optional(),
     type: z.string().optional(),
     prompt: z.string().optional(),
+    structure: z.string().optional(),
     // T4-bundle (v0.2.2): autoregen replaces regenerate as the sole regen gate.
     autoregen: z.boolean().optional(),
   })

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -299,6 +299,7 @@ export default function WikiDetailPage() {
       chipLabel={typeLabel}
       title={wiki.name}
       promptOverride={wiki.prompt}
+      structureOverride={wiki.structure ?? ''}
       description={wiki.description ?? wiki.shortDescriptor ?? ''}
       bouncerMode={wiki.bouncerMode as 'auto' | 'review' | undefined}
       published={wiki.published === true}

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -87,13 +87,20 @@ export default function AddWikiModal({
   const [description, setDescription] = useState("");
   const [subtitle, setSubtitle] = useState<string | undefined>(undefined);
   /**
-   * #240: Wiki Structure (UI label rename) — inline override of the
-   * type's system_message. Empty string === "use the type default".
-   * `wikis.prompt` storage stays a system_message override; only the UI
-   * label and presentation changed.
+   * Wiki Style override (#358), persisted to `wikis.prompt`. Swaps the
+   * type's `system_message` (LLM persona / tone) at regen time. Empty
+   * string === "use the type default".
    */
   const [wikiPrompt, setWikiPrompt] = useState<string>("");
   const [wikiPromptEdited, setWikiPromptEdited] = useState<boolean>(false);
+  /**
+   * Document Format override (#358), persisted to `wikis.structure`.
+   * Swaps the type's `default_structure` (document skeleton, used as
+   * `{{structure}}` in the wiki-type template) at regen time. Sibling of
+   * `wikiPrompt`; same empty-string semantics.
+   */
+  const [wikiStructure, setWikiStructure] = useState<string>("");
+  const [wikiStructureEdited, setWikiStructureEdited] = useState<boolean>(false);
   /** Existing-wiki settings: form read-only until user clicks Edit Wiki */
   const [fieldsEditable, setFieldsEditable] = useState(true);
   const [showSavedToast, setShowSavedToast] = useState(false);
@@ -136,6 +143,15 @@ export default function AddWikiModal({
       .sort((a, b) => a.displayLabel.localeCompare(b.displayLabel));
   }, [wikiTypesData?.wikiTypes]);
 
+  // Per-type defaults used as field placeholders so the empty-state of
+  // Document Format / Wiki Style shows what the override would replace.
+  const activeType = useMemo(() => {
+    if (!wikiType) return null;
+    return sortedTypes.find((t) => t.slug === wikiType) ?? null;
+  }, [wikiType, sortedTypes]);
+  const activeTypeDefaultStructure = activeType?.defaultStructure ?? "";
+  const activeTypeDefaultSystemMessage = activeType?.defaultSystemMessage ?? "";
+
   useEffect(() => {
     if (open) {
       if (!wasOpen.current) {
@@ -158,6 +174,12 @@ export default function AddWikiModal({
               prefill.promptOverride && prefill.promptOverride.length > 0,
             ),
           );
+          setWikiStructure(prefill.structureOverride ?? "");
+          setWikiStructureEdited(
+            Boolean(
+              prefill.structureOverride && prefill.structureOverride.length > 0,
+            ),
+          );
           prevWikiTypeRef.current = nextType;
           const bm = prefill.bouncerMode ?? "auto";
           setBouncerMode(bm);
@@ -177,6 +199,8 @@ export default function AddWikiModal({
           setSubtitle(undefined);
           setWikiPrompt("");
           setWikiPromptEdited(false);
+          setWikiStructure("");
+          setWikiStructureEdited(false);
           prevWikiTypeRef.current = "";
           setBouncerMode("auto");
           initialBouncerModeRef.current = "auto";
@@ -329,10 +353,20 @@ export default function AddWikiModal({
       setSubmitting(true);
       setSubmitError(null);
       try {
-        // Empty string clears the override; non-empty sets it.
-        // Never send null — Zod rejects.
-        const payload: { name?: string; type?: string; description?: string; prompt: string } = {
+        // Empty string clears the override; non-empty sets it. Never send
+        // null because Zod rejects. Wiki Style edits `wikis.prompt`,
+        // Document Format edits `wikis.structure`. The two are independent
+        // overrides and both ride on every save so a cleared field reaches
+        // the server as "".
+        const payload: {
+          name?: string;
+          type?: string;
+          description?: string;
+          prompt: string;
+          structure: string;
+        } = {
           prompt: wikiPrompt,
+          structure: wikiStructure,
         };
         if (prefill && trimmedName !== prefill.name) {
           payload.name = trimmedName;
@@ -396,11 +430,13 @@ export default function AddWikiModal({
     setSubmitError(null);
     try {
       const trimmedPrompt = wikiPrompt.trim();
+      const trimmedStructure = wikiStructure.trim();
       const body = {
         name: trimmedName,
         type: wikiType,
         description: description.trim() || undefined,
         prompt: trimmedPrompt.length > 0 ? trimmedPrompt : undefined,
+        structure: trimmedStructure.length > 0 ? trimmedStructure : undefined,
       };
       const res = await fetch("/api/wikis", {
         method: "POST",
@@ -585,6 +621,54 @@ export default function AddWikiModal({
             />
           </div>
 
+          {/* Document Format (#358). Binds to wikis.structure, overrides
+              the type's default_structure (the {{structure}} block in the
+              wiki-type template). Sits next to Description because both
+              shape WHAT the wiki contains. Empty value = "use the type
+              default"; the Revert button clears the override. */}
+          <div className="px-5 pt-4 flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+              <FieldLabel>
+                Document Format <InfoIcon className="text-[#545353]" />
+              </FieldLabel>
+              <button
+                type="button"
+                onClick={() => {
+                  setWikiStructure("");
+                  setWikiStructureEdited(false);
+                }}
+                disabled={locked || !wikiStructureEdited}
+                aria-label="Revert Document Format to default"
+                className="text-[11px] leading-4 underline disabled:opacity-50 disabled:no-underline"
+                style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked || !wikiStructureEdited ? "default" : "pointer" }}
+              >
+                Revert to default
+              </button>
+            </div>
+            <Textarea
+              value={wikiStructure}
+              onChange={(e) => {
+                const next = e.target.value;
+                setWikiStructure(next);
+                setWikiStructureEdited(next.trim().length > 0);
+              }}
+              placeholder={
+                activeTypeDefaultStructure ||
+                "# Section\n- bullet\n## Another section"
+              }
+              rows={6}
+              disabled={locked || !wikiType}
+              className="min-h-[120px] resize-none font-mono"
+            />
+            <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
+              {wikiStructureEdited
+                ? "Custom format overrides the type's default structure at regen time."
+                : activeTypeDefaultStructure
+                  ? "Showing the type default. Type to override."
+                  : "Empty, uses the wiki type's default structure."}
+            </span>
+          </div>
+
           {/* Collections — visible in both create and settings mode. In create
               mode, selections are staged locally and applied after POST /wikis
               succeeds (see handleConfirm). In settings mode, add/remove fire
@@ -679,13 +763,15 @@ export default function AddWikiModal({
             ) : null}
           </div>
 
-          {/* Wiki Structure (#240) — inline textarea matching the
-              Description field's shape. Empty value = "use the type
-              default"; the Revert button clears the override. */}
+          {/* Wiki Style (#358). Binds to wikis.prompt, swaps the type's
+              system_message at regen time. Sits below Document Format
+              because tone is a customization on top of the document the
+              user just shaped. Empty value = "use the type default";
+              the Revert button clears the override. */}
           <div className="px-5 pt-4 flex flex-col gap-2">
             <div className="flex items-center justify-between gap-2">
               <FieldLabel>
-                Wiki Structure <InfoIcon className="text-[#545353]" />
+                Wiki Style <InfoIcon className="text-[#545353]" />
               </FieldLabel>
               <button
                 type="button"
@@ -694,7 +780,7 @@ export default function AddWikiModal({
                   setWikiPromptEdited(false);
                 }}
                 disabled={locked || !wikiPromptEdited}
-                aria-label="Revert to default"
+                aria-label="Revert Wiki Style to default"
                 className="text-[11px] leading-4 underline disabled:opacity-50 disabled:no-underline"
                 style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked || !wikiPromptEdited ? "default" : "pointer" }}
               >
@@ -708,15 +794,20 @@ export default function AddWikiModal({
                 setWikiPrompt(next);
                 setWikiPromptEdited(next.trim().length > 0);
               }}
-              placeholder={"# Type: title\n## Section\n- bullet\n## Another section"}
+              placeholder={
+                activeTypeDefaultSystemMessage ||
+                "Tone, voice, and persona instructions for this wiki."
+              }
               rows={6}
               disabled={locked || !wikiType}
               className="min-h-[120px] resize-none font-mono"
             />
             <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
               {wikiPromptEdited
-                ? "Custom structure overrides the type default at regen time."
-                : "Empty — uses the wiki type's default structure."}
+                ? "Custom style overrides the type's tone and voice at regen time."
+                : activeTypeDefaultSystemMessage
+                  ? "Showing the type's tone and voice. Type to override."
+                  : "Empty, uses the wiki type's tone and voice."}
             </span>
           </div>
 

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -277,8 +277,10 @@ export type WikiEntityArticleProps = {
    * Optional sections rendered after divider and before modal.
    */
   customBottomSections?: ReactNode;
-  /** Per-wiki prompt override to prefill in settings modal */
+  /** Per-wiki Wiki Style override to prefill in settings modal (wikis.prompt). */
   promptOverride?: string;
+  /** Per-wiki Document Format override to prefill in settings modal (wikis.structure). */
+  structureOverride?: string;
   /** Wiki description / shortDescriptor to prefill in settings modal */
   description?: string;
   /** Current bouncer mode for settings modal prefill */
@@ -339,6 +341,7 @@ export function WikiEntityArticle({
   renderCustomInfobox,
   customBottomSections,
   promptOverride,
+  structureOverride,
   description,
   wikiId,
   bouncerMode,
@@ -408,14 +411,20 @@ export function WikiEntityArticle({
 
   const wikiSettingsPrefill = useMemo(
     () => ({
-      ...wikiEntitySettingsPrefill({ title: displayTitle, chipLabel: displayChipLabel, description, promptOverride }),
+      ...wikiEntitySettingsPrefill({
+        title: displayTitle,
+        chipLabel: displayChipLabel,
+        description,
+        promptOverride,
+        structureOverride,
+      }),
       bouncerMode,
       published,
       publishedSlug,
       publishedOrigin,
       collections,
     }),
-    [displayTitle, displayChipLabel, description, promptOverride, bouncerMode, published, publishedSlug, publishedOrigin, collections],
+    [displayTitle, displayChipLabel, description, promptOverride, structureOverride, bouncerMode, published, publishedSlug, publishedOrigin, collections],
   );
 
   const tabs = ["Read", "Edit", "View history"] as const;

--- a/wiki/src/hooks/useWikiTypesList.ts
+++ b/wiki/src/hooks/useWikiTypesList.ts
@@ -15,6 +15,19 @@ export interface WikiTypeListItem {
   displayOrder: number;
   promptYaml: string;
   defaultYaml: string;
+  /**
+   * The type's `default_structure` block extracted from its YAML spec.
+   * Used as the placeholder for the Document Format field in the
+   * AddWiki settings modal so users see what their override would
+   * replace.
+   */
+  defaultStructure: string;
+  /**
+   * The type's `system_message` block extracted from its YAML spec.
+   * Used as the placeholder for the Wiki Style field, which overrides
+   * `wikis.prompt` (the system_message swap at regen time).
+   */
+  defaultSystemMessage: string;
   userModified: boolean;
   basedOnVersion: number;
   inputVariables: InputVariable[];

--- a/wiki/src/lib/generated/types.gen.ts
+++ b/wiki/src/lib/generated/types.gen.ts
@@ -238,12 +238,14 @@ export type CreateThreadBodySchema = {
     type?: string;
     description?: string;
     prompt?: string;
+    structure?: string;
 };
 
 export type UpdateThreadBodySchema = {
     name?: string;
     type?: string;
     prompt?: string;
+    structure?: string;
 };
 
 export type ThreadResponseSchema = {
@@ -254,6 +256,7 @@ export type ThreadResponseSchema = {
     description?: string;
     type: string;
     prompt: string;
+    structure?: string;
     state: 'PENDING' | 'RESOLVED' | 'LINKING' | 'DIRTY';
     lastRebuiltAt: string;
     createdAt: string;
@@ -284,6 +287,7 @@ export type ThreadWithWikiResponseSchema = {
     description?: string;
     type: string;
     prompt: string;
+    structure?: string;
     state: 'PENDING' | 'RESOLVED' | 'LINKING' | 'DIRTY';
     lastRebuiltAt: string;
     createdAt: string;
@@ -347,6 +351,7 @@ export type WikiDetailResponseSchema = {
     description?: string;
     type: string;
     prompt: string;
+    structure?: string;
     state: 'PENDING' | 'RESOLVED' | 'LINKING' | 'DIRTY';
     lastRebuiltAt: string;
     createdAt: string;

--- a/wiki/src/lib/wikiSettingsPrefill.ts
+++ b/wiki/src/lib/wikiSettingsPrefill.ts
@@ -7,8 +7,18 @@ export type WikiSettingsPrefill = {
   gatekeep?: boolean;
   /** Modal subtitle under the title */
   subtitle?: string;
-  /** Per-wiki prompt override (empty string = "no override", undefined = unseeded) */
+  /**
+   * Per-wiki Wiki Style override, persisted to `wikis.prompt`. Swaps the
+   * type's `system_message` at regen time. Empty string = "no override",
+   * undefined = unseeded.
+   */
   promptOverride?: string;
+  /**
+   * Per-wiki Document Format override, persisted to `wikis.structure`.
+   * Swaps the type's `default_structure` at regen time. Same empty /
+   * undefined semantics as promptOverride.
+   */
+  structureOverride?: string;
   /** Current bouncer mode: 'auto' or 'review' */
   bouncerMode?: 'auto' | 'review';
   /** Current publish state — drives the publish toggle in settings (#255) */
@@ -58,13 +68,15 @@ export function wikiEntitySettingsPrefill(input: {
   chipLabel: string;
   description?: string;
   promptOverride?: string;
+  structureOverride?: string;
 }): WikiSettingsPrefill {
   return {
     name: input.title,
     wikiType: wikiTypeSelectValueForChip(input.chipLabel),
     folder: "default",
     description: input.description ?? WIKI_INTRO_LEAD_PLAINTEXT,
-    subtitle: `${input.chipLabel} wiki — update name, type, and visibility`,
+    subtitle: `${input.chipLabel} wiki, update name, type, and visibility`,
     promptOverride: input.promptOverride,
+    structureOverride: input.structureOverride,
   };
 }


### PR DESCRIPTION
## Summary

The AddWiki settings modal had a single textarea labeled "Wiki Structure" that actually edited \`wikis.prompt\` (system_message override). PR #244 had already added \`wikis.structure\` as a real document-skeleton override but never wired a UI for it. Result: the field's label, binding, and regen effect were three different things.

This PR splits the override into two honest fields and exposes the per-type defaults on the API so each field can show what its empty state would replace.

| Field | Binds to | Effect at regen | Placeholder |
| --- | --- | --- | --- |
| **Document Format** (new) | \`wikis.structure\` | Swaps the type's \`default_structure\` (the \`{{structure}}\` block in the wiki-type template) | Type's \`default_structure\` |
| **Wiki Style** (renamed from "Wiki Structure") | \`wikis.prompt\` | Swaps the type's \`system_message\` | Type's \`system_message\` |

Document Format sits right after Description because both shape WHAT the wiki contains. Wiki Style sits lower as a tone / voice customization.

Closes #358. Supersedes #355 (closed).

## Backend

- \`wikiResponseSchema\` now carries \`structure\`.
- \`createWikiBodySchema\` and \`updateWikiBodySchema\` accept optional \`structure\`. Update marks state PENDING on change.
- \`wikiTypeItemResponseSchema\` gains \`defaultStructure\` and \`defaultSystemMessage\`, sourced from \`parseSpecFromBlob\`.
- \`openapi.json\` and \`openapi-manifest.json\` refreshed.

## Frontend

- \`useWikiTypesList\` carries the two new defaults.
- \`wikiSettingsPrefill\` threads \`structureOverride\` alongside \`promptOverride\`.
- \`AddWikiModal\` adds \`wikiStructure\` state, the new Document Format textarea, relabels the existing field to Wiki Style, and submits both \`prompt\` and \`structure\` on save.
- \`WikiEntityArticle\` accepts a new \`structureOverride\` prop and threads it through prefill.
- The wiki detail page passes \`wiki.structure\` in.
- SDK \`types.gen.ts\` manually patched to add \`structure?: string\` to the response and body schemas. The next \`bun run gen\` will reproduce the same change cleanly.

## Test plan

- [ ] CI green (typecheck, biome, eslint)
- [ ] Open a wiki's settings modal: see Document Format above Wiki Style. Both placeholders show the type's actual defaults.
- [ ] Type into Document Format, save. Reopen: textarea retains the value. Helper text reads "Custom format overrides the type's default structure at regen time."
- [ ] Click Revert on Document Format: textarea clears, placeholder reappears.
- [ ] Same flow for Wiki Style with placeholder = type's system_message.
- [ ] Regen the wiki and confirm the body uses the custom Document Format (sections it specifies appear).
- [ ] Confirm an unedited wiki regen produces the same body as before this change (no behavioral regression for the un-customized case).

## Out of scope

- Backfilling existing wikis. Both columns keep their current values; users adopt the new field by editing it.
- SDK regeneration via \`bun run gen\`. The manual patches keep the typecheck honest until someone runs the regen against a server with this PR.