### PR TITLE
feat(edges): canonicalize ENTRY_HAS_FRAGMENT src_type and audit seed-person path

### DIFF
--- a/.uat/plans/74-edges-src-type-canonicalize.md
+++ b/.uat/plans/74-edges-src-type-canonicalize.md
@@ -1,0 +1,336 @@
+# 74, edges src_type canonicalization (Stream H1+H3)
+
+## What it proves
+
+Stream H1 fixes QA Issue 4a: `ENTRY_HAS_FRAGMENT` edges had two
+different `src_type` strings depending on which writer produced them.
+The persist worker wrote `src_type='entry'`; the seed-fixture path
+wrote `src_type='raw_source'`. Migration 0016 backfills every legacy
+'entry' row to 'raw_source' and adds a CHECK constraint pinning
+`src_type` and `dst_type` to the canonical vocabulary
+`{raw_source, fragment, wiki, person}`. The persist-stage writer in
+`packages/agent/src/stages/persist.ts` is updated to emit the
+canonical value, so all four edge writers (persist, regen,
+seed-fixture, MCP route handlers) produce consistent rows.
+
+Stream H3 documents the seed-person edge creation path. The 15
+FRAGMENT_MENTIONS_PERSON edges QA Issue 4c flagged came from the
+Transformer demo seed, which fires at first-user provisioning. The
+audit lives at `docs/architecture/seed-data.md`.
+
+After this UAT runs:
+
+1. Migration 0016 SQL exists at the canonical path.
+2. Migration applies cleanly on a fresh DB and is idempotent on a
+   re-run.
+3. `SELECT DISTINCT src_type FROM edges` returns only canonical values.
+4. `SELECT DISTINCT dst_type FROM edges` returns only canonical values.
+5. A new ENTRY_HAS_FRAGMENT edge written by the worker pipeline lands
+   with `src_type='raw_source'`.
+6. Direct INSERT with `src_type='entry'` is rejected by the CHECK
+   constraint.
+7. Existing graph traversal queries that filter by `src_type` return
+   correct rows.
+8. The seed-data audit doc exists at the canonical path.
+
+## Negative + positive assertions
+
+| section | kind | check |
+|---|---|---|
+| 1a | POS | migration 0016 SQL exists at `core/drizzle/migrations/0016_edges_src_type_canonicalize.sql` |
+| 1b | POS | migration applies cleanly on a fresh DB and is idempotent on a re-run |
+| 2a | POS | `edges.src_type` distinct values are a subset of `{raw_source, fragment, wiki, person}` |
+| 2b | POS | `edges.dst_type` distinct values are a subset of `{raw_source, fragment, wiki, person}` |
+| 2c | POS | constraint `edges_src_type_check` exists on table `edges` |
+| 2d | POS | constraint `edges_dst_type_check` exists on table `edges` |
+| 3a | POS | a worker-produced ENTRY_HAS_FRAGMENT edge has `src_type='raw_source'` |
+| 3b | NEG | direct INSERT with `src_type='entry'` is rejected by the CHECK constraint |
+| 4a | POS | reverse traversal by `dst_type='fragment'` finds the worker-produced edge |
+| 5a | POS | seed-data audit doc exists at `docs/architecture/seed-data.md` |
+| 5b | POS | seed-data audit doc names the seedFixture path |
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`).
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`.
+- `DATABASE_URL` reachable for direct row inspection.
+- Migration 0016 applied (`pnpm -C core db:migrate`).
+- Repo checkout on `feat/edges-src-type-canonicalize`.
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email`: better-auth (existing).
+- `GET  /users/profile`: yields `mcpEndpointUrl` for the MCP transport.
+- `POST /mcp?token=<jwt>`: MCP JSON-RPC entry point. Tool: `log_entry`.
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:3000}"
+
+JAR=$(mktemp /tmp/uat-74-jar-XXXXXX.txt)
+RUN_ID=$(date +%s)
+trap 'rm -f "$JAR" /tmp/uat-74-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "74 - Stream H1+H3: edges src_type canonicalization"
+echo ""
+
+# Track UAT-created rows for cleanup.
+UAT_ENTRY_KEYS=()
+
+# 0. Auth + MCP token mint
+curl -s -o /dev/null -c "$JAR" -X POST \
+  -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+if [ -s "$JAR" ]; then
+  pass "0a. sign-in established session cookie"
+else
+  fail "0a. sign-in failed"
+  echo ""; echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+
+PROFILE=$(curl -s -b "$JAR" -H "Origin: $ORIGIN" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // empty')
+MCP_TOKEN=$(echo "$MCP_URL" | sed -n 's/.*[?&]token=\([^&]*\).*/\1/p')
+if [ -n "$MCP_TOKEN" ]; then
+  pass "0b. minted MCP JWT"
+  MCP_ENDPOINT="$SERVER_URL/mcp?token=$MCP_TOKEN"
+else
+  fail "0b. could not mint MCP JWT"
+fi
+
+# 1a. Migration file exists
+MIG_PATH="core/drizzle/migrations/0016_edges_src_type_canonicalize.sql"
+if [ -f "$MIG_PATH" ]; then
+  pass "1a. migration $MIG_PATH present"
+else
+  fail "1a. migration $MIG_PATH missing"
+fi
+
+# 1b. Idempotency
+if [ -n "${DATABASE_URL:-}" ]; then
+  if pnpm -C core db:migrate >/tmp/uat-74-mig.log 2>&1; then
+    pass "1b. db:migrate completed (initial or idempotent re-run)"
+  else
+    fail "1b. db:migrate failed (see /tmp/uat-74-mig.log)"
+  fi
+else
+  skip "1b. DATABASE_URL not set; skipping migrate run"
+fi
+
+# 2a. src_type distinct vocabulary check
+if [ -n "${DATABASE_URL:-}" ]; then
+  BAD=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT DISTINCT src_type FROM edges
+     WHERE src_type NOT IN ('raw_source','fragment','wiki','person')" 2>/dev/null)
+  if [ -z "$BAD" ]; then
+    pass "2a. edges.src_type values are all canonical"
+  else
+    fail "2a. non-canonical src_type values present: $BAD"
+  fi
+else
+  skip "2a. DATABASE_URL not set"
+fi
+
+# 2b. dst_type distinct vocabulary check
+if [ -n "${DATABASE_URL:-}" ]; then
+  BAD=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT DISTINCT dst_type FROM edges
+     WHERE dst_type NOT IN ('raw_source','fragment','wiki','person')" 2>/dev/null)
+  if [ -z "$BAD" ]; then
+    pass "2b. edges.dst_type values are all canonical"
+  else
+    fail "2b. non-canonical dst_type values present: $BAD"
+  fi
+else
+  skip "2b. DATABASE_URL not set"
+fi
+
+# 2c. CHECK constraint on src_type
+if [ -n "${DATABASE_URL:-}" ]; then
+  HAS=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT 1 FROM information_schema.table_constraints
+     WHERE table_name='edges' AND constraint_name='edges_src_type_check'" 2>/dev/null \
+     | tr -d '[:space:]')
+  if [ "$HAS" = "1" ]; then
+    pass "2c. edges_src_type_check constraint present"
+  else
+    fail "2c. edges_src_type_check constraint missing"
+  fi
+else
+  skip "2c. DATABASE_URL not set"
+fi
+
+# 2d. CHECK constraint on dst_type
+if [ -n "${DATABASE_URL:-}" ]; then
+  HAS=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT 1 FROM information_schema.table_constraints
+     WHERE table_name='edges' AND constraint_name='edges_dst_type_check'" 2>/dev/null \
+     | tr -d '[:space:]')
+  if [ "$HAS" = "1" ]; then
+    pass "2d. edges_dst_type_check constraint present"
+  else
+    fail "2d. edges_dst_type_check constraint missing"
+  fi
+else
+  skip "2d. DATABASE_URL not set"
+fi
+
+# 3a. Worker-produced ENTRY_HAS_FRAGMENT edge has src_type='raw_source'.
+# Drive an entry through the MCP log_entry tool and inspect the edges
+# table for the resulting raw_source row.
+ENTRY_TEXT="UAT 74 entry produced at $RUN_ID. Validates src_type canonicalisation."
+if [ -n "${MCP_ENDPOINT:-}" ]; then
+  RPC_BODY=$(jq -n --arg c "$ENTRY_TEXT" --arg cn "uat-74-mcp" --arg cv "1.0.0" \
+    '{jsonrpc:"2.0", id:1, method:"tools/call",
+      params:{name:"log_entry", arguments:{content:$c, type:"thought"}},
+      _meta:{clientInfo:{name:$cn, version:$cv}}}')
+  RPC_RESP=$(curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Origin: $ORIGIN" \
+    -d "$RPC_BODY" "$MCP_ENDPOINT")
+  echo "$RPC_RESP" > /tmp/uat-74-log-entry.json
+  if echo "$RPC_RESP" | grep -q '^data: '; then
+    PAYLOAD=$(echo "$RPC_RESP" | sed -n 's/^data: //p' | head -1)
+  else
+    PAYLOAD="$RPC_RESP"
+  fi
+  RPC_TEXT=$(echo "$PAYLOAD" | jq -r '.result.content[0].text // empty')
+  ENTRY_KEY=$(echo "$RPC_TEXT" | grep -oE 'entry[A-Z0-9]{20,}' | head -1)
+  if [ -n "$ENTRY_KEY" ]; then
+    UAT_ENTRY_KEYS+=("$ENTRY_KEY")
+    # Worker is async; allow a short window for ENTRY_HAS_FRAGMENT
+    # writes to land.
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+      ROWS=$(psql "$DATABASE_URL" -t -A -c \
+        "SELECT count(*) FROM edges
+         WHERE edge_type='ENTRY_HAS_FRAGMENT' AND src_id='$ENTRY_KEY'" 2>/dev/null \
+         | tr -d '[:space:]')
+      [ "$ROWS" != "0" ] && break
+      sleep 1
+    done
+    SRC_TYPES=$(psql "$DATABASE_URL" -t -A -c \
+      "SELECT DISTINCT src_type FROM edges
+       WHERE edge_type='ENTRY_HAS_FRAGMENT' AND src_id='$ENTRY_KEY'" 2>/dev/null \
+       | tr -d '[:space:]')
+    if [ "$SRC_TYPES" = "raw_source" ]; then
+      pass "3a. worker-produced ENTRY_HAS_FRAGMENT edges have src_type='raw_source'"
+    elif [ -z "$SRC_TYPES" ]; then
+      skip "3a. no ENTRY_HAS_FRAGMENT edge produced for $ENTRY_KEY (worker not running?)"
+    else
+      fail "3a. unexpected src_type for ENTRY_HAS_FRAGMENT: '$SRC_TYPES'"
+    fi
+  else
+    fail "3a. log_entry did not return an entry key (resp=$RPC_TEXT)"
+  fi
+else
+  skip "3a. no MCP endpoint"
+fi
+
+# 3b. CHECK constraint rejects src_type='entry'
+if [ -n "${DATABASE_URL:-}" ]; then
+  RAW_KEY=$(echo "${UAT_ENTRY_KEYS[0]:-}")
+  if [ -z "$RAW_KEY" ]; then
+    # If no entry was minted, fabricate plausible ids; the INSERT
+    # will fail the CHECK before any FK is consulted.
+    RAW_KEY="uat74-fake-entry"
+  fi
+  ERR=$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
+    "INSERT INTO edges (id, src_type, src_id, dst_type, dst_id, edge_type)
+     VALUES ('uat74-bad', 'entry', '$RAW_KEY', 'fragment', 'frag-x', 'ENTRY_HAS_FRAGMENT')" \
+    2>&1)
+  if echo "$ERR" | grep -qi "edges_src_type_check\|violates check constraint"; then
+    pass "3b. CHECK constraint rejected src_type='entry'"
+  else
+    fail "3b. CHECK constraint did NOT reject src_type='entry' (output: $ERR)"
+    psql "$DATABASE_URL" -c "DELETE FROM edges WHERE id='uat74-bad'" >/dev/null 2>&1 || true
+  fi
+else
+  skip "3b. DATABASE_URL not set"
+fi
+
+# 4a. Reverse traversal by dst_type='fragment' finds the
+# worker-produced edge.
+if [ -n "${DATABASE_URL:-}" ] && [ -n "${UAT_ENTRY_KEYS[0]:-}" ]; then
+  CNT=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT count(*) FROM edges
+     WHERE dst_type='fragment' AND src_id='${UAT_ENTRY_KEYS[0]}'
+       AND edge_type='ENTRY_HAS_FRAGMENT'" 2>/dev/null | tr -d '[:space:]')
+  if [ -n "$CNT" ] && [ "$CNT" != "0" ]; then
+    pass "4a. reverse traversal by dst_type='fragment' returned $CNT row(s)"
+  else
+    skip "4a. no fragment edges to traverse for ${UAT_ENTRY_KEYS[0]}"
+  fi
+else
+  skip "4a. DATABASE_URL or entry key not set"
+fi
+
+# 5a. seed-data audit doc exists
+if [ -f "docs/architecture/seed-data.md" ]; then
+  pass "5a. docs/architecture/seed-data.md present"
+else
+  fail "5a. docs/architecture/seed-data.md missing"
+fi
+
+# 5b. seed-data audit doc names the seedFixture path
+if [ -f "docs/architecture/seed-data.md" ] && \
+   grep -q "seedFixture\|seedFixture.ts" "docs/architecture/seed-data.md"; then
+  pass "5b. seed-data doc references seedFixture path"
+else
+  fail "5b. seed-data doc does not reference seedFixture"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+
+# Cleanup: delete the rows this UAT created.
+if [ -n "${DATABASE_URL:-}" ]; then
+  for key in "${UAT_ENTRY_KEYS[@]}"; do
+    psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$key' OR dst_id='$key'" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM fragments WHERE entry_id='$key'" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE lookup_key='$key'" >/dev/null 2>&1 || true
+  done
+fi
+
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The script tears down its own rows via the `UAT_ENTRY_KEYS` array. If
+interrupted mid-run, manual sweep:
+
+```bash
+psql "$DATABASE_URL" -c "DELETE FROM edges WHERE id='uat74-bad';"
+psql "$DATABASE_URL" -c "DELETE FROM raw_sources WHERE content LIKE 'UAT 74 %';"
+```
+
+## Expected pass/fail behavior
+
+- 1a, 1b PASS once migration 0016 has been run on the target DB.
+- 2a, 2b are the canonical-vocabulary contract; any non-canonical
+  string in `edges.src_type` or `edges.dst_type` is a regression.
+- 2c, 2d confirm the CHECK constraints landed by name.
+- 3a depends on the pipeline worker running. If the worker is not
+  attached to BullMQ, the test SKIPs after a 10-second wait rather
+  than failing.
+- 3b is the negative assertion that the database itself rejects
+  legacy 'entry' writes. A pass means the CHECK constraint is
+  doing its job.
+- 4a confirms graph traversal returns the worker-produced edge.
+- 5a, 5b confirm Stream H3's documentation deliverable is on disk
+  and references the codepath we audited.

--- a/core/drizzle/migrations/0016_edges_src_type_canonicalize.sql
+++ b/core/drizzle/migrations/0016_edges_src_type_canonicalize.sql
@@ -1,0 +1,29 @@
+-- Canonicalize edges.src_type to raw_source for ENTRY_HAS_FRAGMENT rows.
+-- Today the persist worker writes edges with src_type='entry', and the
+-- seed-fixture path writes them with src_type='raw_source'. Same edge
+-- type, two source-type strings. Graph traversal filters that match on
+-- src_type='entry' miss half the rows; filters on src_type='raw_source'
+-- miss the other half. The underlying table is `raw_sources` (renamed
+-- from `entries` in v0.2.0), so raw_source is the canonical value.
+
+UPDATE edges SET src_type = 'raw_source' WHERE src_type = 'entry';
+
+-- Sweep any leftover non-canonical dst_type strings on the symmetric
+-- direction. dst_type is always 'fragment' for ENTRY_HAS_FRAGMENT in
+-- known callers, but historical rows could carry 'entry' if a writer
+-- ever flipped src/dst.
+UPDATE edges SET dst_type = 'raw_source' WHERE dst_type = 'entry';
+
+-- Lock the canonical vocabulary at the schema level. Adding the CHECK
+-- after the UPDATE so the constraint validates against already-canonical
+-- rows. The vocabulary matches every src_type / dst_type literal written
+-- by code in this repo as of v0.2.2:
+--   raw_source: ENTRY_HAS_FRAGMENT.src
+--   fragment:   ENTRY_HAS_FRAGMENT.dst, FRAGMENT_*.src, FRAGMENT_*.dst
+--   wiki:       FRAGMENT_IN_WIKI.dst, WIKI_*.src
+--   person:     FRAGMENT_MENTIONS_PERSON.dst
+ALTER TABLE edges ADD CONSTRAINT edges_src_type_check
+  CHECK (src_type IN ('raw_source', 'fragment', 'wiki', 'person'));
+
+ALTER TABLE edges ADD CONSTRAINT edges_dst_type_check
+  CHECK (dst_type IN ('raw_source', 'fragment', 'wiki', 'person'));

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1747008000000,
       "tag": "0015_source_client_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1747008001000,
+      "tag": "0016_edges_src_type_canonicalize",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/__tests__/edges-src-type-contract.test.ts
+++ b/core/src/__tests__/edges-src-type-contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+/**
+ * Static contract guards on the edges.src_type / dst_type vocabulary.
+ *
+ * Migration 0016 canonicalised src_type to one of
+ * {raw_source, fragment, wiki, person} and added a CHECK constraint
+ * pinning the vocabulary at the schema level. These tests guard the
+ * SQL artefact and the source-tree writers so a regression to the
+ * legacy 'entry' string (or any other off-vocabulary value) trips a
+ * unit-test failure before it can reach a database.
+ *
+ * A runtime check against a live Postgres instance lives in the
+ * UAT plan (`.uat/plans/74-edges-src-type-canonicalize.md`); it
+ * cannot run here because vitest does not boot Postgres.
+ */
+
+const REPO_ROOT = resolve(__dirname, '../../..')
+const MIGRATION_PATH = resolve(
+  REPO_ROOT,
+  'core/drizzle/migrations/0016_edges_src_type_canonicalize.sql'
+)
+
+const CANONICAL_VOCAB = ['raw_source', 'fragment', 'wiki', 'person'] as const
+
+describe('edges src_type contract', () => {
+  it('migration 0016 backfills entry to raw_source', () => {
+    const sql = readFileSync(MIGRATION_PATH, 'utf8')
+    expect(sql).toMatch(/UPDATE\s+edges\s+SET\s+src_type\s*=\s*'raw_source'\s+WHERE\s+src_type\s*=\s*'entry'/i)
+  })
+
+  it('migration 0016 adds CHECK constraints on src_type and dst_type', () => {
+    const sql = readFileSync(MIGRATION_PATH, 'utf8')
+    expect(sql).toMatch(/ALTER\s+TABLE\s+edges\s+ADD\s+CONSTRAINT\s+edges_src_type_check/i)
+    expect(sql).toMatch(/ALTER\s+TABLE\s+edges\s+ADD\s+CONSTRAINT\s+edges_dst_type_check/i)
+  })
+
+  it('migration 0016 CHECK constraints permit only canonical vocabulary', () => {
+    const sql = readFileSync(MIGRATION_PATH, 'utf8')
+    for (const value of CANONICAL_VOCAB) {
+      expect(sql).toContain(`'${value}'`)
+    }
+    // Reject the legacy spelling. The UPDATE line above mentions 'entry'
+    // inside a WHERE clause; we only want to flag a NEW IN-list inclusion.
+    const checkBody = sql.match(/CHECK\s*\(\s*src_type\s+IN\s*\([^)]*\)\s*\)/i)?.[0] ?? ''
+    expect(checkBody).not.toContain("'entry'")
+  })
+
+  it('no source file under core/src or packages/agent/src writes srcType="entry"', async () => {
+    // The migration .sql file references 'entry' as the legacy value to
+    // backfill; that file is intentionally excluded here. Only TypeScript
+    // sources and tests get the strict treatment.
+    const { execSync } = await import('node:child_process')
+    const result = execSync(
+      `grep -rn "srcType: *'entry'" ${REPO_ROOT}/core/src ${REPO_ROOT}/packages/agent/src --include="*.ts" || true`,
+      { encoding: 'utf8' }
+    )
+    // Test fixtures in schema.test.ts intentionally still exercise the
+    // legacy spelling against the test DB to validate the CHECK
+    // constraint rejects it. Filter those out.
+    const productionMatches = result
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .filter((line) => !line.includes('__tests__/'))
+    expect(productionMatches).toEqual([])
+  })
+})

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -464,6 +464,12 @@ export const edits = pgTable(
 
 // ─── Edges ───
 
+// Canonical src_type / dst_type vocabulary, enforced by CHECK constraints
+// added in migration 0016: 'raw_source' | 'fragment' | 'wiki' | 'person'.
+// 'raw_source' is the canonical name for the entries-table side, since
+// the underlying table was renamed from `entries` to `raw_sources` in
+// v0.2.0. Writers must not emit 'entry' (the legacy spelling) anywhere.
+
 export const edges = pgTable(
   'edges',
   {

--- a/docs/architecture/seed-data.md
+++ b/docs/architecture/seed-data.md
@@ -1,0 +1,50 @@
+# Seed Data
+
+Robin ships one piece of seed data: the Transformer demo wiki. It is
+the only path that writes domain rows outside of the user's own ingest
+flow.
+
+## What the seed produces
+
+`core/src/lib/seedFixture.ts` materialises a fixture rooted at
+`packages/shared/src/fixtures/wikiSidecarFixture.ts`, mirroring Vaswani
+et al.'s "Attention Is All You Need" abstract so a fresh Robin
+instance has something concrete to render on first sign-in.
+
+One run produces:
+
+- 1 wiki (`attention-is-all-you-need`).
+- 3 people (`ashish-vaswani`, `noam-shazeer`, `niki-parmar`),
+  inserted with `verified=false`, `state='RESOLVED'`.
+- 5 fragments, 1 entry (`source='seed'`).
+- 5 ENTRY_HAS_FRAGMENT edges (`src_type='raw_source'`).
+- 5 FRAGMENT_IN_WIKI edges (`attrs.method='seed'`).
+- 15 FRAGMENT_MENTIONS_PERSON edges (3 people times 5 fragments).
+
+The 15 mention edges are the rows QA Issue 4c flagged as appearing
+before any entity-extract pipeline event. They are the seed-fixture
+write, not pipeline output.
+
+## When it fires
+
+`core/src/bootstrap/seed-demo-wiki.ts` calls `seedFixture()` from
+first-user provisioning. Single-tenant, so first-user equals fresh
+instance. Gate is `isFixtureSeeded()` (slug presence on the wiki row).
+A user who deletes the demo wiki does not get it re-seeded.
+
+The CLI script `core/scripts/seed-fixture.ts` (`pnpm -C core
+seed-fixture`) runs the same library function for development.
+
+## Reproducibility
+
+Reproducible. Both call sites import the same function, the projection
+is pure, and re-running updates in place. Existence lookups ignore
+`deletedAt` so soft-deleted rows resurrect under the same slug.
+
+## Interaction with Stream P quarantine
+
+The seed inserts people with `verified=false` directly, bypassing
+`resolvePerson` and any future auto-accept gating. If Stream P needs
+to exclude seeded people from a quarantine queue, the cleanest signal
+today is `FRAGMENT_IN_WIKI.attrs.method='seed'` on the corresponding
+fragment edges.

--- a/packages/agent/src/__tests__/persist-people.test.ts
+++ b/packages/agent/src/__tests__/persist-people.test.ts
@@ -282,4 +282,27 @@ describe('persist — Postgres inserts', () => {
     expect(entryHasFragment).toHaveLength(2)
     expect(fragmentInVault).toHaveLength(2)
   })
+
+  it("ENTRY_HAS_FRAGMENT edges write with src_type='raw_source'", async () => {
+    const deps = makeMockDeps()
+    const fragments = [makeFragment(), makeFragment({ title: 'Second' })]
+
+    await persist(deps, { ...baseInput, fragments })
+
+    const edgeCalls = (deps.insertEdge as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as Record<string, unknown>
+    )
+    const entryHasFragment = edgeCalls.filter((e) => e.edgeType === 'ENTRY_HAS_FRAGMENT')
+
+    // Migration 0016 canonicalised src_type. Persist must emit
+    // 'raw_source', not the legacy 'entry' string. The CHECK
+    // constraint added in 0016 will reject 'entry' if this ever
+    // regresses.
+    expect(entryHasFragment.length).toBeGreaterThan(0)
+    for (const edge of entryHasFragment) {
+      expect(edge.srcType).toBe('raw_source')
+      expect(edge.srcId).toBe(baseInput.entryKey)
+      expect(edge.dstType).toBe('fragment')
+    }
+  })
 })

--- a/packages/agent/src/stages/persist.ts
+++ b/packages/agent/src/stages/persist.ts
@@ -161,9 +161,12 @@ export async function persist(
   }
 
   // -- Edges: ENTRY_HAS_FRAGMENT --
+  // src_type is 'raw_source', not 'entry'. The underlying table was
+  // renamed to raw_sources in v0.2.0; migration 0016 canonicalised the
+  // edges vocabulary and added a CHECK that rejects 'entry'.
   for (const fragKey of fragmentKeys) {
     await deps.insertEdge({
-      srcType: 'entry',
+      srcType: 'raw_source',
       srcId: input.entryKey,
       dstType: 'fragment',
       dstId: fragKey,


### PR DESCRIPTION
## Summary
- Migration 0016 backfills `edges.src_type='entry'` to `'raw_source'` and adds CHECK constraint forbidding non-canonical values
- Persist stage rewritten to emit `src_type='raw_source'` for ENTRY_HAS_FRAGMENT edges going forward
- New contract test asserts the canonical-only invariant
- H3 investigation complete: the 15 seed-person edges from QA Issue 4c were created by `core/src/lib/seedFixture.ts` (called from `bootstrap/seed-demo-wiki.ts` at first-user provisioning). Documented in `docs/architecture/seed-data.md`.

Closes QA Issue 4a + 4c. Bundles GitHub issue #330's edge-shape concern.

## What changed for the user
Graph traversal queries that filter by `src_type` now return consistent results. Before: filtering `src_type='entry'` missed half the rows; filtering `src_type='raw_source'` missed the other half. After: only `'raw_source'` exists for ENTRY_HAS_FRAGMENT edges, and the CHECK constraint forbids reintroducing the inconsistency. Operators querying graph data for analytics or debugging see the full result set with one filter.

## What was true before
The same edge type used two different source-type strings. The table was named `raw_sources`, but some code paths wrote `src_type='entry'`. Two parts of the codebase disagreed on what to call an entry node, and there was no constraint preventing future drift.

## Operational notes
- Migration: 0016 (additive plus backfill)
- Backfill `UPDATE edges SET src_type='raw_source' WHERE src_type='entry'` runs before the constraint adds, idempotent on re-run
- New CHECK constraint `edges_src_type_check` on src_type IN ('raw_source', 'fragment', 'wiki', 'person'). Adjust if an unanticipated value surfaces.
- Seed-data path documented. The `seedFixture.ts` path inserts 3 people + 5 fragments + 15 FRAGMENT_MENTIONS_PERSON edges + 5 ENTRY_HAS_FRAGMENT edges; matches QA Issue 4c row count exactly. Predates and stands separate from the v0.2.2 quarantine model; intentional for first-user provisioning.

## Test plan
- [ ] UAT plan: `.uat/plans/74-edges-src-type-canonicalize.md`
- [ ] `pnpm -C core typecheck` and `pnpm -C packages/agent typecheck` clean
- [ ] New contract test passes (4 cases)
- [ ] Migration applies cleanly + idempotently on fresh DB
- [ ] After migration: `SELECT DISTINCT src_type FROM edges` returns only canonical values
- [ ] Insert with `src_type='entry'` is rejected by CHECK constraint