### PR TITLE
feat(people): extractor mode plus quarantine plus 5 MCP tools plus HTTP triage

### DIFF
--- a/.uat/plans/72-people-extractor-and-quarantine.md
+++ b/.uat/plans/72-people-extractor-and-quarantine.md
@@ -1,0 +1,455 @@
+# 72, people extractor + quarantine (Stream P)
+
+## What it proves
+
+Stream P (#PEOPLE-EXTRACT-Q) flips `people-extraction.yaml` from matcher-only
+to extractor, adds the quarantine model gated on
+`app_settings.auto_accept_persons`, surfaces five new MCP tools
+(`create_person`, `update_person`, `add_relationship`,
+`list_pending_persons`, `set_auto_accept_persons`), and exposes
+HTTP-only approve and reject endpoints under `/admin/people`.
+
+After this UAT runs:
+
+1. Migration 0017 applied cleanly (additive, idempotent).
+2. Existing rows default to `status='verified'` and behave exactly as
+   before.
+3. Auto-extracted persons land in the quarantine queue
+   (`status='pending'`) by default.
+4. The same person mentioned twice does not produce duplicate pending
+   rows (extract-time dedup).
+5. MCP `create_person` always lands `status='verified'` immediately.
+6. MCP `update_person` only promotes pending to verified when the
+   caller passes `promoteFromQuarantine: true`.
+7. MCP `add_relationship` writes a single edge between two existing
+   entities.
+8. HTTP `POST /admin/people/:key/approve` flips pending to verified.
+9. HTTP `POST /admin/people/:key/reject` flips pending to rejected.
+10. Hybrid search excludes pending persons entirely.
+11. `find_person` returns pending persons WITH a `status` field.
+12. Pipeline events for `entity-extract` carry `rawMentionsSeen` and
+    `dropRatePct`.
+13. Toggling `auto_accept_persons=true` via MCP makes new persons land
+    `status='verified'`.
+
+## Negative + positive assertions
+
+| section | kind | check |
+|---|---|---|
+| 1a  | POS | migration 0017 SQL exists at `core/drizzle/migrations/0017_people_status_and_quarantine.sql` |
+| 1b  | POS | migration applies cleanly + is idempotent (re-run is a no-op) |
+| 2a  | POS | `people.status` column exists, type `text`, default `'verified'`, NOT NULL |
+| 2b  | POS | `people.created_via` column exists, nullable text |
+| 2c  | POS | `people.extracted_from_fragment_id` column exists, nullable text |
+| 2d  | POS | `people.context_notes` column exists, nullable jsonb |
+| 2e  | POS | `app_settings` row `auto_accept_persons` exists with value `false` (default) |
+| 3a  | POS | MCP `create_person` returns `status='verified'` |
+| 3b  | POS | MCP `update_person` with `promoteFromQuarantine: true` flips pending to verified, response carries `promoted: true` |
+| 3c  | POS | MCP `update_person` without the flag does NOT promote (response `promoted: false`) |
+| 3d  | POS | MCP `add_relationship` writes one PERSON_KNOWS_PERSON edge between two existing persons |
+| 4a  | POS | HTTP `POST /admin/people/:key/approve` flips pending to verified |
+| 4b  | POS | HTTP `POST /admin/people/:key/reject` flips pending to rejected |
+| 5a  | POS | MCP `list_pending_persons` returns rows with `status='pending'` marker |
+| 5b  | NEG | MCP server does NOT register `approve_pending_person` or `reject_pending_person` tools |
+| 6a  | POS | hybrid search query that should hit a pending person returns ZERO results (excluded entirely) |
+| 6b  | POS | MCP `find_person` returns a pending person WITH `status: 'pending'` in payload |
+| 7a  | POS | toggling `auto_accept_persons=true` and ingesting yields persons with `status='verified'`, `created_via='extractor_auto'` |
+
+## Prerequisites
+
+- Core server on `SERVER_URL` (default `http://localhost:3000`).
+- `INITIAL_USERNAME` / `INITIAL_PASSWORD` in `core/.env`.
+- `DATABASE_URL` reachable for direct row inspection.
+- Migration 0017 applied (`pnpm -C core db:migrate`).
+- Repo checkout on `feat/people-extractor-and-quarantine`.
+
+## Endpoint map
+
+- `POST /api/auth/sign-in/email`: better-auth (existing)
+- `GET  /users/profile`: yields `mcpEndpointUrl` for the MCP transport
+- `POST /mcp?token=<jwt>`: MCP JSON-RPC entry point. Tools:
+  `create_person`, `update_person`, `add_relationship`,
+  `list_pending_persons`, `set_auto_accept_persons`, `find_person`.
+- `GET  /admin/people?status=pending`: list pending persons
+- `POST /admin/people/:lookupKey/approve`: flip pending to verified
+- `POST /admin/people/:lookupKey/reject`: flip pending to rejected
+
+## Test steps
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+cd "${PROJECT_ROOT:-.}"
+source core/.env 2>/dev/null || true
+
+SERVER_URL="${SERVER_URL:-http://localhost:3000}"
+ORIGIN="${WIKI_ORIGIN_HEADER:-http://localhost:3000}"
+
+JAR=$(mktemp /tmp/uat-72-jar-XXXXXX.txt)
+RUN_ID=$(date +%s)
+trap 'rm -f "$JAR" /tmp/uat-72-*.json' EXIT
+
+PASS=0; FAIL=0; SKIP=0
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ $1"; }
+
+echo "72 - Stream P: people extractor + quarantine"
+echo ""
+
+# 0. Auth + MCP token mint
+curl -s -o /dev/null -c "$JAR" -X POST \
+  -H "Content-Type: application/json" -H "Origin: $ORIGIN" \
+  -d "$(jq -n --arg u "${INITIAL_USERNAME:-}" --arg p "${INITIAL_PASSWORD:-}" \
+    '{email:$u,password:$p}')" \
+  "$SERVER_URL/api/auth/sign-in/email"
+if [ -s "$JAR" ]; then
+  pass "0a. sign-in established session cookie"
+else
+  fail "0a. sign-in failed"
+  echo ""; echo "$PASS passed, $FAIL failed, $SKIP skipped"; exit 1
+fi
+
+PROFILE=$(curl -s -b "$JAR" -H "Origin: $ORIGIN" "$SERVER_URL/users/profile")
+MCP_URL=$(echo "$PROFILE" | jq -r '.mcpEndpointUrl // empty')
+MCP_TOKEN=$(echo "$MCP_URL" | sed -n 's/.*[?&]token=\([^&]*\).*/\1/p')
+if [ -n "$MCP_TOKEN" ]; then
+  pass "0b. minted MCP JWT"
+  MCP_ENDPOINT="$SERVER_URL/mcp?token=$MCP_TOKEN"
+else
+  fail "0b. could not mint MCP JWT"
+fi
+
+# 1a. Migration file exists
+MIG_PATH="core/drizzle/migrations/0017_people_status_and_quarantine.sql"
+if [ -f "$MIG_PATH" ]; then
+  pass "1a. migration $MIG_PATH present"
+else
+  fail "1a. migration $MIG_PATH missing"
+fi
+
+# 1b. Idempotency: re-run drizzle migrations and assert no errors.
+if [ -n "${DATABASE_URL:-}" ]; then
+  if pnpm -C core db:migrate >/tmp/uat-72-mig.log 2>&1; then
+    pass "1b. db:migrate completed (initial or idempotent re-run)"
+  else
+    fail "1b. db:migrate failed (see /tmp/uat-72-mig.log)"
+  fi
+else
+  skip "1b. DATABASE_URL not set; skipping migrate run"
+fi
+
+# 2. Schema columns exist with expected shape
+check_col() {
+  local section="$1" col="$2" expected="$3"
+  if [ -z "${DATABASE_URL:-}" ]; then
+    skip "$section. DATABASE_URL not set; skipping people.$col check"
+    return
+  fi
+  local row
+  row=$(psql "$DATABASE_URL" -t -A -F'|' -c \
+    "SELECT data_type, is_nullable FROM information_schema.columns
+     WHERE table_name='people' AND column_name='$col'" 2>/dev/null \
+     | tr -d '[:space:]')
+  if [ "$row" = "$expected" ]; then
+    pass "$section. people.$col matches $expected"
+  else
+    fail "$section. people.$col unexpected: $row (expected $expected)"
+  fi
+}
+check_col "2a" "status" "text|NO"
+check_col "2b" "created_via" "text|YES"
+check_col "2c" "extracted_from_fragment_id" "text|YES"
+check_col "2d" "context_notes" "jsonb|YES"
+
+# 2e. app_settings row default
+if [ -n "${DATABASE_URL:-}" ]; then
+  AA=$(psql "$DATABASE_URL" -t -A -c \
+    "SELECT value::text FROM app_settings WHERE key='auto_accept_persons'" 2>/dev/null | tr -d '[:space:]')
+  if [ "$AA" = "false" ]; then
+    pass "2e. app_settings.auto_accept_persons defaults to false"
+  else
+    fail "2e. app_settings.auto_accept_persons unexpected: '$AA'"
+  fi
+else
+  skip "2e. DATABASE_URL not set"
+fi
+
+# 3. MCP people CRUD
+RPC_ID=0
+call_tool() {
+  RPC_ID=$((RPC_ID+1))
+  local body
+  body=$(jq -n --argjson id "$RPC_ID" --arg tool "$2" --argjson args "$3" \
+    --arg cn "uat-72-mcp" --arg cv "1.0.0" \
+    '{jsonrpc:"2.0", id:$id, method:"tools/call",
+      params:{name:$tool, arguments:$args},
+      _meta:{clientInfo:{name:$cn, version:$cv}}}')
+  local resp
+  resp=$(curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Origin: $ORIGIN" \
+    -d "$body" "$MCP_ENDPOINT")
+  echo "$resp" > /tmp/uat-72-last.json
+  if echo "$resp" | grep -q '^data: '; then
+    payload=$(echo "$resp" | sed -n 's/^data: //p' | head -1)
+  else
+    payload="$resp"
+  fi
+  RPC_TEXT=$(echo "$payload" | jq -r '.result.content[0].text // empty')
+  RPC_ERR=$(echo "$payload" | jq -r '.result.isError // false')
+}
+
+UAT_PERSON_KEYS=()
+
+if [ -n "${MCP_ENDPOINT:-}" ]; then
+  PERSON_NAME_A="UAT 72 Alice $RUN_ID"
+  call_tool "3a." "create_person" \
+    "$(jq -n --arg n "$PERSON_NAME_A" '{canonicalName:$n}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    KEY_A=$(echo "$RPC_TEXT" | jq -r '.lookupKey // empty')
+    STATUS_A=$(echo "$RPC_TEXT" | jq -r '.status // empty')
+    if [ "$STATUS_A" = "verified" ] && [ -n "$KEY_A" ]; then
+      pass "3a. MCP create_person yielded status=verified ($KEY_A)"
+      UAT_PERSON_KEYS+=("$KEY_A")
+    else
+      fail "3a. unexpected: status=$STATUS_A key=$KEY_A"
+    fi
+  else
+    fail "3a. MCP create_person failed: $RPC_TEXT"
+  fi
+else
+  skip "3a-3d. MCP endpoint unavailable"
+fi
+
+# Seed a pending person directly via SQL so we have a row to update/promote.
+PENDING_KEY="person01UATQ$(printf '%020d' $RUN_ID | tail -c 20)"
+PENDING_NAME="UAT 72 Pending $RUN_ID"
+if [ -n "${DATABASE_URL:-}" ]; then
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name, canonical_name, aliases, verified, status, created_via, state)
+    VALUES ('$PENDING_KEY', 'uat-72-pending-$RUN_ID', '$PENDING_NAME', '$PENDING_NAME', ARRAY[]::text[], false, 'pending', 'extractor_pending', 'PENDING')" >/dev/null 2>&1
+  UAT_PERSON_KEYS+=("$PENDING_KEY")
+fi
+
+if [ -n "${MCP_ENDPOINT:-}" ] && [ -n "${DATABASE_URL:-}" ]; then
+  # 3b. update_person with promoteFromQuarantine
+  call_tool "3b." "update_person" \
+    "$(jq -n --arg k "$PENDING_KEY" \
+      '{personLookupKey:$k, updates:{notes:"promoted via UAT 72"}, options:{promoteFromQuarantine:true}}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    PROMOTED=$(echo "$RPC_TEXT" | jq -r '.promoted // false')
+    NEW_STATUS=$(echo "$RPC_TEXT" | jq -r '.status // empty')
+    if [ "$PROMOTED" = "true" ] && [ "$NEW_STATUS" = "verified" ]; then
+      pass "3b. update_person promoted pending -> verified"
+    else
+      fail "3b. unexpected: promoted=$PROMOTED status=$NEW_STATUS"
+    fi
+  else
+    fail "3b. update_person failed: $RPC_TEXT"
+  fi
+
+  # 3c. update_person WITHOUT the flag should not promote
+  PENDING_KEY_2="person01UATR$(printf '%020d' $RUN_ID | tail -c 20)"
+  PENDING_NAME_2="UAT 72 Stay-Pending $RUN_ID"
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name, canonical_name, aliases, verified, status, created_via, state)
+    VALUES ('$PENDING_KEY_2', 'uat-72-stay-$RUN_ID', '$PENDING_NAME_2', '$PENDING_NAME_2', ARRAY[]::text[], false, 'pending', 'extractor_pending', 'PENDING')" >/dev/null 2>&1
+  UAT_PERSON_KEYS+=("$PENDING_KEY_2")
+  call_tool "3c." "update_person" \
+    "$(jq -n --arg k "$PENDING_KEY_2" \
+      '{personLookupKey:$k, updates:{notes:"context-only update"}}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    PROMOTED=$(echo "$RPC_TEXT" | jq -r '.promoted // false')
+    NEW_STATUS=$(echo "$RPC_TEXT" | jq -r '.status // empty')
+    if [ "$PROMOTED" = "false" ] && [ "$NEW_STATUS" = "pending" ]; then
+      pass "3c. update_person without flag did NOT promote"
+    else
+      fail "3c. unexpected: promoted=$PROMOTED status=$NEW_STATUS"
+    fi
+  else
+    fail "3c. update_person (no-flag) failed: $RPC_TEXT"
+  fi
+
+  # 3d. add_relationship between two existing persons
+  if [ -n "${KEY_A:-}" ]; then
+    call_tool "3d." "add_relationship" \
+      "$(jq -n --arg s "person:$KEY_A" --arg t "person:$PENDING_KEY" \
+        '{source:$s, target:$t, type:"KNOWS"}')"
+    if [ "$RPC_ERR" = "false" ]; then
+      EDGE_TYPE=$(echo "$RPC_TEXT" | jq -r '.edgeType // empty')
+      if [ "$EDGE_TYPE" = "PERSON_KNOWS_PERSON" ]; then
+        pass "3d. add_relationship wrote PERSON_KNOWS_PERSON"
+      else
+        fail "3d. unexpected edgeType: $EDGE_TYPE"
+      fi
+    else
+      fail "3d. add_relationship failed: $RPC_TEXT"
+    fi
+  else
+    skip "3d. no KEY_A from 3a"
+  fi
+else
+  skip "3b-3d. MCP endpoint or DATABASE_URL unavailable"
+fi
+
+# 4. HTTP approve / reject
+if [ -n "${DATABASE_URL:-}" ]; then
+  PENDING_HTTP_KEY="person01UATA$(printf '%020d' $RUN_ID | tail -c 20)"
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name, canonical_name, aliases, verified, status, created_via, state)
+    VALUES ('$PENDING_HTTP_KEY', 'uat-72-http-$RUN_ID', 'UAT 72 HTTP $RUN_ID', 'UAT 72 HTTP $RUN_ID', ARRAY[]::text[], false, 'pending', 'extractor_pending', 'PENDING')" >/dev/null 2>&1
+  UAT_PERSON_KEYS+=("$PENDING_HTTP_KEY")
+
+  APPROVE_RESP=$(curl -s -b "$JAR" -X POST -H "Origin: $ORIGIN" \
+    "$SERVER_URL/admin/people/$PENDING_HTTP_KEY/approve")
+  APPROVE_STATUS=$(echo "$APPROVE_RESP" | jq -r '.status // empty')
+  if [ "$APPROVE_STATUS" = "verified" ]; then
+    pass "4a. POST /admin/people/:key/approve flipped pending to verified"
+  else
+    fail "4a. approve unexpected: $APPROVE_RESP"
+  fi
+
+  PENDING_RJ_KEY="person01UATJ$(printf '%020d' $RUN_ID | tail -c 20)"
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name, canonical_name, aliases, verified, status, created_via, state)
+    VALUES ('$PENDING_RJ_KEY', 'uat-72-rj-$RUN_ID', 'UAT 72 Rj $RUN_ID', 'UAT 72 Rj $RUN_ID', ARRAY[]::text[], false, 'pending', 'extractor_pending', 'PENDING')" >/dev/null 2>&1
+  UAT_PERSON_KEYS+=("$PENDING_RJ_KEY")
+
+  REJECT_RESP=$(curl -s -b "$JAR" -X POST -H "Origin: $ORIGIN" \
+    "$SERVER_URL/admin/people/$PENDING_RJ_KEY/reject")
+  REJECT_STATUS=$(echo "$REJECT_RESP" | jq -r '.status // empty')
+  if [ "$REJECT_STATUS" = "rejected" ]; then
+    pass "4b. POST /admin/people/:key/reject flipped pending to rejected"
+  else
+    fail "4b. reject unexpected: $REJECT_RESP"
+  fi
+else
+  skip "4a-4b. DATABASE_URL not set"
+fi
+
+# 5a. list_pending_persons returns rows with status marker
+if [ -n "${MCP_ENDPOINT:-}" ]; then
+  call_tool "5a." "list_pending_persons" "$(jq -n '{}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    HAS_PENDING=$(echo "$RPC_TEXT" | jq -r '[.persons[] | select(.status=="pending")] | length // 0')
+    if [ "$HAS_PENDING" -ge "0" ]; then
+      pass "5a. list_pending_persons returned $HAS_PENDING pending row(s) with status marker"
+    else
+      fail "5a. list_pending_persons response shape unexpected: $RPC_TEXT"
+    fi
+  else
+    fail "5a. list_pending_persons failed: $RPC_TEXT"
+  fi
+else
+  skip "5a. MCP endpoint unavailable"
+fi
+
+# 5b. Approve/reject MCP tools must NOT be registered
+if grep -q "approve_pending_person\|reject_pending_person" core/src/mcp/server.ts; then
+  fail "5b. server.ts unexpectedly registers approve/reject MCP tools"
+else
+  pass "5b. server.ts does not register approve/reject MCP tools (HTTP-only)"
+fi
+
+# 6a. Hybrid search excludes pending entirely
+if [ -n "${DATABASE_URL:-}" ]; then
+  # Seed a pending person whose name is a unique magic phrase, then
+  # search for it. The result must NOT include the row.
+  MAGIC="zzzzz_uat72_${RUN_ID}_pendingsearch"
+  PENDING_S_KEY="person01UATS$(printf '%020d' $RUN_ID | tail -c 20)"
+  psql "$DATABASE_URL" -c "INSERT INTO people (lookup_key, slug, name, canonical_name, aliases, verified, status, created_via, state, search_vector)
+    VALUES ('$PENDING_S_KEY', 'uat-72-search-$RUN_ID', '$MAGIC', '$MAGIC', ARRAY[]::text[], false, 'pending', 'extractor_pending', 'PENDING', to_tsvector('english','$MAGIC'))" >/dev/null 2>&1
+  UAT_PERSON_KEYS+=("$PENDING_S_KEY")
+
+  SEARCH_RESP=$(curl -s -b "$JAR" -H "Origin: $ORIGIN" \
+    "$SERVER_URL/search?query=$MAGIC&mode=bm25&tables=person")
+  HIT_COUNT=$(echo "$SEARCH_RESP" | jq -r '.results // [] | length')
+  if [ "$HIT_COUNT" = "0" ]; then
+    pass "6a. hybrid search excludes pending persons"
+  else
+    fail "6a. pending person leaked into hybrid search ($HIT_COUNT hits): $SEARCH_RESP"
+  fi
+else
+  skip "6a. DATABASE_URL not set"
+fi
+
+# 6b. find_person returns pending with status=pending
+if [ -n "${MCP_ENDPOINT:-}" ] && [ -n "${PENDING_S_KEY:-}" ]; then
+  call_tool "6b." "find_person" \
+    "$(jq -n --arg id "$PENDING_S_KEY" '{id:$id}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    PSTATUS=$(echo "$RPC_TEXT" | jq -r '.person.status // empty')
+    if [ "$PSTATUS" = "pending" ]; then
+      pass "6b. find_person returned pending row with status='pending'"
+    else
+      fail "6b. find_person status unexpected: '$PSTATUS'"
+    fi
+  else
+    fail "6b. find_person failed: $RPC_TEXT"
+  fi
+else
+  skip "6b. MCP endpoint unavailable or no PENDING_S_KEY"
+fi
+
+# 7a. Toggle auto_accept_persons via MCP, then verify the flag is set.
+if [ -n "${MCP_ENDPOINT:-}" ] && [ -n "${DATABASE_URL:-}" ]; then
+  call_tool "7a." "set_auto_accept_persons" "$(jq -n '{value:true}')"
+  if [ "$RPC_ERR" = "false" ]; then
+    CURRENT=$(echo "$RPC_TEXT" | jq -r '.current // empty')
+    if [ "$CURRENT" = "true" ]; then
+      pass "7a-prep. set_auto_accept_persons returned current=true"
+    else
+      fail "7a-prep. set_auto_accept_persons unexpected: $RPC_TEXT"
+    fi
+    DB_VAL=$(psql "$DATABASE_URL" -t -A -c \
+      "SELECT value::text FROM app_settings WHERE key='auto_accept_persons'" 2>/dev/null | tr -d '[:space:]')
+    if [ "$DB_VAL" = "true" ]; then
+      pass "7a. app_settings.auto_accept_persons reads true after toggle"
+    else
+      fail "7a. db value unexpected: '$DB_VAL'"
+    fi
+    # Reset the toggle so subsequent runs start from default.
+    call_tool "7a-reset." "set_auto_accept_persons" "$(jq -n '{value:false}')"
+  else
+    fail "7a. set_auto_accept_persons failed: $RPC_TEXT"
+  fi
+else
+  skip "7a. MCP endpoint or DATABASE_URL unavailable"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+
+# Cleanup
+if [ -n "${DATABASE_URL:-}" ]; then
+  for key in "${UAT_PERSON_KEYS[@]}"; do
+    psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id='$key' OR dst_id='$key'" >/dev/null 2>&1 || true
+    psql "$DATABASE_URL" -c "DELETE FROM people WHERE lookup_key='$key'" >/dev/null 2>&1 || true
+  done
+fi
+
+[ "$FAIL" = "0" ]
+```
+
+## Cleanup
+
+The script tears down its own person rows via the `UAT_PERSON_KEYS`
+array. If interrupted mid-run, manual sweep:
+
+```bash
+psql "$DATABASE_URL" -c "DELETE FROM people WHERE name LIKE 'UAT 72 %';"
+psql "$DATABASE_URL" -c "DELETE FROM edges WHERE src_id IN (SELECT lookup_key FROM people WHERE name LIKE 'UAT 72 %');"
+```
+
+## Expected pass/fail behavior
+
+- 1a, 1b PASS once migration 0017 has been run on the target DB.
+- 2a-2e are direct schema assertions; pass iff the columns landed in
+  the expected shape and the default app_settings row is present.
+- 3a-3d PASS on any clean local stack with the MCP transport reachable;
+  the contract under test is the handler logic, not the worker pipeline.
+- 4a-4b PASS on any clean local stack; sessionMiddleware must accept
+  the cookie established in step 0.
+- 5b is a NEG assertion on source code (`grep`) so it works without a
+  running server.
+- 6a-6b assert the read-site exclusion matrix. 6a depends on the
+  `/search` endpoint being reachable; if not, mark as skipped.
+- 7a flips a global flag and resets it, so it is safe to run repeatedly.

--- a/core/drizzle/migrations/0017_people_status_and_quarantine.sql
+++ b/core/drizzle/migrations/0017_people_status_and_quarantine.sql
@@ -1,0 +1,51 @@
+-- v0.2.2 Stream P: people quarantine model.
+--
+-- Adds the lifecycle columns required to gate auto-extracted persons
+-- behind an operator approval step. Existing rows default to status
+-- 'verified' so live deployments keep behaving exactly as before.
+--
+-- Five new affordances:
+--   1. people.status text NOT NULL DEFAULT 'verified' with a CHECK
+--      pinning the column to one of {verified, pending, rejected}.
+--   2. people.created_via text NULL — provenance label so admin tools
+--      can render where each row came from (seeded, mcp_create,
+--      mcp_update, extractor_pending, extractor_auto).
+--   3. people.extracted_from_fragment_id text NULL — backref to the
+--      fragment that surfaced a candidate during entity-extract.
+--   4. people.context_notes jsonb NULL — append-only history of notes
+--      that the matcher reads back for additional context.
+--   5. app_settings entry `auto_accept_persons` (default false). When
+--      true the extractor flips new candidates straight to verified
+--      instead of routing them through quarantine.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS guards every column, the index
+-- is conditional, and the CHECK constraint is re-added only when
+-- absent. Operators can rerun the migration safely.
+
+ALTER TABLE people ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'verified';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.constraint_column_usage
+    WHERE table_name = 'people' AND constraint_name = 'people_status_check'
+  ) THEN
+    ALTER TABLE people
+      ADD CONSTRAINT people_status_check
+      CHECK (status IN ('verified', 'pending', 'rejected'));
+  END IF;
+END $$;
+
+ALTER TABLE people ADD COLUMN IF NOT EXISTS created_via text;
+-- 'seeded' | 'mcp_create' | 'mcp_update' | 'extractor_pending' | 'extractor_auto'
+
+ALTER TABLE people ADD COLUMN IF NOT EXISTS extracted_from_fragment_id text;
+
+ALTER TABLE people ADD COLUMN IF NOT EXISTS context_notes jsonb;
+-- Structured notes appended via update_person; matcher reads for context.
+
+CREATE INDEX IF NOT EXISTS people_status_idx ON people(status);
+
+INSERT INTO app_settings (key, value)
+  VALUES ('auto_accept_persons', 'false'::jsonb)
+  ON CONFLICT (key) DO NOTHING;

--- a/core/drizzle/migrations/meta/_journal.json
+++ b/core/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1747008000000,
       "tag": "0015_source_client_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1747094400000,
+      "tag": "0017_people_status_and_quarantine",
+      "breakpoints": true
     }
   ]
 }

--- a/core/eval/people-extraction/fixtures/01-known-and-unknown.json
+++ b/core/eval/people-extraction/fixtures/01-known-and-unknown.json
@@ -1,0 +1,13 @@
+{
+  "input": "Had coffee with Sarah. Bob said hello and Carol waved.",
+  "knownPeople": [
+    {
+      "key": "person01ABC",
+      "canonicalName": "Sarah Ouma",
+      "aliases": ["Sarah"]
+    }
+  ],
+  "expectedMatched": ["Sarah"],
+  "expectedCandidates": ["Bob", "Carol"],
+  "notes": "Mixed bucket: one match, two candidates. Verifies the extractor surfaces unknown names instead of dropping them."
+}

--- a/core/eval/people-extraction/fixtures/02-only-unknown.json
+++ b/core/eval/people-extraction/fixtures/02-only-unknown.json
@@ -1,0 +1,7 @@
+{
+  "input": "Met Diana and Eric at the office. They run the analytics group.",
+  "knownPeople": [],
+  "expectedMatched": [],
+  "expectedCandidates": ["Diana", "Eric"],
+  "notes": "No known people seeded. Both names must surface as candidates rather than being silently dropped."
+}

--- a/core/eval/people-extraction/fixtures/03-no-people.json
+++ b/core/eval/people-extraction/fixtures/03-no-people.json
@@ -1,0 +1,7 @@
+{
+  "input": "Just shipped the v2 release. The build went green at 3pm.",
+  "knownPeople": [],
+  "expectedMatched": [],
+  "expectedCandidates": [],
+  "notes": "No person-like mentions. Both buckets stay empty."
+}

--- a/core/eval/people-extraction/people-extraction.eval.ts
+++ b/core/eval/people-extraction/people-extraction.eval.ts
@@ -1,0 +1,92 @@
+import { evalite } from 'evalite'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { readdir, readFile } from 'node:fs/promises'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixturesDir = join(here, 'fixtures')
+
+interface PeopleExtractionFixture {
+  input: string
+  knownPeople: Array<{ key: string; canonicalName: string; aliases: string[] }>
+  expectedMatched: string[]
+  expectedCandidates: string[]
+  notes?: string
+}
+
+async function loadFixtures(): Promise<
+  Array<{ name: string; input: PeopleExtractionFixture; expected: PeopleExtractionFixture }>
+> {
+  const entries = await readdir(fixturesDir, { withFileTypes: true })
+  const files = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.json'))
+    .map((e) => e.name)
+    .sort()
+
+  const out = []
+  for (const file of files) {
+    const raw = await readFile(join(fixturesDir, file), 'utf8')
+    const parsed = JSON.parse(raw) as PeopleExtractionFixture
+    out.push({ name: file.replace(/\.json$/, ''), input: parsed, expected: parsed })
+  }
+  return out
+}
+
+/**
+ * Stream P (#237 follow-up) — people-extraction eval. Verifies that the
+ * extractor surfaces every person-like mention into matched (verified
+ * known person) or candidates (unknown), instead of silently dropping
+ * unfamiliar names. Run with:
+ *
+ *   pnpm -F @robin/core eval
+ *
+ * The default task is a deterministic stub that splits the input into
+ * proper-noun-shaped tokens and routes each through the known-people
+ * list. Replace with the real entityExtractor agent when wiring an
+ * LLM-backed run, mirroring core/src/queue/worker.ts.
+ */
+evalite('people-extraction', {
+  data: () => loadFixtures(),
+  task: async (input: PeopleExtractionFixture) => {
+    // Stub extractor: pick capitalised single-token names from the
+    // input. Each token is matched against knownPeople (canonicalName
+    // or alias) and routed to matched, otherwise candidates.
+    const tokens = Array.from(
+      new Set(
+        input.input
+          .split(/[^A-Za-z]+/)
+          .filter((t) => /^[A-Z][a-z]+$/.test(t))
+      )
+    )
+    const known = new Map<string, string>()
+    for (const p of input.knownPeople) {
+      known.set(p.canonicalName, p.key)
+      for (const a of p.aliases) known.set(a, p.key)
+    }
+    const matched: Array<{ mention: string; matchedKey: string }> = []
+    const candidates: Array<{ mention: string }> = []
+    for (const t of tokens) {
+      const key = known.get(t)
+      if (key) matched.push({ mention: t, matchedKey: key })
+      else candidates.push({ mention: t })
+    }
+    return { matched, candidates }
+  },
+  scorers: [
+    {
+      name: 'extractor-bucket-shape',
+      scorer: ({ output, expected }) => {
+        const matchedNames = output.matched.map((m: { mention: string }) => m.mention).sort()
+        const candidateNames = output.candidates
+          .map((c: { mention: string }) => c.mention)
+          .sort()
+        const expMatched = [...expected.expectedMatched].sort()
+        const expCandidates = [...expected.expectedCandidates].sort()
+        const matchedOk = JSON.stringify(matchedNames) === JSON.stringify(expMatched)
+        const candidateOk =
+          JSON.stringify(candidateNames) === JSON.stringify(expCandidates)
+        return matchedOk && candidateOk ? 1 : 0
+      },
+    },
+  ],
+})

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -2230,6 +2230,123 @@
         }
       }
     },
+    "/admin/people": {
+      "get": {
+        "operationId": "listAdminPeople",
+        "summary": "List people by status (Stream P)",
+        "description": "Triage list. Defaults to status=pending so the admin UI can render the quarantine queue without a query string.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["pending", "verified", "rejected"],
+              "default": "pending"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200, "default": 50 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0, "default": 0 }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Persons list with total"
+          }
+        }
+      }
+    },
+    "/admin/people/{lookupKey}/approve": {
+      "post": {
+        "operationId": "approvePendingPerson",
+        "summary": "Approve a pending person (Stream P)",
+        "description": "Flips the row to status='verified'. Existing edges become fully involved with no backfill.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lookupKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Person approved" },
+          "404": { "description": "Person not found" }
+        }
+      }
+    },
+    "/admin/people/{lookupKey}/reject": {
+      "post": {
+        "operationId": "rejectPendingPerson",
+        "summary": "Reject a pending person (Stream P)",
+        "description": "Default: status='rejected'. With { hardDelete: true } the row and edges are deleted.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lookupKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "hardDelete": { "type": "boolean", "default": false }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Person rejected" },
+          "404": { "description": "Person not found" }
+        }
+      }
+    },
     "/mcp": {
       "post": {
         "operationId": "mcpTransport",

--- a/core/src/__tests__/mcp-add-relationship.test.ts
+++ b/core/src/__tests__/mcp-add-relationship.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../db/slug.js', () => ({
+  resolvePersonSlug: vi.fn(),
+  resolveWikiSlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveEntrySlug: vi.fn(),
+}))
+
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn(async () => {}),
+}))
+
+const resolveMock = vi.fn()
+vi.mock('../lib/people/relationship-resolver.js', () => ({
+  resolveAndWriteRelationship: (...args: unknown[]) => resolveMock(...args),
+}))
+
+vi.mock('@robin/agent', () => ({
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: { lookupKey: 'lookup_key', deletedAt: 'deleted_at' },
+  wikiTypes: {},
+  edits: {},
+}))
+
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+const { handleAddRelationship } = await import('../mcp/handlers.js')
+
+function makeDb(sourceFound: boolean) {
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (sourceFound ? [{ lookupKey: 'person01SRC' }] : []),
+      }),
+    }),
+  }))
+  return { select }
+}
+
+function makeDeps(db: unknown) {
+  return {
+    db,
+    producer: {} as unknown,
+    spawnWriteWorker: vi.fn(),
+    entityExtractCall: vi.fn(),
+    loadUserPeople: vi.fn(),
+  } as unknown as Parameters<typeof handleAddRelationship>[0]
+}
+
+beforeEach(() => {
+  resolveMock.mockReset()
+})
+
+describe('handleAddRelationship — Stream P', () => {
+  it('writes a person->person KNOWS edge', async () => {
+    resolveMock.mockResolvedValue({
+      resolved: {
+        type: 'KNOWS',
+        target: 'person:person01DST',
+        edgeId: 'edge1',
+        edgeType: 'PERSON_KNOWS_PERSON',
+      },
+    })
+    const db = makeDb(true)
+    const deps = makeDeps(db)
+    const res = await handleAddRelationship(
+      deps,
+      { source: 'person:person01SRC', target: 'person:person01DST', type: 'KNOWS' },
+      'user-1'
+    )
+    expect(res.isError).toBeUndefined()
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.edgeType).toBe('PERSON_KNOWS_PERSON')
+  })
+
+  it('returns error when source is not in person:<key> form', async () => {
+    const db = makeDb(true)
+    const deps = makeDeps(db)
+    const res = await handleAddRelationship(
+      deps,
+      { source: 'wiki:foo', target: 'wiki:bar', type: 'WORKS_AT' },
+      'user-1'
+    )
+    expect(res.isError).toBe(true)
+  })
+
+  it('returns 404 when source person does not exist', async () => {
+    const db = makeDb(false)
+    const deps = makeDeps(db)
+    const res = await handleAddRelationship(
+      deps,
+      { source: 'person:person01MISSING', target: 'person:person01DST', type: 'KNOWS' },
+      'user-1'
+    )
+    expect(res.isError).toBe(true)
+  })
+
+  it('surfaces resolver pending as error response', async () => {
+    resolveMock.mockResolvedValue({
+      pending: { type: 'KNOWS', target: 'person:person01MISSING', reason: 'target-not-found' },
+    })
+    const db = makeDb(true)
+    const deps = makeDeps(db)
+    const res = await handleAddRelationship(
+      deps,
+      { source: 'person:person01SRC', target: 'person:person01MISSING', type: 'KNOWS' },
+      'user-1'
+    )
+    expect(res.isError).toBe(true)
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.reason).toBe('target-not-found')
+  })
+})

--- a/core/src/__tests__/mcp-create-person.test.ts
+++ b/core/src/__tests__/mcp-create-person.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Module-level mocks ─────────────────────────────────────────────────────
+
+vi.mock('../db/slug.js', () => ({
+  resolvePersonSlug: vi.fn(async (_db: unknown, slug: string) => slug),
+  resolveWikiSlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveEntrySlug: vi.fn(),
+}))
+
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn(async () => {}),
+}))
+
+vi.mock('../lib/people/relationship-resolver.js', () => ({
+  resolveAndWriteRelationship: vi.fn(async (_db: unknown, _src: string, rel: { type: string; target: string }) => ({
+    resolved: { type: rel.type, target: rel.target, edgeId: 'edge-x', edgeType: 'PERSON_KNOWS_PERSON' },
+  })),
+}))
+
+vi.mock('@robin/agent', () => ({
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: { lookupKey: 'lookup_key', canonicalName: 'canonical_name', deletedAt: 'deleted_at', slug: 'slug' },
+  wikiTypes: {},
+  edits: {},
+}))
+
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+const { handleCreatePerson } = await import('../mcp/handlers.js')
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDb(existingPerson: { lookupKey: string; slug: string } | null = null) {
+  const insertCaptured: { values?: Record<string, unknown> } = {}
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (existingPerson ? [existingPerson] : []),
+      }),
+    }),
+  }))
+  const insert = vi.fn(() => ({
+    values: async (vals: Record<string, unknown>) => {
+      insertCaptured.values = vals
+    },
+  }))
+  return { db: { select, insert }, insertCaptured }
+}
+
+function makeDeps(db: unknown) {
+  return {
+    db,
+    producer: {} as unknown,
+    spawnWriteWorker: vi.fn(),
+    entityExtractCall: vi.fn(),
+    loadUserPeople: vi.fn(),
+  } as unknown as Parameters<typeof handleCreatePerson>[0]
+}
+
+beforeEach(() => {})
+
+describe('handleCreatePerson — Stream P', () => {
+  it('inserts a verified person with status=verified and createdVia=mcp_create', async () => {
+    const { db, insertCaptured } = makeDb(null)
+    const deps = makeDeps(db)
+    const res = await handleCreatePerson(
+      deps,
+      { canonicalName: 'Alice Yang', aliases: ['Alice'], relationship: 'colleague' },
+      'user-1'
+    )
+    expect(res.isError).toBeUndefined()
+    expect(insertCaptured.values).toMatchObject({
+      canonicalName: 'Alice Yang',
+      status: 'verified',
+      createdVia: 'mcp_create',
+    })
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.status).toBe('verified')
+    expect(payload.lookupKey).toMatch(/^person/)
+  })
+
+  it('rejects empty canonicalName', async () => {
+    const { db } = makeDb(null)
+    const deps = makeDeps(db)
+    const res = await handleCreatePerson(deps, { canonicalName: '   ' }, 'user-1')
+    expect(res.isError).toBe(true)
+  })
+
+  it('rejects unauthenticated calls', async () => {
+    const { db } = makeDb(null)
+    const deps = makeDeps(db)
+    const res = await handleCreatePerson(deps, { canonicalName: 'Sam' }, undefined)
+    expect(res.isError).toBe(true)
+  })
+
+  it('returns idempotent response when canonical name already exists', async () => {
+    const { db } = makeDb({ lookupKey: 'person01EXIST', slug: 'sam' })
+    const deps = makeDeps(db)
+    const res = await handleCreatePerson(deps, { canonicalName: 'Sam' }, 'user-1')
+    expect(res.isError).toBeUndefined()
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.lookupKey).toBe('person01EXIST')
+    expect(payload.alreadyExists).toBe(true)
+  })
+})

--- a/core/src/__tests__/mcp-list-pending.test.ts
+++ b/core/src/__tests__/mcp-list-pending.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../db/slug.js', () => ({
+  resolvePersonSlug: vi.fn(),
+  resolveWikiSlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveEntrySlug: vi.fn(),
+}))
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+vi.mock('../db/audit.js', () => ({ emitAuditEvent: vi.fn(async () => {}) }))
+vi.mock('../lib/people/relationship-resolver.js', () => ({
+  resolveAndWriteRelationship: vi.fn(),
+}))
+vi.mock('@robin/agent', () => ({
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: {
+    lookupKey: 'lookup_key',
+    canonicalName: 'canonical_name',
+    slug: 'slug',
+    aliases: 'aliases',
+    deletedAt: 'deleted_at',
+    status: 'status',
+    createdAt: 'created_at',
+    createdVia: 'created_via',
+    extractedFromFragmentId: 'extracted_from_fragment_id',
+  },
+  wikiTypes: {},
+  edits: {},
+  appSettings: { key: 'key', value: 'value', updatedAt: 'updated_at' },
+}))
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+const { handleListPendingPersons } = await import('../mcp/handlers.js')
+
+function makeDb(rows: Record<string, unknown>[], total = rows.length) {
+  let queryNum = 0
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => {
+        queryNum += 1
+        if (queryNum === 1) {
+          return {
+            orderBy: () => ({
+              limit: () => ({
+                offset: async () => rows,
+              }),
+            }),
+          }
+        }
+        // Second select is the count query
+        return Promise.resolve([{ count: total }])
+      },
+    }),
+  }))
+  return { select }
+}
+
+function makeDeps(db: unknown) {
+  return {
+    db,
+    producer: {} as unknown,
+    spawnWriteWorker: vi.fn(),
+    entityExtractCall: vi.fn(),
+    loadUserPeople: vi.fn(),
+  } as unknown as Parameters<typeof handleListPendingPersons>[0]
+}
+
+beforeEach(() => {})
+
+describe('handleListPendingPersons — Stream P', () => {
+  it('returns the pending queue with a status marker', async () => {
+    const created = new Date('2026-05-09T00:00:00Z')
+    const rows = [
+      {
+        lookupKey: 'person01PND',
+        slug: 'diana-patel',
+        canonicalName: 'Diana Patel',
+        aliases: [],
+        createdAt: created,
+        createdVia: 'extractor_pending',
+        extractedFromFragmentId: 'frag01',
+      },
+    ]
+    const db = makeDb(rows, 1)
+    const deps = makeDeps(db)
+    const res = await handleListPendingPersons(deps, {}, 'user-1')
+    expect(res.isError).toBeUndefined()
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.total).toBe(1)
+    expect(payload.persons[0]).toMatchObject({
+      lookupKey: 'person01PND',
+      status: 'pending',
+      createdVia: 'extractor_pending',
+    })
+  })
+
+  it('rejects unauthenticated calls', async () => {
+    const db = makeDb([])
+    const deps = makeDeps(db)
+    const res = await handleListPendingPersons(deps, {}, undefined)
+    expect(res.isError).toBe(true)
+  })
+})

--- a/core/src/__tests__/mcp-set-auto-accept.test.ts
+++ b/core/src/__tests__/mcp-set-auto-accept.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../db/slug.js', () => ({
+  resolvePersonSlug: vi.fn(),
+  resolveWikiSlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveEntrySlug: vi.fn(),
+}))
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+vi.mock('../db/audit.js', () => ({ emitAuditEvent: vi.fn(async () => {}) }))
+vi.mock('../lib/people/relationship-resolver.js', () => ({
+  resolveAndWriteRelationship: vi.fn(),
+}))
+vi.mock('@robin/agent', () => ({
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+const writeMock = vi.fn(async (_db: unknown, value: boolean) => ({
+  previous: !value,
+  current: value,
+}))
+vi.mock('../lib/people-settings.js', () => ({
+  loadAutoAcceptPersons: vi.fn(async () => false),
+  setAutoAcceptPersons: writeMock,
+  loadVerifiedPeople: vi.fn(),
+  loadPendingPeople: vi.fn(),
+  insertExtractedPerson: vi.fn(),
+}))
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: {},
+  wikiTypes: {},
+  edits: {},
+  appSettings: { key: 'key', value: 'value', updatedAt: 'updated_at' },
+}))
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+const { handleSetAutoAcceptPersons } = await import('../mcp/handlers.js')
+
+function makeDeps() {
+  return {
+    db: {},
+    producer: {} as unknown,
+    spawnWriteWorker: vi.fn(),
+    entityExtractCall: vi.fn(),
+    loadUserPeople: vi.fn(),
+  } as unknown as Parameters<typeof handleSetAutoAcceptPersons>[0]
+}
+
+beforeEach(() => {
+  writeMock.mockClear()
+})
+
+describe('handleSetAutoAcceptPersons — Stream P', () => {
+  it('flips the toggle and returns previous + current', async () => {
+    const res = await handleSetAutoAcceptPersons(makeDeps(), { value: true }, 'user-1')
+    expect(res.isError).toBeUndefined()
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload).toEqual({ previous: false, current: true })
+    expect(writeMock).toHaveBeenCalledWith(expect.anything(), true)
+  })
+
+  it('rejects unauthenticated calls', async () => {
+    const res = await handleSetAutoAcceptPersons(makeDeps(), { value: true }, undefined)
+    expect(res.isError).toBe(true)
+  })
+
+  it('rejects non-boolean value', async () => {
+    const res = await handleSetAutoAcceptPersons(
+      makeDeps(),
+      { value: 'true' as unknown as boolean },
+      'user-1'
+    )
+    expect(res.isError).toBe(true)
+  })
+})

--- a/core/src/__tests__/mcp-update-person.test.ts
+++ b/core/src/__tests__/mcp-update-person.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Module-level mocks ─────────────────────────────────────────────────────
+
+vi.mock('../db/slug.js', () => ({
+  resolvePersonSlug: vi.fn(async (_db: unknown, slug: string) => slug),
+  resolveWikiSlug: vi.fn(),
+  resolveFragmentSlug: vi.fn(),
+  resolveEntrySlug: vi.fn(),
+}))
+
+vi.mock('../db/dedup.js', () => ({
+  computeContentHash: vi.fn(),
+  findDuplicateEntry: vi.fn(),
+  findDuplicateFragment: vi.fn(),
+}))
+
+vi.mock('../db/audit.js', () => ({
+  emitAuditEvent: vi.fn(async () => {}),
+}))
+
+vi.mock('../lib/people/relationship-resolver.js', () => ({
+  resolveAndWriteRelationship: vi.fn(),
+}))
+
+vi.mock('@robin/agent', () => ({
+  DEFAULT_RESOLUTION_CONFIG: {},
+  embedText: vi.fn(),
+}))
+
+vi.mock('../db/schema.js', () => ({
+  entries: {},
+  fragments: {},
+  wikis: {},
+  edges: {},
+  people: { lookupKey: 'lookup_key', canonicalName: 'canonical_name', deletedAt: 'deleted_at', slug: 'slug' },
+  wikiTypes: {},
+  edits: {},
+}))
+
+vi.mock('../db/client.js', () => ({ db: {} }))
+
+const { handleUpdatePerson } = await import('../mcp/handlers.js')
+
+function makeDb(person: Record<string, unknown> | null) {
+  const updateCaptured: { values?: Record<string, unknown> } = {}
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (person ? [person] : []),
+      }),
+    }),
+  }))
+  const update = vi.fn(() => ({
+    set: (vals: Record<string, unknown>) => ({
+      where: async () => {
+        updateCaptured.values = vals
+      },
+    }),
+  }))
+  return { db: { select, update }, updateCaptured }
+}
+
+function makeDeps(db: unknown) {
+  return {
+    db,
+    producer: {} as unknown,
+    spawnWriteWorker: vi.fn(),
+    entityExtractCall: vi.fn(),
+    loadUserPeople: vi.fn(),
+  } as unknown as Parameters<typeof handleUpdatePerson>[0]
+}
+
+beforeEach(() => {})
+
+describe('handleUpdatePerson — Stream P', () => {
+  it('appends aliases by default (no replaceAliases)', async () => {
+    const { db, updateCaptured } = makeDb({
+      lookupKey: 'person01XYZ',
+      canonicalName: 'Sam',
+      aliases: ['Samuel'],
+      status: 'verified',
+      contextNotes: null,
+    })
+    const deps = makeDeps(db)
+    const res = await handleUpdatePerson(
+      deps,
+      {
+        personLookupKey: 'person01XYZ',
+        updates: { aliases: ['Sammy'] },
+      },
+      'user-1'
+    )
+    expect(res.isError).toBeUndefined()
+    expect(updateCaptured.values).toMatchObject({ aliases: ['Samuel', 'Sammy'] })
+  })
+
+  it('promotes pending -> verified when promoteFromQuarantine=true', async () => {
+    const { db, updateCaptured } = makeDb({
+      lookupKey: 'person01PND',
+      canonicalName: 'Diana',
+      aliases: [],
+      status: 'pending',
+      contextNotes: null,
+      createdVia: 'extractor_pending',
+    })
+    const deps = makeDeps(db)
+    const res = await handleUpdatePerson(
+      deps,
+      {
+        personLookupKey: 'person01PND',
+        updates: { notes: 'works on platform team' },
+        options: { promoteFromQuarantine: true },
+      },
+      'user-1'
+    )
+    expect(res.isError).toBeUndefined()
+    expect(updateCaptured.values).toMatchObject({ status: 'verified', verified: true })
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.promoted).toBe(true)
+    expect(payload.status).toBe('verified')
+  })
+
+  it('does NOT promote without the flag, even when notes are appended', async () => {
+    const { db, updateCaptured } = makeDb({
+      lookupKey: 'person01PND',
+      canonicalName: 'Diana',
+      aliases: [],
+      status: 'pending',
+      contextNotes: null,
+    })
+    const deps = makeDeps(db)
+    const res = await handleUpdatePerson(
+      deps,
+      {
+        personLookupKey: 'person01PND',
+        updates: { notes: 'works on platform team' },
+      },
+      'user-1'
+    )
+    expect(res.isError).toBeUndefined()
+    expect(updateCaptured.values).not.toHaveProperty('status')
+    const payload = JSON.parse((res.content[0] as { text: string }).text)
+    expect(payload.promoted).toBe(false)
+    expect(payload.status).toBe('pending')
+  })
+
+  it('returns 404 when person does not exist', async () => {
+    const { db } = makeDb(null)
+    const deps = makeDeps(db)
+    const res = await handleUpdatePerson(
+      deps,
+      { personLookupKey: 'person01MISSING', updates: {} },
+      'user-1'
+    )
+    expect(res.isError).toBe(true)
+  })
+
+  it('rejects unauthenticated calls', async () => {
+    const { db } = makeDb(null)
+    const deps = makeDeps(db)
+    const res = await handleUpdatePerson(
+      deps,
+      { personLookupKey: 'person01XYZ', updates: {} },
+      undefined
+    )
+    expect(res.isError).toBe(true)
+  })
+})

--- a/core/src/__tests__/quarantine-contract.test.ts
+++ b/core/src/__tests__/quarantine-contract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Stream P (#PEOPLE-EXTRACT-Q) — quarantine contract test.
+ *
+ * Asserts the read-site exclusion matrix locked 2026-05-09 by inspecting
+ * the source files directly (no DB roundtrip needed). Each section
+ * pins one promise of the matrix to a code-side check that breaks
+ * loudly if a future refactor regresses the behaviour.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SRC = join(here, '..')
+
+function read(rel: string): string {
+  return readFileSync(join(SRC, rel), 'utf8')
+}
+
+describe('quarantine contract — read-site exclusion matrix', () => {
+  it('hybrid search filters person rows to status=verified', () => {
+    const search = read('lib/search.ts')
+    expect(search).toMatch(/personStatusFilter/)
+    expect(search).toMatch(/people\.status.+= 'verified'/s)
+  })
+
+  it('embedding-retry-worker skips pending persons', () => {
+    const worker = read('queue/embedding-retry-worker.ts')
+    expect(worker).toMatch(/people\.status.+= 'verified'/)
+  })
+
+  it('GET /people defaults to status=verified', () => {
+    const peopleRoute = read('routes/people.ts')
+    expect(peopleRoute).toMatch(/statusFilter\s*=\s*c\.req\.query\('status'\)\s*\?\?\s*'verified'/)
+  })
+
+  it('find_person / findPersonById return status field on the person payload', () => {
+    const resolvers = read('mcp/resolvers.ts')
+    // The PersonDetail interface carries a status field
+    expect(resolvers).toMatch(/status:\s*'verified'\s*\|\s*'pending'\s*\|\s*'rejected'/)
+  })
+
+  it('brief_person surfaces a quarantine notice for pending persons', () => {
+    const resolvers = read('mcp/resolvers.ts')
+    expect(resolvers).toMatch(/Quarantine: this person is awaiting operator approval/)
+  })
+
+  it('wikis read endpoint carries person status through aggregated edges', () => {
+    const wikis = read('routes/wikis.ts')
+    expect(wikis).toMatch(/status: people\.status/)
+  })
+
+  it('list_pending_persons exists and is read-only', () => {
+    const handlers = read('mcp/handlers.ts')
+    expect(handlers).toMatch(/handleListPendingPersons/)
+    expect(handlers).not.toMatch(/handleApprovePending\b/)
+    expect(handlers).not.toMatch(/handleRejectPending\b/)
+  })
+
+  it('does not register approve/reject MCP tools (HTTP-only by design)', () => {
+    const server = read('mcp/server.ts')
+    expect(server).not.toMatch(/'approve_pending_person'/)
+    expect(server).not.toMatch(/'reject_pending_person'/)
+  })
+})

--- a/core/src/db/schema.ts
+++ b/core/src/db/schema.ts
@@ -412,6 +412,19 @@ export const people = pgTable(
     // [AUTHORSHIP] block tells the agent to interpret first-person
     // pronouns as this Person.
     isOwner: boolean('is_owner').notNull().default(false),
+    // Stream P quarantine model (migration 0017). Status gates whether
+    // a row is "graph-visible" or sitting in the pending tray awaiting
+    // operator approval. Existing rows default to 'verified' so legacy
+    // deployments behave exactly as before. createdVia carries the
+    // provenance label, extractedFromFragmentId backreferences the
+    // surfacing fragment, contextNotes is an append-only history the
+    // matcher reads back to disambiguate similar names.
+    status: text('status').notNull().default('verified'),
+    createdVia: text('created_via'),
+    extractedFromFragmentId: text('extracted_from_fragment_id'),
+    contextNotes: jsonb('context_notes').$type<{
+      entries: Array<{ note: string; addedAt: string; source: string }>
+    } | null>(),
     lastRebuiltAt: timestamp('last_rebuilt_at'),
     embedding: vector('embedding', { dimensions: 1536 }),
     // Embedding retry bookkeeping — same shape as fragments and wikis.
@@ -422,6 +435,7 @@ export const people = pgTable(
   (t) => [
     uniqueIndex('people_slug_uidx').on(t.slug),
     index('people_aliases_gin_idx').using('gin', t.aliases),
+    index('people_status_idx').on(t.status),
   ]
 )
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -37,6 +37,7 @@ import { producer } from './queue/producer.js'
 import { QUEUE_NAMES } from '@robin/queue'
 import { bullBoardApp } from './routes/bull-board.js'
 import { adminRoutes } from './routes/admin.js'
+import { adminPeopleRoutes } from './routes/admin/people.js'
 import { authRecoverRoutes } from './routes/auth-recover.js'
 import {
   checkOpenRouterKey,
@@ -205,6 +206,7 @@ app.get('/favicon.ico', (c) =>
 )
 // M2 dormant: git-sync webhook. See import comment above.
 // app.route('/internal', internalRoutes)
+app.route('/admin/people', adminPeopleRoutes)
 app.route('/admin', adminRoutes)
 app.route('/auth', authRecoverRoutes)
 app.route('/published', publishedRoutes)

--- a/core/src/lib/people-settings.ts
+++ b/core/src/lib/people-settings.ts
@@ -1,6 +1,7 @@
 import { eq, isNull, sql } from 'drizzle-orm'
 import { appSettings, people } from '../db/schema.js'
 import type { DB } from '../db/client.js'
+import { emitAuditEvent } from '../db/audit.js'
 import type { KnownPerson } from '@robin/agent'
 
 /**
@@ -113,5 +114,20 @@ export async function insertExtractedPerson(
       state: 'PENDING',
     })
     .onConflictDoNothing()
+
+  await emitAuditEvent(db, {
+    entityType: 'person',
+    entityId: input.lookupKey,
+    eventType: 'created',
+    source: 'system',
+    summary: `Person ${input.status === 'pending' ? 'queued for review' : 'created'}: ${trimmed}`,
+    detail: {
+      personKey: input.lookupKey,
+      canonicalName: trimmed,
+      status: input.status,
+      createdVia: input.createdVia,
+      extractedFromFragmentId: input.extractedFromFragmentId,
+    },
+  })
   void isNull // silence unused import in tighter compile modes
 }

--- a/core/src/lib/people-settings.ts
+++ b/core/src/lib/people-settings.ts
@@ -1,0 +1,117 @@
+import { eq, isNull, sql } from 'drizzle-orm'
+import { appSettings, people } from '../db/schema.js'
+import type { DB } from '../db/client.js'
+import type { KnownPerson } from '@robin/agent'
+
+/**
+ * Stream P helpers — shared between the worker pipeline (entityExtract)
+ * and the MCP `log_fragment` handler. Centralised here so both surfaces
+ * read the same pending-people pool, the same auto-accept toggle, and
+ * therefore produce identical extraction outcomes.
+ */
+
+const AUTO_ACCEPT_KEY = 'auto_accept_persons'
+
+export async function loadAutoAcceptPersons(db: DB): Promise<boolean> {
+  const [row] = await db
+    .select({ value: appSettings.value })
+    .from(appSettings)
+    .where(eq(appSettings.key, AUTO_ACCEPT_KEY))
+    .limit(1)
+  if (!row) return false
+  // Stored as raw jsonb. Most call paths write `true` / `false` /
+  // `"true"` — treat anything truthy that is NOT the literal string
+  // "false" or boolean `false` as a positive toggle.
+  const v = row.value
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') return v === 'true' || v === '1'
+  return Boolean(v)
+}
+
+export async function setAutoAcceptPersons(
+  db: DB,
+  next: boolean
+): Promise<{ previous: boolean; current: boolean }> {
+  const previous = await loadAutoAcceptPersons(db)
+  await db
+    .insert(appSettings)
+    .values({ key: AUTO_ACCEPT_KEY, value: next })
+    .onConflictDoUpdate({
+      target: appSettings.key,
+      set: { value: next, updatedAt: new Date() },
+    })
+  return { previous, current: next }
+}
+
+/** Load the verified-only matcher pool (used for the LLM prompt). */
+export async function loadVerifiedPeople(db: DB): Promise<KnownPerson[]> {
+  const rows = await db
+    .select({
+      lookupKey: people.lookupKey,
+      canonicalName: people.canonicalName,
+      aliases: people.aliases,
+    })
+    .from(people)
+    .where(sql`${people.status} = 'verified' AND ${people.deletedAt} IS NULL`)
+  return rows.map((r) => ({
+    lookupKey: r.lookupKey,
+    canonicalName: r.canonicalName,
+    aliases: r.aliases ?? [],
+  }))
+}
+
+/** Load the pending-people pool. Used for extract-time dedup only. */
+export async function loadPendingPeople(db: DB): Promise<KnownPerson[]> {
+  const rows = await db
+    .select({
+      lookupKey: people.lookupKey,
+      canonicalName: people.canonicalName,
+      aliases: people.aliases,
+    })
+    .from(people)
+    .where(sql`${people.status} = 'pending' AND ${people.deletedAt} IS NULL`)
+  return rows.map((r) => ({
+    lookupKey: r.lookupKey,
+    canonicalName: r.canonicalName,
+    aliases: r.aliases ?? [],
+  }))
+}
+
+/**
+ * Insert a new person row. Centralised here so the worker pipeline,
+ * MCP `log_fragment`, and MCP `create_person` all stamp the right
+ * provenance fields uniformly.
+ */
+export async function insertExtractedPerson(
+  db: DB,
+  input: {
+    lookupKey: string
+    canonicalName: string
+    status: 'verified' | 'pending'
+    createdVia: 'extractor_pending' | 'extractor_auto'
+    extractedFromFragmentId: string | null
+  }
+): Promise<void> {
+  const trimmed = input.canonicalName.trim() || '(unnamed)'
+  const slug =
+    trimmed
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '') || `person-${input.lookupKey.slice(-6).toLowerCase()}`
+  await db
+    .insert(people)
+    .values({
+      lookupKey: input.lookupKey,
+      slug,
+      name: trimmed,
+      canonicalName: trimmed,
+      aliases: [],
+      verified: input.status === 'verified',
+      status: input.status,
+      createdVia: input.createdVia,
+      extractedFromFragmentId: input.extractedFromFragmentId ?? null,
+      state: 'PENDING',
+    })
+    .onConflictDoNothing()
+  void isNull // silence unused import in tighter compile modes
+}

--- a/core/src/lib/people/relationship-resolver.ts
+++ b/core/src/lib/people/relationship-resolver.ts
@@ -1,0 +1,171 @@
+import { and, eq, isNull, sql } from 'drizzle-orm'
+import { people, wikis, edges as edgesTable } from '../../db/schema.js'
+import type { DB } from '../../db/client.js'
+
+/**
+ * Stream P (#PEOPLE-EXTRACT-Q) — relationship resolver shared by the
+ * MCP create_person and update_person handlers. Each Relationship in
+ * the input payload points at either a person or a wiki, identified
+ * by `${kind}:<key|slug|canonical-name>`. The resolver looks the
+ * target up in the right table; on a hit it writes the appropriate
+ * edge type, on a miss it surfaces the unresolved entry on the
+ * response so the caller can reissue once the target lands.
+ */
+
+export type RelationshipInput =
+  | {
+      type: 'KNOWS' | 'RELATED_TO'
+      target: string // person:<key> | person:<canonical-name>
+      direction?: 'bidirectional' | 'outbound'
+      note?: string
+      sourceFragmentId?: string
+    }
+  | {
+      type: 'WORKS_AT' | 'AFFILIATED_WITH'
+      target: string // wiki:<key> | wiki:<slug>
+      role?: string
+      note?: string
+      sourceFragmentId?: string
+    }
+
+export interface ResolvedRelationship {
+  type: RelationshipInput['type']
+  target: string
+  edgeId: string
+  edgeType: string
+}
+
+export interface PendingRelationship {
+  type: RelationshipInput['type']
+  target: string
+  reason: 'target-not-found' | 'invalid-format'
+}
+
+const personEdgeMap: Record<'KNOWS' | 'RELATED_TO', string> = {
+  KNOWS: 'PERSON_KNOWS_PERSON',
+  RELATED_TO: 'PERSON_RELATED_TO_PERSON',
+}
+
+const wikiEdgeMap: Record<'WORKS_AT' | 'AFFILIATED_WITH', string> = {
+  WORKS_AT: 'PERSON_WORKS_AT_WIKI',
+  AFFILIATED_WITH: 'PERSON_AFFILIATED_WITH_WIKI',
+}
+
+function parseTarget(target: string): { kind: 'person' | 'wiki'; ref: string } | null {
+  const colon = target.indexOf(':')
+  if (colon < 0) return null
+  const kind = target.slice(0, colon)
+  const ref = target.slice(colon + 1).trim()
+  if (kind !== 'person' && kind !== 'wiki') return null
+  if (!ref) return null
+  return { kind, ref }
+}
+
+async function resolvePersonTarget(db: DB, ref: string): Promise<string | null> {
+  // Exact key first.
+  const [exact] = await db
+    .select({ lookupKey: people.lookupKey })
+    .from(people)
+    .where(and(eq(people.lookupKey, ref), isNull(people.deletedAt)))
+    .limit(1)
+  if (exact) return exact.lookupKey
+
+  // Canonical-name match (case-insensitive, exact text).
+  const [byCanonical] = await db
+    .select({ lookupKey: people.lookupKey })
+    .from(people)
+    .where(
+      and(
+        sql`lower(${people.canonicalName}) = lower(${ref})`,
+        isNull(people.deletedAt)
+      )
+    )
+    .limit(1)
+  return byCanonical?.lookupKey ?? null
+}
+
+async function resolveWikiTarget(db: DB, ref: string): Promise<string | null> {
+  const [exact] = await db
+    .select({ lookupKey: wikis.lookupKey })
+    .from(wikis)
+    .where(and(eq(wikis.lookupKey, ref), isNull(wikis.deletedAt)))
+    .limit(1)
+  if (exact) return exact.lookupKey
+  const [bySlug] = await db
+    .select({ lookupKey: wikis.lookupKey })
+    .from(wikis)
+    .where(and(eq(wikis.slug, ref), isNull(wikis.deletedAt)))
+    .limit(1)
+  return bySlug?.lookupKey ?? null
+}
+
+export async function resolveAndWriteRelationship(
+  db: DB,
+  sourcePersonKey: string,
+  rel: RelationshipInput
+): Promise<{ resolved?: ResolvedRelationship; pending?: PendingRelationship }> {
+  const parsed = parseTarget(rel.target)
+  if (!parsed) {
+    return { pending: { type: rel.type, target: rel.target, reason: 'invalid-format' } }
+  }
+
+  if (parsed.kind === 'person' && (rel.type === 'KNOWS' || rel.type === 'RELATED_TO')) {
+    const targetKey = await resolvePersonTarget(db, parsed.ref)
+    if (!targetKey) {
+      return { pending: { type: rel.type, target: rel.target, reason: 'target-not-found' } }
+    }
+    const edgeId = crypto.randomUUID()
+    const edgeType = personEdgeMap[rel.type]
+    await db
+      .insert(edgesTable)
+      .values({
+        id: edgeId,
+        srcType: 'person',
+        srcId: sourcePersonKey,
+        dstType: 'person',
+        dstId: targetKey,
+        edgeType,
+        attrs: {
+          ...(rel.note ? { note: rel.note } : {}),
+          ...(rel.sourceFragmentId ? { sourceFragmentId: rel.sourceFragmentId } : {}),
+          ...(rel.direction ? { direction: rel.direction } : {}),
+        },
+      })
+      .onConflictDoNothing()
+    return { resolved: { type: rel.type, target: rel.target, edgeId, edgeType } }
+  }
+
+  if (
+    parsed.kind === 'wiki' &&
+    (rel.type === 'WORKS_AT' || rel.type === 'AFFILIATED_WITH')
+  ) {
+    const targetKey = await resolveWikiTarget(db, parsed.ref)
+    if (!targetKey) {
+      return { pending: { type: rel.type, target: rel.target, reason: 'target-not-found' } }
+    }
+    const edgeId = crypto.randomUUID()
+    const edgeType = wikiEdgeMap[rel.type]
+    await db
+      .insert(edgesTable)
+      .values({
+        id: edgeId,
+        srcType: 'person',
+        srcId: sourcePersonKey,
+        dstType: 'wiki',
+        dstId: targetKey,
+        edgeType,
+        attrs: {
+          ...(rel.note ? { note: rel.note } : {}),
+          ...(rel.sourceFragmentId ? { sourceFragmentId: rel.sourceFragmentId } : {}),
+          ...(rel.type === 'WORKS_AT' && (rel as { role?: string }).role
+            ? { role: (rel as { role?: string }).role }
+            : {}),
+        },
+      })
+      .onConflictDoNothing()
+    return { resolved: { type: rel.type, target: rel.target, edgeId, edgeType } }
+  }
+
+  // Mismatched kind/type combo (e.g. KNOWS pointing at a wiki).
+  return { pending: { type: rel.type, target: rel.target, reason: 'invalid-format' } }
+}

--- a/core/src/lib/search.ts
+++ b/core/src/lib/search.ts
@@ -142,13 +142,19 @@ async function bm25SearchTable(
   // pass each tag as its own parameter and bind them inside an
   // EXISTS over jsonb_array_elements_text — equivalent to
   // `tags ?| array[...]` (UNION) but bind-safe.
+  // Stream P quarantine: pending persons are EXCLUDED from hybrid
+  // search entirely (no marker, just absent). Verified-only filter
+  // attaches when the search lane is the person table.
+  const personStatusFilter =
+    tableType === 'person' ? sql` AND ${people.status} = 'verified'` : sql``
+
   const whereClause =
     tags && tableType === 'fragment'
       ? sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery} AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${fragments.tags}) AS t(elem) WHERE t.elem IN (${sql.join(
           tags.map((tag) => sql`${tag}`),
           sql`, `
         )}))`
-      : sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery}`
+      : sql`${meta.deletedAtCol} IS NULL AND ${meta.searchVectorCol} @@ ${tsQuery}${personStatusFilter}`
 
   const rows = await database
     .select({
@@ -204,13 +210,17 @@ async function vectorSearchTable(
     tagsFilter && tagsFilter.length > 0 ? tagsFilter : null
   if (tags && tableType !== 'fragment') return []
 
+  // Stream P quarantine: pending persons stay out of vector search too.
+  const personStatusFilter =
+    tableType === 'person' ? sql` AND ${people.status} = 'verified'` : sql``
+
   const whereClause =
     tags && tableType === 'fragment'
       ? sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${fragments.tags}) AS t(elem) WHERE t.elem IN (${sql.join(
           tags.map((tag) => sql`${tag}`),
           sql`, `
         )}))`
-      : sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL`
+      : sql`${meta.deletedAtCol} IS NULL AND ${meta.embeddingCol} IS NOT NULL${personStatusFilter}`
 
   const rows = await database
     .select({

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -57,8 +57,11 @@ import {
 import type { McpResolverDeps } from './resolvers.js'
 import { DEFAULT_RESOLUTION_CONFIG, embedText } from '@robin/agent'
 import type { KnownPerson } from '@robin/agent'
+import { resolveAndWriteRelationship } from '../lib/people/relationship-resolver.js'
+import type { RelationshipInput } from '../lib/people/relationship-resolver.js'
+import { resolvePersonSlug } from '../db/slug.js'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
-import { eq, and, isNull, inArray, ne } from 'drizzle-orm'
+import { eq, and, isNull, inArray, ne, sql } from 'drizzle-orm'
 import { nanoid } from '../lib/id.js'
 import { logger } from '../lib/logger.js'
 import { emitAuditEvent } from '../db/audit.js'
@@ -1316,6 +1319,462 @@ export async function handleRegenNow(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     log.error({ err, userId }, 'mcp regen_now failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/***********************************************************************
+ * Stream P (#PEOPLE-EXTRACT-Q) — Person CRUD MCP tools
+ ***********************************************************************/
+
+const MAX_NAME_LEN = 200
+
+function appendContextNote(
+  current: { entries: Array<{ note: string; addedAt: string; source: string }> } | null,
+  note: string,
+  source: string
+): { entries: Array<{ note: string; addedAt: string; source: string }> } {
+  const entries = current?.entries ?? []
+  return {
+    entries: [
+      ...entries,
+      { note: note.trim(), addedAt: new Date().toISOString(), source },
+    ],
+  }
+}
+
+/**
+ * Handle the `create_person` MCP tool call.
+ *
+ * @summary Operator-or-AI-agent flow for intentional Person creation.
+ * Always lands the row with status='verified' and created_via='mcp_create',
+ * so MCP creation is the explicit "I know who this is" path that bypasses
+ * the quarantine queue. The quarantine queue is reserved for auto-extraction.
+ */
+export async function handleCreatePerson(
+  deps: McpServerDeps,
+  input: {
+    canonicalName: string
+    aliases?: string[]
+    relationship?: string
+    isOwner?: boolean
+    metadata?: {
+      relationships?: RelationshipInput[]
+      notes?: string
+    }
+  },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  const trimmed = input.canonicalName?.trim() ?? ''
+  if (!trimmed) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: canonicalName is required' }],
+      isError: true as const,
+    }
+  }
+  if (trimmed.length > MAX_NAME_LEN) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error: canonicalName exceeds ${MAX_NAME_LEN} chars`,
+        },
+      ],
+      isError: true as const,
+    }
+  }
+
+  try {
+    // Idempotency: existing canonical name match returns that person.
+    const lower = trimmed.toLowerCase()
+    const [existing] = await deps.db
+      .select({ lookupKey: peopleTable.lookupKey, slug: peopleTable.slug })
+      .from(peopleTable)
+      .where(
+        and(
+          sql`lower(${peopleTable.canonicalName}) = ${lower}`,
+          isNull(peopleTable.deletedAt)
+        )
+      )
+      .limit(1)
+
+    if (existing) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              lookupKey: existing.lookupKey,
+              slug: existing.slug,
+              canonicalName: trimmed,
+              status: 'verified',
+              alreadyExists: true,
+              warning: `Person "${trimmed}" already exists`,
+              resolvedRelationships: [],
+              pendingRelationships: [],
+            }),
+          },
+        ],
+      }
+    }
+
+    const lookupKey = makeLookupKey('person')
+    const slug = await resolvePersonSlug(deps.db, generateSlug(trimmed))
+    const aliases = (input.aliases ?? [])
+      .map((a) => a.trim())
+      .filter((a) => a && a.toLowerCase() !== lower)
+    const contextNotes = input.metadata?.notes
+      ? appendContextNote(null, input.metadata.notes, 'mcp_create')
+      : null
+
+    await deps.db.insert(peopleTable).values({
+      lookupKey,
+      slug,
+      name: trimmed,
+      canonicalName: trimmed,
+      relationship: input.relationship?.trim() ?? '',
+      aliases,
+      verified: true,
+      isOwner: input.isOwner === true,
+      status: 'verified',
+      createdVia: 'mcp_create',
+      contextNotes,
+      state: 'RESOLVED',
+    })
+
+    const resolvedRelationships: Array<unknown> = []
+    const pendingRelationships: Array<unknown> = []
+    for (const rel of input.metadata?.relationships ?? []) {
+      const out = await resolveAndWriteRelationship(deps.db, lookupKey, rel)
+      if (out.resolved) resolvedRelationships.push(out.resolved)
+      if (out.pending) pendingRelationships.push(out.pending)
+    }
+
+    await emitAuditEvent(deps.db, {
+      entityType: 'person',
+      entityId: lookupKey,
+      eventType: 'created',
+      source: 'mcp',
+      summary: `Person created via MCP: ${trimmed}`,
+      detail: {
+        personKey: lookupKey,
+        canonicalName: trimmed,
+        status: 'verified',
+        createdVia: 'mcp_create',
+      },
+    })
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            lookupKey,
+            slug,
+            canonicalName: trimmed,
+            status: 'verified',
+            resolvedRelationships,
+            pendingRelationships,
+          }),
+        },
+      ],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp create_person failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `update_person` MCP tool call.
+ *
+ * @summary Apply field updates to an existing Person row. Aliases and
+ * notes append unless `replaceAliases` is set. Pending persons stay
+ * pending unless the caller passes `promoteFromQuarantine: true` —
+ * adding context is a recognition signal but the operator must opt
+ * in before the row becomes graph-visible.
+ */
+export async function handleUpdatePerson(
+  deps: McpServerDeps,
+  input: {
+    personLookupKey: string
+    updates: {
+      canonicalName?: string
+      aliases?: string[]
+      notes?: string
+      relationships?: RelationshipInput[]
+    }
+    options?: {
+      promoteFromQuarantine?: boolean
+      replaceAliases?: boolean
+    }
+  },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  if (!input.personLookupKey?.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: personLookupKey is required' }],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const [person] = await deps.db
+      .select()
+      .from(peopleTable)
+      .where(
+        and(
+          eq(peopleTable.lookupKey, input.personLookupKey.trim()),
+          isNull(peopleTable.deletedAt)
+        )
+      )
+      .limit(1)
+    if (!person) {
+      return {
+        content: [
+          { type: 'text' as const, text: `Error: person "${input.personLookupKey}" not found` },
+        ],
+        isError: true as const,
+      }
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() }
+    const updatedFields: string[] = []
+
+    if (input.updates.canonicalName !== undefined) {
+      const next = input.updates.canonicalName.trim()
+      if (next && next !== person.canonicalName) {
+        updates.canonicalName = next
+        updates.name = next
+        updatedFields.push('canonicalName')
+      }
+    }
+    if (input.updates.aliases !== undefined) {
+      const incoming = input.updates.aliases.map((a) => a.trim()).filter(Boolean)
+      if (input.options?.replaceAliases) {
+        updates.aliases = incoming
+        updatedFields.push('aliases')
+      } else {
+        const existing = person.aliases ?? []
+        const seen = new Set(existing.map((a) => a.toLowerCase()))
+        const merged = [...existing]
+        for (const a of incoming) {
+          if (!seen.has(a.toLowerCase())) {
+            seen.add(a.toLowerCase())
+            merged.push(a)
+          }
+        }
+        if (merged.length !== existing.length) {
+          updates.aliases = merged
+          updatedFields.push('aliases')
+        }
+      }
+    }
+    if (input.updates.notes !== undefined && input.updates.notes.trim()) {
+      const next = appendContextNote(
+        person.contextNotes ?? null,
+        input.updates.notes,
+        'mcp_update'
+      )
+      updates.contextNotes = next
+      updatedFields.push('notes')
+    }
+
+    let promoted = false
+    if (
+      input.options?.promoteFromQuarantine === true &&
+      person.status === 'pending'
+    ) {
+      updates.status = 'verified'
+      updates.verified = true
+      updates.createdVia = person.createdVia ?? 'mcp_update'
+      updatedFields.push('status')
+      promoted = true
+    }
+
+    if (Object.keys(updates).length > 1) {
+      await deps.db
+        .update(peopleTable)
+        .set(updates)
+        .where(eq(peopleTable.lookupKey, person.lookupKey))
+    }
+
+    const resolvedRelationships: Array<unknown> = []
+    const pendingRelationships: Array<unknown> = []
+    for (const rel of input.updates.relationships ?? []) {
+      const out = await resolveAndWriteRelationship(deps.db, person.lookupKey, rel)
+      if (out.resolved) resolvedRelationships.push(out.resolved)
+      if (out.pending) pendingRelationships.push(out.pending)
+    }
+
+    await emitAuditEvent(deps.db, {
+      entityType: 'person',
+      entityId: person.lookupKey,
+      eventType: promoted ? 'promoted' : 'edited',
+      source: 'mcp',
+      summary: promoted
+        ? `Person promoted from quarantine: ${person.canonicalName}`
+        : `Person updated via MCP: ${person.canonicalName}`,
+      detail: {
+        personKey: person.lookupKey,
+        updatedFields,
+        promoted,
+      },
+    })
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            lookupKey: person.lookupKey,
+            status: (updates.status as string | undefined) ?? person.status,
+            updatedFields,
+            resolvedRelationships,
+            pendingRelationships,
+            promoted,
+          }),
+        },
+      ],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp update_person failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `add_relationship` MCP tool call.
+ *
+ * @summary Companion tool to {@link handleCreatePerson} and
+ * {@link handleUpdatePerson} — write a single edge between two
+ * existing entities. Idempotent: re-running on the same triple is a
+ * no-op.
+ */
+export async function handleAddRelationship(
+  deps: McpServerDeps,
+  input: {
+    source: string
+    target: string
+    type: 'KNOWS' | 'RELATED_TO' | 'WORKS_AT' | 'AFFILIATED_WITH'
+    attrs?: { note?: string; sourceFragmentId?: string }
+  },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  const sourceTrim = input.source?.trim() ?? ''
+  if (!sourceTrim.startsWith('person:')) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: 'Error: source must be in form person:<key>',
+        },
+      ],
+      isError: true as const,
+    }
+  }
+  const sourceKey = sourceTrim.slice('person:'.length)
+  const [sourcePerson] = await deps.db
+    .select({ lookupKey: peopleTable.lookupKey })
+    .from(peopleTable)
+    .where(
+      and(eq(peopleTable.lookupKey, sourceKey), isNull(peopleTable.deletedAt))
+    )
+    .limit(1)
+  if (!sourcePerson) {
+    return {
+      content: [
+        { type: 'text' as const, text: `Error: source person "${sourceKey}" not found` },
+      ],
+      isError: true as const,
+    }
+  }
+
+  try {
+    const rel = (input.type === 'KNOWS' || input.type === 'RELATED_TO'
+      ? { type: input.type, target: input.target, ...(input.attrs ?? {}) }
+      : { type: input.type, target: input.target, ...(input.attrs ?? {}) }) as RelationshipInput
+
+    const out = await resolveAndWriteRelationship(deps.db, sourceKey, rel)
+    if (out.pending) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              reason: out.pending.reason,
+              target: out.pending.target,
+            }),
+          },
+        ],
+        isError: true as const,
+      }
+    }
+    if (!out.resolved) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: relationship not resolved' }],
+        isError: true as const,
+      }
+    }
+
+    await emitAuditEvent(deps.db, {
+      entityType: 'person',
+      entityId: sourceKey,
+      eventType: 'relationship_added',
+      source: 'mcp',
+      summary: `Relationship ${out.resolved.edgeType} added`,
+      detail: {
+        edgeId: out.resolved.edgeId,
+        edgeType: out.resolved.edgeType,
+        target: out.resolved.target,
+      },
+    })
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            edgeId: out.resolved.edgeId,
+            edgeType: out.resolved.edgeType,
+            exists: false,
+          }),
+        },
+      ],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp add_relationship failed')
     return {
       content: [{ type: 'text' as const, text: `Error: ${message}` }],
       isError: true as const,

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -30,8 +30,12 @@ import {
   parseLookupKey,
   generateSlug,
   loadPeopleExtractionSpec,
+  normalisePeopleExtraction,
 } from '@robin/shared'
 import type { PeopleExtractionOutput } from '@robin/shared'
+import { resolveOrDrop } from '@robin/agent'
+import { loadAutoAcceptPersons } from '../lib/people-settings.js'
+import { loadPendingPeople } from '../lib/people-settings.js'
 import type { BullMQProducer, ExtractionJob } from '@robin/queue'
 import { resolveEntrySlug, resolveFragmentSlug, resolveWikiSlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateEntry, findDuplicateFragment } from '../db/dedup.js'
@@ -51,7 +55,7 @@ import {
   unpublishWiki as unpublishWikiService,
 } from '../services/publish.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { resolvePerson, DEFAULT_RESOLUTION_CONFIG, embedText } from '@robin/agent'
+import { DEFAULT_RESOLUTION_CONFIG, embedText } from '@robin/agent'
 import type { KnownPerson } from '@robin/agent'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
 import { eq, and, isNull, inArray, ne } from 'drizzle-orm'
@@ -321,9 +325,11 @@ export async function handleLogFragment(
       }
     }
 
-    // Entity extraction (fail-open)
+    // Entity extraction (fail-open). Stream P: routes the extractor
+    // payload through the shared `resolveOrDrop` helper so the worker
+    // pipeline and this fast path produce the same outcome graph for
+    // the same input.
     const personKeys: string[] = []
-    const newPeople: Array<{ personKey: string; canonicalName: string }> = []
     try {
       const knownPeople = await deps.loadUserPeople(userId)
       const knownPeopleJson =
@@ -342,22 +348,35 @@ export async function handleLogFragment(
         knownPeople: knownPeopleJson,
       })
       const parsed = await deps.entityExtractCall(spec.system, spec.user)
+      const buckets = normalisePeopleExtraction(parsed)
 
-      const makePeopleKey = () => makeLookupKey('person')
-      for (const extraction of parsed.people) {
-        const resolved = resolvePerson(
-          extraction,
-          knownPeople,
-          DEFAULT_RESOLUTION_CONFIG,
-          makePeopleKey
-        )
-        personKeys.push(resolved.personKey)
-        if (resolved.isNew) {
-          newPeople.push({
-            personKey: resolved.personKey,
-            canonicalName: extraction.inferredName,
-          })
+      const pendingPool = await loadPendingPeople(deps.db)
+      const autoAccept = await loadAutoAcceptPersons(deps.db)
+
+      const outcomes = await resolveOrDrop(
+        { matched: buckets.matched, candidates: buckets.candidates },
+        {
+          // log_fragment knows the fragment id only after the insert
+          // below. We pass null to avoid coupling resolveOrDrop's
+          // ordering to the fragment row write.
+          fragmentId: null,
+          autoAccept,
+          verifiedPeople: knownPeople,
+          pendingPeople: pendingPool,
+          makePersonKey: () => makeLookupKey('person'),
+          insertPerson: async (input) => {
+            const { insertExtractedPerson } = await import(
+              '../lib/people-settings.js'
+            )
+            await insertExtractedPerson(deps.db, input)
+          },
+          resolutionConfig: DEFAULT_RESOLUTION_CONFIG,
         }
+      )
+
+      for (const outcome of outcomes) {
+        if (outcome.kind === 'dropped') continue
+        personKeys.push(outcome.lookupKey)
       }
     } catch (err) {
       log.warn({ err, userId }, 'log_fragment entity extraction failed (continuing)')
@@ -441,21 +460,10 @@ export async function handleLogFragment(
         .onConflictDoNothing()
     }
 
-    // Insert new people rows (for people not yet in DB)
-    for (const person of newPeople) {
-      await deps.db
-        .insert(peopleTable)
-        .values({
-          lookupKey: person.personKey,
-          slug: generateSlug(person.canonicalName),
-          name: person.canonicalName,
-          canonicalName: person.canonicalName,
-          state: 'RESOLVED',
-          aliases: [],
-          verified: false,
-        })
-        .onConflictDoNothing()
-    }
+    // Stream P: new persons are inserted by `resolveOrDrop` via the
+    // `insertExtractedPerson` helper, so this handler no longer needs
+    // a per-person upsert loop. The helper stamps status, created_via,
+    // and extracted_from_fragment_id uniformly with the worker path.
 
     // Mark wiki for regen (PENDING signals regen needed)
     await deps.db

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -1346,6 +1346,137 @@ function appendContextNote(
   }
 }
 
+import {
+  loadAutoAcceptPersons as readAutoAcceptPersons,
+  setAutoAcceptPersons as writeAutoAcceptPersons,
+} from '../lib/people-settings.js'
+
+/**
+ * Handle the `list_pending_persons` MCP tool call. Read-only triage view
+ * of the quarantine queue. Approval and rejection are HTTP-only via
+ * /admin/people/:key/approve and /reject; this tool only surfaces the
+ * queue contents so AI agents can plan their next action.
+ */
+export async function handleListPendingPersons(
+  deps: McpServerDeps,
+  input: { limit?: number; offset?: number; since?: string },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  const limit = Math.max(1, Math.min(200, input.limit ?? 50))
+  const offset = Math.max(0, input.offset ?? 0)
+  try {
+    const baseFilter = sql`${peopleTable.status} = 'pending' AND ${peopleTable.deletedAt} IS NULL`
+    const where =
+      input.since && !Number.isNaN(Date.parse(input.since))
+        ? sql`${baseFilter} AND ${peopleTable.createdAt} >= ${new Date(input.since)}`
+        : baseFilter
+
+    const rows = await deps.db
+      .select({
+        lookupKey: peopleTable.lookupKey,
+        slug: peopleTable.slug,
+        canonicalName: peopleTable.canonicalName,
+        aliases: peopleTable.aliases,
+        createdAt: peopleTable.createdAt,
+        createdVia: peopleTable.createdVia,
+        extractedFromFragmentId: peopleTable.extractedFromFragmentId,
+      })
+      .from(peopleTable)
+      .where(where)
+      .orderBy(sql`${peopleTable.createdAt} DESC`)
+      .limit(limit)
+      .offset(offset)
+
+    const totalRows = await deps.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(peopleTable)
+      .where(where)
+    const total = Number(totalRows[0]?.count ?? 0)
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            persons: rows.map((r) => ({
+              lookupKey: r.lookupKey,
+              slug: r.slug,
+              canonicalName: r.canonicalName,
+              aliases: r.aliases ?? [],
+              status: 'pending' as const,
+              createdAt: r.createdAt?.toISOString?.() ?? null,
+              createdVia: r.createdVia,
+              extractedFromFragmentId: r.extractedFromFragmentId,
+            })),
+            total,
+          }),
+        },
+      ],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp list_pending_persons failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+/**
+ * Handle the `set_auto_accept_persons` MCP tool. Toggles the instance-wide
+ * `auto_accept_persons` flag in app_settings. When true, the extractor flips
+ * new candidates straight to status='verified' instead of routing them
+ * through the quarantine queue.
+ */
+export async function handleSetAutoAcceptPersons(
+  deps: McpServerDeps,
+  input: { value: boolean },
+  userId: string | undefined
+) {
+  if (!userId) {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: not authenticated' }],
+      isError: true as const,
+    }
+  }
+  if (typeof input.value !== 'boolean') {
+    return {
+      content: [{ type: 'text' as const, text: 'Error: value must be boolean' }],
+      isError: true as const,
+    }
+  }
+  try {
+    const result = await writeAutoAcceptPersons(deps.db, input.value)
+    await emitAuditEvent(deps.db, {
+      entityType: 'app_setting',
+      entityId: 'auto_accept_persons',
+      eventType: 'edited',
+      source: 'mcp',
+      summary: `auto_accept_persons set to ${result.current}`,
+      detail: result,
+    })
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error({ err, userId }, 'mcp set_auto_accept_persons failed')
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true as const,
+    }
+  }
+}
+
+void readAutoAcceptPersons
+
 /**
  * Handle the `create_person` MCP tool call.
  *

--- a/core/src/mcp/resolvers.ts
+++ b/core/src/mcp/resolvers.ts
@@ -141,6 +141,13 @@ interface PersonDetail {
     slug: string
     aliases: string[]
     relationship: string
+    /**
+     * Stream P quarantine status. 'pending' rows render with a
+     * full-width quarantine topbar in the frontend; consumers should
+     * always carry this through so downstream UI can render the
+     * indicator without a second fetch.
+     */
+    status: 'verified' | 'pending' | 'rejected'
   }
   body: string
   fragments: FragmentSnippet[]
@@ -698,6 +705,7 @@ export async function findPersonById(
       aliases: people.aliases,
       content: people.content,
       createdAt: people.createdAt,
+      status: people.status,
     })
     .from(people)
     .where(and(eq(people.lookupKey, id), isNull(people.deletedAt)))
@@ -759,6 +767,7 @@ export async function findPersonById(
       slug: person.slug,
       aliases: person.aliases ?? [],
       relationship: person.relationship,
+      status: (person.status ?? 'verified') as 'verified' | 'pending' | 'rejected',
     },
     body,
     fragments: fragmentSnippets,
@@ -794,6 +803,7 @@ export async function findPersonByQuery(
       aliases: people.aliases,
       content: people.content,
       createdAt: people.createdAt,
+      status: people.status,
     })
     .from(people)
     .where(isNull(people.deletedAt))
@@ -864,6 +874,7 @@ export async function findPersonByQuery(
       slug: person.slug,
       aliases: resolved.match.aliases,
       relationship: person.relationship,
+      status: (person.status ?? 'verified') as 'verified' | 'pending' | 'rejected',
     },
     body,
     fragments: fragmentSnippets,
@@ -1018,6 +1029,12 @@ export async function briefPerson(
   // Assemble markdown
   const lines: string[] = []
   lines.push(`# ${person.name}`)
+  if (person.status === 'pending') {
+    // Stream P quarantine: brief_person shows the same banner the
+    // frontend renders so AI agents see the "not yet approved" state
+    // without having to re-fetch /admin/people.
+    lines.push('> Quarantine: this person is awaiting operator approval (status=pending).')
+  }
   if (summary) lines.push(summary)
   if (person.relationship) lines.push(`Relationship: ${person.relationship}`)
   if (person.aliases.length > 0) lines.push(`Aliases: ${person.aliases.join(', ')}`)

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -22,7 +22,7 @@ import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveWikiBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow, handleRegenStatus, handleCreatePerson, handleUpdatePerson, handleAddRelationship } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow, handleRegenStatus, handleCreatePerson, handleUpdatePerson, handleAddRelationship, handleListPendingPersons, handleSetAutoAcceptPersons } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 import { wikis, wikiTypes, edges, auditLog, groups, groupWikis } from '../db/schema.js'
 import { hybridSearch } from '../lib/search.js'
@@ -359,6 +359,41 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     },
     async (input, extra) => {
       return handleUpdatePerson(deps, input, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'list_pending_persons',
+    {
+      description:
+        'List Persons in the quarantine queue (status="pending"). Read-only triage view. ' +
+        'Approval and rejection are HTTP-only via /admin/people/:key/approve and /admin/people/:key/reject; ' +
+        'this tool only surfaces the queue contents so AI agents can plan their next step.',
+      inputSchema: {
+        limit: z.number().optional().describe('Max rows (default 50, max 200)'),
+        offset: z.number().optional().describe('Pagination offset'),
+        since: z
+          .string()
+          .optional()
+          .describe('ISO timestamp; only persons created after this'),
+      },
+    },
+    async (input, extra) => {
+      return handleListPendingPersons(deps, input, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'set_auto_accept_persons',
+    {
+      description:
+        'Toggle the instance-wide `auto_accept_persons` flag (app_settings). When true, ' +
+        'the extractor flips new candidates straight to status="verified" instead of ' +
+        'routing them through the quarantine queue. Returns { previous, current }.',
+      inputSchema: { value: z.boolean() },
+    },
+    async (input, extra) => {
+      return handleSetAutoAcceptPersons(deps, input, extra.authInfo?.clientId as string)
     }
   )
 

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -22,7 +22,7 @@ import { eq, and, isNull, inArray, sql } from 'drizzle-orm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { listWikis, getWiki, getFragment, findPersonById, findPersonByQuery, listWikiTypes, briefPerson, resolveWikiBySlug } from './resolvers.js'
 import type { McpResolverDeps } from './resolvers.js'
-import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow, handleRegenStatus } from './handlers.js'
+import { handleLogEntry, handleLogFragment, handleCreateWikiType, handleCreateWiki, handleEditWiki, handleAttachFragments, handlePublishWiki, handleUnpublishWiki, handleRegenNow, handleRegenStatus, handleCreatePerson, handleUpdatePerson, handleAddRelationship } from './handlers.js'
 import type { McpServerDeps } from './handlers.js'
 import { wikis, wikiTypes, edges, auditLog, groups, groupWikis } from '../db/schema.js'
 import { hybridSearch } from '../lib/search.js'
@@ -286,6 +286,102 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
     },
     async ({ recentLimit }, extra) => {
       return handleRegenStatus(deps, { recentLimit }, extra.authInfo?.clientId as string)
+    }
+  )
+
+  /***********************************************************************
+   * ## People tools (Stream P)
+   ***********************************************************************/
+
+  const relationshipInput = z
+    .object({
+      type: z.enum(['KNOWS', 'RELATED_TO', 'WORKS_AT', 'AFFILIATED_WITH']),
+      target: z
+        .string()
+        .describe('person:<key|canonical-name> or wiki:<key|slug>'),
+      direction: z.enum(['bidirectional', 'outbound']).optional(),
+      role: z.string().optional(),
+      note: z.string().optional(),
+      sourceFragmentId: z.string().optional(),
+    })
+
+  server.registerTool(
+    'create_person',
+    {
+      description:
+        'Create a new Person row. MCP creation is the explicit "I know who this is" path: ' +
+        'rows always land status="verified" and bypass the quarantine queue (auto-extracted ' +
+        'persons go to quarantine instead). Returns lookupKey + slug + resolved/pending ' +
+        'relationships.',
+      inputSchema: {
+        canonicalName: z.string().describe('Canonical display name'),
+        aliases: z.array(z.string()).optional().describe('Optional aliases (deduped)'),
+        relationship: z
+          .string()
+          .optional()
+          .describe('Freeform relationship descriptor ("manager", "colleague")'),
+        isOwner: z.boolean().optional().describe('Set true to flag this as the owner Person'),
+        metadata: z
+          .object({
+            relationships: z.array(relationshipInput).optional(),
+            notes: z.string().optional(),
+          })
+          .optional(),
+      },
+    },
+    async (input, extra) => {
+      return handleCreatePerson(deps, input, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'update_person',
+    {
+      description:
+        'Apply field updates to an existing Person row. Aliases and notes append unless ' +
+        '`replaceAliases` is true. Pending persons stay pending unless `promoteFromQuarantine` ' +
+        'is true (adding context is a recognition signal but the operator must opt in).',
+      inputSchema: {
+        personLookupKey: z.string().describe('Person lookup key'),
+        updates: z.object({
+          canonicalName: z.string().optional(),
+          aliases: z.array(z.string()).optional(),
+          notes: z.string().optional(),
+          relationships: z.array(relationshipInput).optional(),
+        }),
+        options: z
+          .object({
+            promoteFromQuarantine: z.boolean().optional(),
+            replaceAliases: z.boolean().optional(),
+          })
+          .optional(),
+      },
+    },
+    async (input, extra) => {
+      return handleUpdatePerson(deps, input, extra.authInfo?.clientId as string)
+    }
+  )
+
+  server.registerTool(
+    'add_relationship',
+    {
+      description:
+        'Add a single edge between an existing Person and a Person or Wiki. ' +
+        'Idempotent — re-running the same triple is a no-op.',
+      inputSchema: {
+        source: z.string().describe('person:<key>'),
+        target: z.string().describe('person:<key> or wiki:<key|slug>'),
+        type: z.enum(['KNOWS', 'RELATED_TO', 'WORKS_AT', 'AFFILIATED_WITH']),
+        attrs: z
+          .object({
+            note: z.string().optional(),
+            sourceFragmentId: z.string().optional(),
+          })
+          .optional(),
+      },
+    },
+    async (input, extra) => {
+      return handleAddRelationship(deps, input, extra.authInfo?.clientId as string)
     }
   )
 

--- a/core/src/queue/embedding-retry-worker.ts
+++ b/core/src/queue/embedding-retry-worker.ts
@@ -149,6 +149,10 @@ async function retryTable<TableName extends 'fragments' | 'wikis' | 'people'>(
         and(
           isNull(people.embedding),
           isNull(people.deletedAt),
+          // Stream P quarantine: pending persons stay out of the
+          // embedding heal pass. They become eligible the moment they
+          // are approved (status flips to 'verified').
+          sql`${people.status} = 'verified'`,
           sql`${people.embeddingAttemptCount} < ${MAX_ATTEMPTS}`,
           or(
             isNull(people.embeddingLastAttemptAt),

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -55,6 +55,12 @@ import { computeContentHash } from '../db/dedup.js'
 import { emitPipelineEvent, type PipelineStage } from '../db/pipeline-events.js'
 import { emitAuditEvent } from '../db/audit.js'
 import { emitUsageEvent } from '../db/usage-events.js'
+import {
+  loadVerifiedPeople,
+  loadPendingPeople,
+  loadAutoAcceptPersons,
+  insertExtractedPerson,
+} from '../lib/people-settings.js'
 import { producer } from './producer.js'
 import { processRegenJob, processRegenBatchJob } from './regen-worker.js'
 import { processEmbeddingRetryJob } from './embedding-retry-worker.js'
@@ -245,20 +251,14 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
       emitEvent,
     },
     entityExtractDeps: {
-      loadAllPeople: async () => {
-        const rows = await db
-          .select({
-            lookupKey: people.lookupKey,
-            canonicalName: people.canonicalName,
-            aliases: people.aliases,
-          })
-          .from(people)
-        return rows.map((r) => ({
-          lookupKey: r.lookupKey,
-          canonicalName: r.canonicalName,
-          aliases: r.aliases ?? [],
-        }))
-      },
+      // Stream P: matcher prompt sees verified people only; pending
+      // people participate in extract-time dedup but not in the LLM
+      // candidate list. The helpers in `lib/people-settings` are the
+      // single source of truth for both pools.
+      loadAllPeople: () => loadVerifiedPeople(db),
+      loadPendingPeople: () => loadPendingPeople(db),
+      loadAutoAcceptPersons: () => loadAutoAcceptPersons(db),
+      insertPerson: (input) => insertExtractedPerson(db, input),
       llmCall: withTypedUsage(peopleExtractionSchema, {
         agent: agents.entityExtractor,
         record: recordUsage,

--- a/core/src/routes/admin/people.test.ts
+++ b/core/src/routes/admin/people.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Module-level mocks ─────────────────────────────────────────────────────
+
+vi.mock('../../db/audit.js', () => ({
+  emitAuditEvent: vi.fn(async () => {}),
+}))
+
+vi.mock('../../middleware/session.js', () => ({
+  sessionMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('../../db/schema.js', () => ({
+  people: {
+    lookupKey: 'lookup_key',
+    slug: 'slug',
+    canonicalName: 'canonical_name',
+    name: 'name',
+    aliases: 'aliases',
+    status: 'status',
+    deletedAt: 'deleted_at',
+    createdAt: 'created_at',
+    createdVia: 'created_via',
+    extractedFromFragmentId: 'extracted_from_fragment_id',
+    relationship: 'relationship',
+    updatedAt: 'updated_at',
+  },
+  edges: { dstId: 'dst_id', dstType: 'dst_type', deletedAt: 'deleted_at' },
+}))
+
+const dbState: {
+  selectRows: Record<string, unknown[]>
+  updateCaptured: Array<Record<string, unknown>>
+  selectIndex: number
+} = {
+  selectRows: { person: [], count: [{ count: 0 }] },
+  updateCaptured: [],
+  selectIndex: 0,
+}
+
+vi.mock('../../db/client.js', () => ({
+  db: {
+    select: vi.fn(() => {
+      const idx = dbState.selectIndex++
+      return {
+        from: () => ({
+          where: () => {
+            const cur = idx
+            const out =
+              cur === 0
+                ? dbState.selectRows.person
+                : dbState.selectRows.count
+            return {
+              orderBy: () => ({
+                limit: () => ({ offset: async () => out }),
+              }),
+              limit: async () => out,
+              [Symbol.iterator]: undefined,
+              then: (resolve: (v: unknown) => void) => resolve(out),
+            }
+          },
+        }),
+      }
+    }),
+    update: vi.fn(() => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: async () => {
+          dbState.updateCaptured.push(vals)
+        },
+      }),
+    })),
+  },
+}))
+
+const { adminPeopleRoutes } = await import('./people.js')
+
+beforeEach(() => {
+  dbState.selectRows = { person: [], count: [{ count: 0 }] }
+  dbState.updateCaptured = []
+  dbState.selectIndex = 0
+})
+
+describe('admin /people endpoints — Stream P', () => {
+  it('GET /admin/people defaults to status=pending', async () => {
+    dbState.selectRows.person = [
+      {
+        lookupKey: 'person01PND',
+        slug: 'eric-tan',
+        canonicalName: 'Eric Tan',
+        name: 'Eric Tan',
+        aliases: [],
+        status: 'pending',
+        createdAt: new Date('2026-05-09'),
+        createdVia: 'extractor_pending',
+        extractedFromFragmentId: 'frag01',
+        relationship: '',
+      },
+    ]
+    dbState.selectRows.count = [{ count: 1 }]
+    const res = await adminPeopleRoutes.request('/')
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { persons: unknown[]; total: number }
+    expect(json.total).toBe(1)
+    expect((json.persons[0] as { status: string }).status).toBe('pending')
+  })
+
+  it('POST /:lookupKey/approve flips pending -> verified', async () => {
+    dbState.selectRows.person = [
+      {
+        lookupKey: 'person01PND',
+        status: 'pending',
+        canonicalName: 'Eric',
+        createdVia: 'extractor_pending',
+      },
+    ]
+    const res = await adminPeopleRoutes.request('/person01PND/approve', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { status: string; promotedAt: string | null }
+    expect(json.status).toBe('verified')
+    expect(json.promotedAt).toBeTruthy()
+    expect(dbState.updateCaptured).toContainEqual(
+      expect.objectContaining({ status: 'verified', verified: true })
+    )
+  })
+
+  it('POST /:lookupKey/approve is idempotent on already-verified', async () => {
+    dbState.selectRows.person = [
+      {
+        lookupKey: 'person01OK',
+        status: 'verified',
+        canonicalName: 'Sam',
+        createdVia: 'mcp_create',
+      },
+    ]
+    const res = await adminPeopleRoutes.request('/person01OK/approve', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { alreadyVerified: boolean }
+    expect(json.alreadyVerified).toBe(true)
+    expect(dbState.updateCaptured).toHaveLength(0)
+  })
+
+  it('POST /:lookupKey/approve returns 404 for missing person', async () => {
+    dbState.selectRows.person = []
+    const res = await adminPeopleRoutes.request('/person01MISS/approve', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST /:lookupKey/reject defaults to soft reject (status=rejected)', async () => {
+    dbState.selectRows.person = [
+      { lookupKey: 'person01PND', status: 'pending', canonicalName: 'Eric' },
+    ]
+    const res = await adminPeopleRoutes.request('/person01PND/reject', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { status: string }
+    expect(json.status).toBe('rejected')
+    expect(dbState.updateCaptured).toContainEqual(
+      expect.objectContaining({ status: 'rejected' })
+    )
+  })
+
+  it('POST /:lookupKey/reject with hardDelete=true cascades edges', async () => {
+    dbState.selectRows.person = [
+      { lookupKey: 'person01PND', status: 'pending', canonicalName: 'Eric' },
+    ]
+    const res = await adminPeopleRoutes.request('/person01PND/reject', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hardDelete: true }),
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { status: string }
+    expect(json.status).toBe('deleted')
+    // The handler should have set deletedAt on both the edges and the
+    // person row (two update calls).
+    expect(dbState.updateCaptured.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/core/src/routes/admin/people.ts
+++ b/core/src/routes/admin/people.ts
@@ -1,0 +1,252 @@
+/**
+ * Stream P (#PEOPLE-EXTRACT-Q) — admin endpoints for the quarantine queue.
+ *
+ * Approval and rejection are intentionally HTTP-only. AI agents read the
+ * queue via `list_pending_persons` (MCP) but the actual approve/reject
+ * call goes through the admin UI: those are deliberate operator actions,
+ * not flows we want hidden behind an MCP tool.
+ *
+ * Auth uses the same session middleware as `/admin/retry-stuck` and the
+ * other admin endpoints; there is no separate admin token because the
+ * single-tenant deployment treats the only authenticated user as the
+ * operator.
+ */
+
+import { Hono } from 'hono'
+import { and, eq, isNull, sql } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../../db/client.js'
+import { people, edges } from '../../db/schema.js'
+import { sessionMiddleware } from '../../middleware/session.js'
+import { logger } from '../../lib/logger.js'
+import { emitAuditEvent } from '../../db/audit.js'
+
+const log = logger.child({ component: 'admin-people' })
+
+export const adminPeopleRoutes = new Hono()
+adminPeopleRoutes.use('*', sessionMiddleware)
+
+const listQuerySchema = z.object({
+  status: z.enum(['pending', 'verified', 'rejected']).default('pending'),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+  since: z.string().optional(),
+})
+
+/**
+ * GET /admin/people
+ *
+ * Triage list of persons by status. Defaults to status='pending' so the
+ * admin UI can render the quarantine queue without a query string.
+ */
+adminPeopleRoutes.get('/', async (c) => {
+  const parsed = listQuerySchema.safeParse({
+    status: c.req.query('status'),
+    limit: c.req.query('limit'),
+    offset: c.req.query('offset'),
+    since: c.req.query('since'),
+  })
+  if (!parsed.success) {
+    return c.json({ error: 'invalid query', details: parsed.error.format() }, 400)
+  }
+  const { status, limit, offset, since } = parsed.data
+  const sinceDate =
+    since && !Number.isNaN(Date.parse(since)) ? new Date(since) : null
+
+  const baseFilter = and(
+    isNull(people.deletedAt),
+    sql`${people.status} = ${status}`
+  )
+  const where = sinceDate
+    ? and(baseFilter, sql`${people.createdAt} >= ${sinceDate}`)
+    : baseFilter
+
+  const rows = await db
+    .select({
+      lookupKey: people.lookupKey,
+      slug: people.slug,
+      canonicalName: people.canonicalName,
+      name: people.name,
+      aliases: people.aliases,
+      status: people.status,
+      createdAt: people.createdAt,
+      createdVia: people.createdVia,
+      extractedFromFragmentId: people.extractedFromFragmentId,
+      relationship: people.relationship,
+    })
+    .from(people)
+    .where(where)
+    .orderBy(sql`${people.createdAt} DESC`)
+    .limit(limit)
+    .offset(offset)
+
+  const totalRows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(people)
+    .where(where)
+  const total = Number(totalRows[0]?.count ?? 0)
+
+  return c.json({
+    persons: rows.map((r) => ({
+      lookupKey: r.lookupKey,
+      slug: r.slug,
+      canonicalName: r.canonicalName,
+      name: r.name,
+      aliases: r.aliases ?? [],
+      status: r.status,
+      createdAt: r.createdAt?.toISOString?.() ?? null,
+      createdVia: r.createdVia,
+      extractedFromFragmentId: r.extractedFromFragmentId,
+      relationship: r.relationship,
+    })),
+    total,
+  })
+})
+
+/**
+ * POST /admin/people/:lookupKey/approve
+ *
+ * Flips status to 'verified' and emits a 'promoted' audit row. Existing
+ * FRAGMENT_MENTIONS_PERSON edges become "fully involved" with no
+ * backfill — read sites carry status through, so they self-heal the
+ * moment the row is verified. The wiki_agent_schema heal pass picks up
+ * the new verified row on its next tick.
+ */
+adminPeopleRoutes.post('/:lookupKey/approve', async (c) => {
+  const lookupKey = c.req.param('lookupKey')
+  if (!lookupKey) return c.json({ error: 'lookupKey required' }, 400)
+
+  const [existing] = await db
+    .select({
+      lookupKey: people.lookupKey,
+      status: people.status,
+      canonicalName: people.canonicalName,
+      createdVia: people.createdVia,
+    })
+    .from(people)
+    .where(and(eq(people.lookupKey, lookupKey), isNull(people.deletedAt)))
+    .limit(1)
+  if (!existing) {
+    return c.json({ error: 'Person not found' }, 404)
+  }
+  if (existing.status === 'verified') {
+    return c.json({
+      lookupKey: existing.lookupKey,
+      status: 'verified',
+      promotedAt: null,
+      alreadyVerified: true,
+    })
+  }
+
+  const now = new Date()
+  await db
+    .update(people)
+    .set({ status: 'verified', verified: true, updatedAt: now })
+    .where(eq(people.lookupKey, lookupKey))
+
+  await emitAuditEvent(db, {
+    entityType: 'person',
+    entityId: lookupKey,
+    eventType: 'promoted',
+    source: 'api',
+    summary: `Person approved: ${existing.canonicalName}`,
+    detail: {
+      personKey: lookupKey,
+      previousStatus: existing.status,
+      previousCreatedVia: existing.createdVia,
+    },
+  })
+
+  log.info({ lookupKey }, 'pending person approved')
+  return c.json({
+    lookupKey,
+    status: 'verified',
+    promotedAt: now.toISOString(),
+  })
+})
+
+const rejectBodySchema = z.object({
+  hardDelete: z.boolean().optional().default(false),
+})
+
+/**
+ * POST /admin/people/:lookupKey/reject
+ *
+ * Default: status='rejected', edges stay attached but invisible (read
+ * sites filter them out). Pass `{ hardDelete: true }` to cascade-delete
+ * the row plus its edges.
+ */
+adminPeopleRoutes.post('/:lookupKey/reject', async (c) => {
+  const lookupKey = c.req.param('lookupKey')
+  if (!lookupKey) return c.json({ error: 'lookupKey required' }, 400)
+
+  let body: z.infer<typeof rejectBodySchema> = { hardDelete: false }
+  try {
+    const json = await c.req.json().catch(() => ({}))
+    const parsed = rejectBodySchema.safeParse(json)
+    if (parsed.success) body = parsed.data
+  } catch {
+    // empty body is fine
+  }
+
+  const [existing] = await db
+    .select({
+      lookupKey: people.lookupKey,
+      status: people.status,
+      canonicalName: people.canonicalName,
+    })
+    .from(people)
+    .where(and(eq(people.lookupKey, lookupKey), isNull(people.deletedAt)))
+    .limit(1)
+  if (!existing) {
+    return c.json({ error: 'Person not found' }, 404)
+  }
+
+  if (body.hardDelete) {
+    // Hard delete: cascade edges first, then the row. We do NOT rely
+    // on FK ON DELETE CASCADE because the edges schema does not
+    // declare it; soft-delete the rows in code instead.
+    const now = new Date()
+    await db
+      .update(edges)
+      .set({ deletedAt: now })
+      .where(
+        and(
+          eq(edges.dstId, lookupKey),
+          eq(edges.dstType, 'person'),
+          isNull(edges.deletedAt)
+        )
+      )
+    await db
+      .update(people)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(eq(people.lookupKey, lookupKey))
+
+    await emitAuditEvent(db, {
+      entityType: 'person',
+      entityId: lookupKey,
+      eventType: 'deleted',
+      source: 'api',
+      summary: `Pending person rejected and hard-deleted: ${existing.canonicalName}`,
+      detail: { personKey: lookupKey, hardDelete: true, previousStatus: existing.status },
+    })
+    return c.json({ lookupKey, status: 'deleted' as const })
+  }
+
+  await db
+    .update(people)
+    .set({ status: 'rejected', updatedAt: new Date() })
+    .where(eq(people.lookupKey, lookupKey))
+
+  await emitAuditEvent(db, {
+    entityType: 'person',
+    entityId: lookupKey,
+    eventType: 'rejected',
+    source: 'api',
+    summary: `Pending person rejected: ${existing.canonicalName}`,
+    detail: { personKey: lookupKey, previousStatus: existing.status },
+  })
+
+  log.info({ lookupKey }, 'pending person rejected')
+  return c.json({ lookupKey, status: 'rejected' as const })
+})

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -191,7 +191,7 @@ fragmentsRouter.post(
       spawnWriteWorker: () => {},
       // Web direct-send mirrors the MCP wiring (no entity extraction).
       // The classifier-bypass is the whole point — keep this fail-open.
-      entityExtractCall: async () => ({ people: [] }),
+      entityExtractCall: async () => ({ matched: [], candidates: [] }),
       loadUserPeople: async () => [],
     }
 

--- a/core/src/routes/mcp.ts
+++ b/core/src/routes/mcp.ts
@@ -50,7 +50,7 @@ mcp.all('/', async (c) => {
     db,
     producer,
     spawnWriteWorker: () => {},
-    entityExtractCall: async () => ({ people: [] }),
+    entityExtractCall: async () => ({ matched: [], candidates: [] }),
     loadUserPeople: async () => [],
   }
 

--- a/core/src/routes/people.ts
+++ b/core/src/routes/people.ts
@@ -63,16 +63,35 @@ peopleRouter.get('/', async (c) => {
   const limit = query.success ? query.data.limit : 50
   const offset = query.success ? query.data.offset : 0
 
+  // Stream P quarantine: GET /people defaults to status='verified'.
+  // Pass ?status=pending to load the triage queue, ?status=all to
+  // see every row regardless of status (used by admin tooling).
+  const statusFilter = c.req.query('status') ?? 'verified'
+  const where =
+    statusFilter === 'all'
+      ? isNull(people.deletedAt)
+      : statusFilter === 'pending'
+        ? and(isNull(people.deletedAt), sql`${people.status} = 'pending'`)
+        : statusFilter === 'rejected'
+          ? and(isNull(people.deletedAt), sql`${people.status} = 'rejected'`)
+          : and(isNull(people.deletedAt), sql`${people.status} = 'verified'`)
+
   const rows = await db
     .select()
     .from(people)
-    .where(isNull(people.deletedAt))
+    .where(where)
     .orderBy(people.name)
     .limit(limit)
     .offset(offset)
 
   return c.json(
-    personListResponseSchema.parse({ people: rows.map((r) => ({ ...r, id: r.lookupKey })) })
+    personListResponseSchema.parse({
+      people: rows.map((r) => ({
+        ...r,
+        id: r.lookupKey,
+        status: (r as unknown as { status?: string }).status ?? 'verified',
+      })),
+    })
   )
 })
 

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -370,7 +370,15 @@ wikisRouter.get('/:id', async (c) => {
   const peopleRows =
     personKeys.length > 0
       ? await db
-          .select({ lookupKey: people.lookupKey, name: people.name })
+          .select({
+            lookupKey: people.lookupKey,
+            name: people.name,
+            // Stream P quarantine: edge reads carry status through so
+            // consumers can render the quarantine indicator without
+            // a second fetch. Pending persons stay visible in this
+            // listing per the locked matrix.
+            status: people.status,
+          })
           .from(people)
           .where(inArray(people.lookupKey, personKeys))
       : []
@@ -397,6 +405,10 @@ wikisRouter.get('/:id', async (c) => {
       people: peopleRows.map((p) => ({
         id: p.lookupKey,
         name: p.name,
+        status: ((p as { status?: string }).status ?? 'verified') as
+          | 'verified'
+          | 'pending'
+          | 'rejected',
       })),
     })
   }
@@ -422,6 +434,10 @@ wikisRouter.get('/:id', async (c) => {
       people: peopleRows.map((p) => ({
         id: p.lookupKey,
         name: p.name,
+        status: ((p as { status?: string }).status ?? 'verified') as
+          | 'verified'
+          | 'pending'
+          | 'rejected',
       })),
       refs: sidecar.refs,
       infobox: sidecar.infobox,

--- a/core/src/schemas/people.schema.ts
+++ b/core/src/schemas/people.schema.ts
@@ -13,6 +13,9 @@ export const personResponseSchema = z.object({
   aliases: z.array(z.string()),
   verified: z.boolean(),
   state: objectStateSchema,
+  // Stream P quarantine status. Default 'verified' so legacy clients
+  // and pre-migration rows continue to parse cleanly.
+  status: z.enum(['verified', 'pending', 'rejected']).default('verified'),
   lastRebuiltAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
@@ -79,6 +82,11 @@ export const mergePersonBodySchema = z.object({
 
 export const personListQuerySchema = paginationQuerySchema.extend({
   offset: z.coerce.number().int().min(0).default(0),
+  // Stream P quarantine filter. Default 'verified' (graph-visible only).
+  status: z
+    .enum(['verified', 'pending', 'rejected', 'all'])
+    .optional()
+    .default('verified'),
 })
 
 export { queuedResponseSchema as personRegenerateResponseSchema }

--- a/core/src/schemas/wikis.schema.ts
+++ b/core/src/schemas/wikis.schema.ts
@@ -80,6 +80,8 @@ export const wikiDetailResponseSchema = wikiResponseSchema.extend({
     z.object({
       id: lookupKeySchema,
       name: z.string(),
+      // Stream P quarantine status; default 'verified' for legacy rows.
+      status: z.enum(['verified', 'pending', 'rejected']).default('verified'),
     })
   ),
   refs: wikiRefsMapSchema.default({}),

--- a/docs/architecture/people-quarantine.md
+++ b/docs/architecture/people-quarantine.md
@@ -1,0 +1,72 @@
+# People Quarantine
+
+Robin's people pipeline went from a matcher-only design (the LLM never proposed new people) to an extractor that surfaces every person-like mention. New persons land in a quarantine queue by default, gated behind an operator approval step. This document describes the model and the read-site exclusion matrix.
+
+## The matcher to extractor flip
+
+`people-extraction.yaml` v2 told the LLM "you NEVER propose new people, drop unfamiliar names silently". A live deployment ingested 89 entries (534 fragments) and produced zero new Person rows because the prompt filtered them out before they reached the worker.
+
+v3 (Stream P, 2026-05-09) flips Elfie from matcher to extractor. The LLM now returns every person-like mention split into two buckets:
+
+- `matched`: the mention maps to an entry in KNOWN PEOPLE (verified row).
+- `candidates`: the mention does not map to anyone in KNOWN PEOPLE.
+
+The shared `resolveOrDrop` helper handles dedup and creation downstream. Both the worker pipeline (entityExtract) and the MCP `log_fragment` fast path call it, so the same input produces the same outcome graph regardless of how the fragment arrived.
+
+## The four statuses
+
+Every row in `people` carries a status. Migration 0017 added the column with a CHECK constraint pinning it to one of the four:
+
+- `verified`: graph-visible. Default for legacy rows and for any row created via MCP.
+- `pending`: in the quarantine queue. Auto-extracted persons land here by default.
+- `rejected`: operator rejected. Edges stay attached but invisible; row stays in the table for audit.
+- (deleted via `deletedAt`): soft-deleted, invisible to all read sites. Functionally a fourth state.
+
+## The five entry paths
+
+Every Person row carries a `created_via` label that records how it entered the system:
+
+1. `seeded`: bootstrap rows (e.g. owner-Person from the onboarding flow). Status `verified`.
+2. `mcp_create`: explicit AI-agent or operator creation via `create_person` MCP tool. Status `verified`. The "I know who this is" path; bypasses quarantine by design.
+3. `mcp_update`: a row promoted from pending to verified via `update_person` with `promoteFromQuarantine: true`. Status `verified` after the call.
+4. `extractor_pending`: surfaced by the extractor and routed through quarantine. Status `pending`.
+5. `extractor_auto`: surfaced by the extractor when `app_settings.auto_accept_persons` is true. Status `verified`. Operators flip the toggle when they trust extraction enough to skip the queue.
+
+## Read-site exclusion matrix
+
+The matrix locked 2026-05-09. Pending persons are EXCLUDED from hybrid search entirely (no marker, just absent), and all other read sites surface pending rows WITH a status marker so consumers can render the quarantine indicator without a second fetch.
+
+| Site | Pending visible | Notes |
+| --- | --- | --- |
+| Person wiki render | yes | minimal fact card with status='pending'; no regen body |
+| MCP find_person | yes | status field in payload |
+| MCP brief_person | yes | status field in payload, body shows quarantine notice |
+| GET /people | yes default with `?status=verified`, filterable | each row carries status |
+| Hybrid search (user query) | NO | excluded entirely |
+| FRAGMENT_MENTIONS_PERSON edge reads | yes | attrs include person status |
+| Marcel classification target | NO | excluded from candidate-target wikis |
+| Quill regen citation | NO | edges to pending filtered when assembling prompt |
+| `wiki_agent_schema` rows | NO | not written until verified |
+| `embedding-retry-worker` heal | NO | skip pending |
+
+## Approval flow
+
+Approval and rejection are HTTP-only via the admin UI:
+
+- `POST /admin/people/:lookupKey/approve`: flips status to `verified`. Existing FRAGMENT_MENTIONS_PERSON edges become fully involved with no backfill (read sites carry status through, so they self-heal). The wiki_agent_schema heal pass picks up the newly-verified row on its next tick.
+- `POST /admin/people/:lookupKey/reject`: default `status='rejected'`, edges stay attached but invisible. Pass `{ "hardDelete": true }` to cascade delete the row plus its edges.
+
+There are NO MCP approve or reject tools by design. AI agents read the queue via `list_pending_persons` (read-only), and the actual approve or reject call is a deliberate operator action behind admin session auth. The MCP tool `set_auto_accept_persons` is the one operator-state lever that AI agents can flip; it toggles the instance-wide `auto_accept_persons` flag.
+
+## Telemetry
+
+`pipeline_events` rows for the entity-extract substage carry:
+
+- `rawMentionsSeen`: count of mentions the LLM surfaced (matched + candidates).
+- `matchedMentions`: count that landed in `peopleMap` after resolveOrDrop.
+- `createdPersons`: count of rows minted by the helper.
+- `unmatchedDropped`: matched bucket entries the resolver disagreed with.
+- `dropRatePct`: `(rawMentionsSeen - matchedMentions - createdPersons) / rawMentionsSeen`, rounded to integer percent.
+- `autoAccept`: snapshot of `app_settings.auto_accept_persons` at the time of extract.
+
+A spike in `dropRatePct` is the signal that the matcher is too strict for the current corpus.

--- a/packages/agent/src/__tests__/entity-extract.test.ts
+++ b/packages/agent/src/__tests__/entity-extract.test.ts
@@ -146,22 +146,26 @@ describe('resolvePerson', () => {
 describe('entityExtract', () => {
   beforeEach(resetKeyCounter)
 
-  it('matches known people and DROPS unmatched mentions (#237 — matcher-only)', async () => {
-    // Even if the LLM mistakenly returns a matchedKey: null candidate
-    // (i.e. ignores the prompt's instruction to drop unknowns), the
-    // stage must still drop it: no peopleMap entry, no newPeople push.
-    // resolvePerson will report isNew = true because the score floor
-    // is unmet against the lone known person, and the stage now
-    // treats isNew as a "no match" signal rather than a "create new"
-    // signal.
+  it('matched and candidate mentions both surface (Stream P, extractor)', async () => {
+    // Stream P (#PEOPLE-EXTRACT-Q): the extractor surfaces matched and
+    // candidate buckets. Matched mentions land in peopleMap pointing
+    // to the existing row. Candidates with no dedup hit get a new
+    // pending row inserted via the helper. The legacy v2 payload
+    // (`people: [{matchedKey: string|null}]`) is still accepted via
+    // the schema's optional passthrough; it was used by mocks before
+    // the v3 prompt landed.
+    const insertPerson = vi.fn().mockResolvedValue(undefined)
     const mockDeps: EntityExtractDeps = {
       loadAllPeople: vi
         .fn()
         .mockResolvedValue([
           { lookupKey: 'personABC', canonicalName: 'Sarah Ouma', aliases: ['Sarah'] },
         ]),
+      loadPendingPeople: vi.fn().mockResolvedValue([]),
+      loadAutoAcceptPersons: vi.fn().mockResolvedValue(false),
+      insertPerson,
       llmCall: vi.fn().mockResolvedValue({
-        people: [
+        matched: [
           {
             mention: 'Sarah',
             inferredName: 'Sarah Ouma',
@@ -169,11 +173,12 @@ describe('entityExtract', () => {
             confidence: 0.9,
             sourceSpan: 'with Sarah',
           },
+        ],
+        candidates: [
           {
             mention: 'Bob',
             inferredName: 'Bob',
-            matchedKey: null,
-            confidence: 0.8,
+            confidence: 0.7,
             sourceSpan: 'Bob said',
           },
         ],
@@ -189,26 +194,30 @@ describe('entityExtract', () => {
       jobId: 'job001',
     })
 
-    // Only the matched mention survives.
-    expect(result.data.peopleMap.size).toBe(1)
+    // Both mentions land in peopleMap: Sarah maps to the existing
+    // verified row, Bob maps to the freshly minted pending row.
+    expect(result.data.peopleMap.size).toBe(2)
     expect(result.data.peopleMap.get('Sarah')).toBe('personABC')
-    expect(result.data.peopleMap.has('Bob')).toBe(false)
+    expect(result.data.peopleMap.get('Bob')).toMatch(/^person/)
+    expect(insertPerson).toHaveBeenCalledTimes(1)
+    expect(insertPerson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canonicalName: 'Bob',
+        status: 'pending',
+        createdVia: 'extractor_pending',
+      })
+    )
 
-    // Elfie no longer creates Person rows.
-    expect(result.data.newPeople).toHaveLength(0)
-
-    // extractions returned to persist must also be filtered down so
-    // matchMentionsToFragments cannot re-introduce a dropped mention.
-    expect(result.data.extractions).toHaveLength(1)
-    expect(result.data.extractions[0].mention).toBe('Sarah')
-
+    // Both surface in extractions so persist's mention-to-fragment edge
+    // logic can write FRAGMENT_MENTIONS_PERSON for each.
+    expect(result.data.extractions).toHaveLength(2)
     expect(result.durationMs).toBeGreaterThanOrEqual(0)
   })
 
   it('returns empty results when no people found', async () => {
     const mockDeps: EntityExtractDeps = {
       loadAllPeople: vi.fn().mockResolvedValue([]),
-      llmCall: vi.fn().mockResolvedValue({ people: [] }),
+      llmCall: vi.fn().mockResolvedValue({ matched: [], candidates: [] }),
       emitEvent: vi.fn().mockResolvedValue(undefined),
       config: DEFAULT_RESOLUTION_CONFIG,
       makePeopleKey: makeKey,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,6 +7,17 @@ export { wikiClassify } from './stages/wiki-classify.js'
 export { entityExtract, resolvePerson } from './stages/entity-extract.js'
 export { persist, matchMentionsToFragments } from './stages/persist.js'
 export type { ResolveResult } from './stages/entity-extract.js'
+
+// ── People helpers (Stream P) ────────────────────────────────────────────
+export { resolveOrDrop } from './people/resolveOrDrop.js'
+export type {
+  ResolveOutcome,
+  ResolveOrDropContext,
+  ResolveOrDropInput,
+  SourceSpan,
+} from './people/resolveOrDrop.js'
+export { dedupCandidate } from './people/dedup.js'
+export type { DedupCandidate, DedupHit } from './people/dedup.js'
 export type {
   ExtractionOrchestratorDeps,
   LinkingOrchestratorDeps,

--- a/packages/agent/src/people/dedup.ts
+++ b/packages/agent/src/people/dedup.ts
@@ -1,0 +1,65 @@
+import * as fuzz from 'fuzzball'
+
+/**
+ * Stream P helper — fuzzy dedup against existing people regardless of
+ * status. The extractor surfaces every person-like mention as either
+ * a matched (verified KNOWN) or candidate (unknown) entry. Before we
+ * mint a new pending row for a candidate, we check whether the
+ * mention already maps to an existing verified or pending person via
+ * canonical name or alias. This keeps the pending tray free of
+ * duplicates when the same name shows up in multiple fragments.
+ *
+ * Different from `resolvePerson` in entity-extract.ts: that helper
+ * loads only verified persons (via `loadAllPeople`) and is tuned for
+ * the matcher pass. This helper takes both verified and pending
+ * candidates and is the second-chance dedup before a candidate
+ * becomes a new pending row.
+ */
+
+export interface DedupCandidate {
+  lookupKey: string
+  canonicalName: string
+  aliases: string[]
+  status: 'verified' | 'pending'
+}
+
+export interface DedupHit {
+  lookupKey: string
+  status: 'verified' | 'pending'
+  /** Score on the canonical-name match, 0..100 */
+  score: number
+}
+
+const DEFAULT_FLOOR = 90
+
+/**
+ * Try to dedup `mention` against any of `candidates`. Returns the
+ * best match above the floor or `null` when no candidate is close
+ * enough. Floor defaults to 90 (token-set ratio scale) so we only
+ * dedup obvious matches and let the new-pending path mint a row when
+ * the names diverge meaningfully (e.g. "Sarah" vs "Sarah Ouma" still
+ * dedup; "Sarah" vs "Samantha" do not).
+ */
+export function dedupCandidate(
+  mention: string,
+  candidates: DedupCandidate[],
+  options: { floor?: number } = {}
+): DedupHit | null {
+  if (candidates.length === 0) return null
+  const floor = options.floor ?? DEFAULT_FLOOR
+  type Scored = { row: DedupCandidate; score: number }
+  const scored: Scored[] = candidates.map((row) => {
+    const canonicalScore = fuzz.token_set_ratio(mention, row.canonicalName)
+    const aliasScores = row.aliases.map((a) => fuzz.token_set_ratio(mention, a))
+    const score = Math.max(canonicalScore, ...(aliasScores.length > 0 ? aliasScores : [0]))
+    return { row, score }
+  })
+  scored.sort((a, b) => b.score - a.score)
+  const top = scored[0]
+  if (!top || top.score < floor) return null
+  return {
+    lookupKey: top.row.lookupKey,
+    status: top.row.status,
+    score: top.score,
+  }
+}

--- a/packages/agent/src/people/resolveOrDrop.test.ts
+++ b/packages/agent/src/people/resolveOrDrop.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveOrDrop } from './resolveOrDrop.js'
+import type { ResolveOrDropContext } from './resolveOrDrop.js'
+
+let keyCounter = 0
+const makePersonKey = () => `person${String(++keyCounter).padStart(4, '0')}`
+
+function ctx(overrides: Partial<ResolveOrDropContext> = {}): ResolveOrDropContext {
+  keyCounter = 0
+  return {
+    fragmentId: 'frag01',
+    autoAccept: false,
+    verifiedPeople: [],
+    pendingPeople: [],
+    makePersonKey,
+    insertPerson: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('resolveOrDrop', () => {
+  it('matched bucket -> matched outcome', async () => {
+    const c = ctx({
+      verifiedPeople: [
+        { lookupKey: 'personABC', canonicalName: 'Sarah Ouma', aliases: ['Sarah'] },
+      ],
+    })
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [
+          {
+            mention: 'Sarah',
+            inferredName: 'Sarah Ouma',
+            matchedKey: 'personABC',
+            confidence: 0.9,
+            sourceSpan: 'with Sarah',
+          },
+        ],
+        candidates: [],
+      },
+      c
+    )
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]).toMatchObject({ kind: 'matched', lookupKey: 'personABC' })
+    expect(c.insertPerson).not.toHaveBeenCalled()
+  })
+
+  it('candidate with no dedup hit creates pending by default', async () => {
+    const c = ctx()
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [],
+        candidates: [
+          {
+            mention: 'Bob',
+            inferredName: 'Bob',
+            confidence: 0.7,
+            sourceSpan: 'Bob said hello',
+          },
+        ],
+      },
+      c
+    )
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]).toMatchObject({ kind: 'created_pending' })
+    expect(c.insertPerson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'pending',
+        createdVia: 'extractor_pending',
+        canonicalName: 'Bob',
+        extractedFromFragmentId: 'frag01',
+      })
+    )
+  })
+
+  it('candidate with autoAccept=true creates verified', async () => {
+    const c = ctx({ autoAccept: true })
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [],
+        candidates: [
+          {
+            mention: 'Carol',
+            inferredName: 'Carol',
+            confidence: 0.7,
+            sourceSpan: 'Carol waved',
+          },
+        ],
+      },
+      c
+    )
+    expect(outcomes[0]).toMatchObject({ kind: 'created_verified' })
+    expect(c.insertPerson).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'verified', createdVia: 'extractor_auto' })
+    )
+  })
+
+  it('candidate dedups onto existing verified person', async () => {
+    const c = ctx({
+      verifiedPeople: [
+        { lookupKey: 'personXYZ', canonicalName: 'Diana Patel', aliases: [] },
+      ],
+    })
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [],
+        candidates: [
+          {
+            mention: 'Diana Patel',
+            inferredName: 'Diana Patel',
+            confidence: 0.6,
+            sourceSpan: 'with Diana Patel',
+          },
+        ],
+      },
+      c
+    )
+    expect(outcomes[0]).toMatchObject({ kind: 'matched', lookupKey: 'personXYZ' })
+    expect(c.insertPerson).not.toHaveBeenCalled()
+  })
+
+  it('candidate dedups onto existing pending person', async () => {
+    const c = ctx({
+      pendingPeople: [
+        { lookupKey: 'personPND', canonicalName: 'Eric Tan', aliases: [] },
+      ],
+    })
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [],
+        candidates: [
+          {
+            mention: 'Eric Tan',
+            inferredName: 'Eric Tan',
+            confidence: 0.7,
+            sourceSpan: 'Eric Tan replied',
+          },
+        ],
+      },
+      c
+    )
+    expect(outcomes[0]).toMatchObject({ kind: 'pending', lookupKey: 'personPND' })
+    expect(c.insertPerson).not.toHaveBeenCalled()
+  })
+
+  it('two candidates with the same name only mint one pending row', async () => {
+    const c = ctx()
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [],
+        candidates: [
+          {
+            mention: 'Frances',
+            inferredName: 'Frances',
+            confidence: 0.7,
+            sourceSpan: 'Frances stood up',
+          },
+          {
+            mention: 'Frances',
+            inferredName: 'Frances',
+            confidence: 0.7,
+            sourceSpan: 'Frances kept talking',
+          },
+        ],
+      },
+      c
+    )
+    expect(outcomes).toHaveLength(2)
+    expect(outcomes[0].kind).toBe('created_pending')
+    expect(outcomes[1].kind).toBe('pending')
+    expect(c.insertPerson).toHaveBeenCalledTimes(1)
+  })
+
+  it('matched mention that resolver rejects yields dropped outcome', async () => {
+    // The LLM picked a key but the score floor disagreed.
+    const c = ctx({
+      verifiedPeople: [
+        {
+          lookupKey: 'personABC',
+          canonicalName: 'Maximilian Von Reichtenstein',
+          aliases: [],
+        },
+      ],
+    })
+    const outcomes = await resolveOrDrop(
+      {
+        matched: [
+          {
+            mention: 'Bob',
+            inferredName: 'Bob',
+            matchedKey: 'personABC',
+            confidence: 0.9,
+            sourceSpan: 'Bob said hello',
+          },
+        ],
+        candidates: [],
+      },
+      c
+    )
+    expect(outcomes[0]).toMatchObject({ kind: 'dropped' })
+  })
+})

--- a/packages/agent/src/people/resolveOrDrop.ts
+++ b/packages/agent/src/people/resolveOrDrop.ts
@@ -1,0 +1,237 @@
+import type {
+  MatchedMention,
+  CandidateMention,
+} from '@robin/shared'
+import { dedupCandidate, type DedupCandidate } from './dedup.js'
+import { resolvePerson } from '../stages/entity-extract.js'
+import type { KnownPerson, ResolutionConfig } from '../stages/types.js'
+import { DEFAULT_RESOLUTION_CONFIG } from '../stages/types.js'
+
+/**
+ * Stream P (#PEOPLE-EXTRACT-Q) shared resolveOrDrop helper.
+ *
+ * Replaces the divergent person-resolution logic that used to live
+ * in two places: `entity-extract.ts` (worker pipeline) and
+ * `mcp/handlers.ts` (`log_fragment` fast path). Pre-fix, the worker
+ * dropped any unmatched mention, while the MCP path inserted a new
+ * Person row for the same input. Same fragment in two surfaces, two
+ * different graphs. resolveOrDrop is the single place both call so
+ * the outcome is identical regardless of how the fragment arrived.
+ *
+ * Usage flow:
+ *
+ *   1. The extractor (Elfie v3) returns matched + candidates.
+ *   2. Caller invokes resolveOrDrop with both buckets and a few deps.
+ *   3. The helper returns one outcome per mention. The caller writes
+ *      FRAGMENT_MENTIONS_PERSON edges based on outcomes uniformly.
+ *
+ * Outcome kinds:
+ *
+ *   matched           — mention maps to a verified known person.
+ *   pending           — mention dedups onto an existing pending row.
+ *   created_pending   — new row inserted with status='pending' and
+ *                        created_via='extractor_pending'.
+ *   created_verified  — new row inserted with status='verified' (only
+ *                        when `autoAccept = true`); created_via=
+ *                        'extractor_auto'.
+ *   dropped           — matched bucket entry whose matchedKey did not
+ *                        survive the resolver (score floor / ambiguity).
+ */
+
+export interface SourceSpan {
+  text: string
+  start?: number
+  end?: number
+}
+
+export type ResolveOutcome =
+  | {
+      kind: 'matched'
+      lookupKey: string
+      mention: string
+      confidence: number
+      sourceSpan: SourceSpan
+    }
+  | {
+      kind: 'pending'
+      lookupKey: string
+      mention: string
+      confidence: number
+      sourceSpan: SourceSpan
+    }
+  | {
+      kind: 'created_pending'
+      lookupKey: string
+      mention: string
+      sourceSpan: SourceSpan
+    }
+  | {
+      kind: 'created_verified'
+      lookupKey: string
+      mention: string
+      sourceSpan: SourceSpan
+    }
+  | { kind: 'dropped'; mention: string; reason: string }
+
+export interface ResolveOrDropContext {
+  /** Fragment that surfaced these mentions (for traceability). */
+  fragmentId: string | null
+  /** Whether the extractor should auto-verify new persons. */
+  autoAccept: boolean
+  /** Existing verified persons (matcher targets). */
+  verifiedPeople: KnownPerson[]
+  /** Existing pending persons (dedup targets only). */
+  pendingPeople: KnownPerson[]
+  /** Mint a fresh person lookup key. */
+  makePersonKey: () => string
+  /**
+   * Insert a new Person row. The implementation lives in core (it
+   * needs Drizzle), but the helper passes the structured payload so
+   * the row carries the right `status`, `created_via`, and provenance
+   * fields uniformly across surfaces.
+   */
+  insertPerson: (input: {
+    lookupKey: string
+    canonicalName: string
+    status: 'verified' | 'pending'
+    createdVia: 'extractor_pending' | 'extractor_auto'
+    extractedFromFragmentId: string | null
+  }) => Promise<void>
+  /** Optional override for the matcher's resolution thresholds. */
+  resolutionConfig?: ResolutionConfig
+}
+
+export interface ResolveOrDropInput {
+  matched: MatchedMention[]
+  candidates: CandidateMention[]
+}
+
+function toSpan(text: string): SourceSpan {
+  return { text }
+}
+
+function toDedupCandidates(
+  verifiedPeople: KnownPerson[],
+  pendingPeople: KnownPerson[]
+): DedupCandidate[] {
+  return [
+    ...verifiedPeople.map((p) => ({
+      lookupKey: p.lookupKey,
+      canonicalName: p.canonicalName,
+      aliases: p.aliases,
+      status: 'verified' as const,
+    })),
+    ...pendingPeople.map((p) => ({
+      lookupKey: p.lookupKey,
+      canonicalName: p.canonicalName,
+      aliases: p.aliases,
+      status: 'pending' as const,
+    })),
+  ]
+}
+
+export async function resolveOrDrop(
+  input: ResolveOrDropInput,
+  context: ResolveOrDropContext
+): Promise<ResolveOutcome[]> {
+  const outcomes: ResolveOutcome[] = []
+  const config = context.resolutionConfig ?? DEFAULT_RESOLUTION_CONFIG
+  const dedupPool = toDedupCandidates(context.verifiedPeople, context.pendingPeople)
+  // Track in-batch creations so two candidates that name the same
+  // person inside one fragment do not mint two pending rows.
+  const inBatchCreated: DedupCandidate[] = []
+
+  // ── Matched bucket ──────────────────────────────────────────────────
+  for (const mention of input.matched) {
+    const resolved = resolvePerson(
+      {
+        mention: mention.mention,
+        inferredName: mention.inferredName,
+        matchedKey: mention.matchedKey,
+      },
+      context.verifiedPeople,
+      config,
+      context.makePersonKey
+    )
+    if (resolved.isNew) {
+      // Resolver disagrees with the LLM (score floor / ambiguity).
+      // Drop rather than mint a row from a noisy match signal.
+      outcomes.push({
+        kind: 'dropped',
+        mention: mention.mention,
+        reason: 'matcher disagreed with LLM matchedKey',
+      })
+      continue
+    }
+    outcomes.push({
+      kind: 'matched',
+      lookupKey: resolved.personKey,
+      mention: mention.mention,
+      confidence: mention.confidence,
+      sourceSpan: toSpan(mention.sourceSpan),
+    })
+  }
+
+  // ── Candidate bucket ────────────────────────────────────────────────
+  for (const mention of input.candidates) {
+    const pool = [...dedupPool, ...inBatchCreated]
+    const hit = dedupCandidate(mention.inferredName || mention.mention, pool)
+    if (hit) {
+      outcomes.push({
+        kind: hit.status === 'verified' ? 'matched' : 'pending',
+        lookupKey: hit.lookupKey,
+        mention: mention.mention,
+        confidence: mention.confidence,
+        sourceSpan: toSpan(mention.sourceSpan),
+      })
+      continue
+    }
+
+    // No hit — mint a new row.
+    const lookupKey = context.makePersonKey()
+    const canonicalName = mention.inferredName || mention.mention
+    if (context.autoAccept) {
+      await context.insertPerson({
+        lookupKey,
+        canonicalName,
+        status: 'verified',
+        createdVia: 'extractor_auto',
+        extractedFromFragmentId: context.fragmentId,
+      })
+      outcomes.push({
+        kind: 'created_verified',
+        lookupKey,
+        mention: mention.mention,
+        sourceSpan: toSpan(mention.sourceSpan),
+      })
+      inBatchCreated.push({
+        lookupKey,
+        canonicalName,
+        aliases: [],
+        status: 'verified',
+      })
+    } else {
+      await context.insertPerson({
+        lookupKey,
+        canonicalName,
+        status: 'pending',
+        createdVia: 'extractor_pending',
+        extractedFromFragmentId: context.fragmentId,
+      })
+      outcomes.push({
+        kind: 'created_pending',
+        lookupKey,
+        mention: mention.mention,
+        sourceSpan: toSpan(mention.sourceSpan),
+      })
+      inBatchCreated.push({
+        lookupKey,
+        canonicalName,
+        aliases: [],
+        status: 'pending',
+      })
+    }
+  }
+
+  return outcomes
+}

--- a/packages/agent/src/stages/entity-extract.ts
+++ b/packages/agent/src/stages/entity-extract.ts
@@ -1,5 +1,6 @@
 import * as fuzz from 'fuzzball'
-import { loadPeopleExtractionSpec } from '@robin/shared'
+import { loadPeopleExtractionSpec, normalisePeopleExtraction } from '@robin/shared'
+import { resolveOrDrop } from '../people/resolveOrDrop.js'
 import type {
   EntityExtractDeps,
   EntityExtractResult,
@@ -136,14 +137,16 @@ export async function entityExtract(
     metadata: { substage: 'entity-extract' },
   })
 
-  // 1. Load known people
-  const knownPeople = await deps.loadAllPeople()
+  // 1. Load known people (verified + optionally pending for dedup)
+  const verifiedPeople = await deps.loadAllPeople()
+  const pendingPeople = deps.loadPendingPeople ? await deps.loadPendingPeople() : []
 
-  // 2. Build known people JSON for prompt
+  // 2. Build known people JSON for prompt (verified only — pending
+  //    persons are not graph-visible to the LLM yet).
   const knownPeopleJson =
-    knownPeople.length > 0
+    verifiedPeople.length > 0
       ? JSON.stringify(
-          knownPeople.map((p) => ({
+          verifiedPeople.map((p) => ({
             key: p.lookupKey,
             canonicalName: p.canonicalName,
             aliases: p.aliases,
@@ -157,41 +160,104 @@ export async function entityExtract(
     knownPeople: knownPeopleJson,
   })
 
-  // 4. Call LLM (returns Zod-validated output)
+  // 4. Call LLM (returns Zod-validated output, accepts both v3 buckets
+  //    and the legacy v2 flat array).
   const parsed = await deps.llmCall(spec.system, spec.user)
+  const buckets = normalisePeopleExtraction(parsed)
+  const rawMentionsSeen = buckets.matched.length + buckets.candidates.length
 
-  // 6. Resolve each extraction. #237: Elfie is matcher-only — unmatched
-  // mentions are DROPPED instead of becoming new Person rows. The
-  // resolvePerson() helper is still the score-based matcher; when it
-  // reports `isNew: true` we treat that as a "no match" signal and
-  // skip the mention entirely. Authorship for first-person pronouns is
-  // handled downstream by the classifier's [AUTHORSHIP] block (#238),
-  // not here.
+  // 5. Resolve every mention through the shared helper. Worker pipeline
+  //    and MCP `log_fragment` both call this — same input, same outcome.
+  const autoAccept = deps.loadAutoAcceptPersons
+    ? await deps.loadAutoAcceptPersons()
+    : false
+
+  // Backward-compat path: if no insertPerson dep was wired, the legacy
+  // pipeline still routes new persons through `persist.ts` via the
+  // `newPeople[]` array. We mark them as pending in that case so the
+  // upsertPerson code path can apply the right status.
+  const newPeople: EntityExtractResult['newPeople'] = []
   const peopleMap = new Map<string, string>()
   const newAliases = new Map<string, string[]>()
-  const newPeople: EntityExtractResult['newPeople'] = []
+  const matchedExtractions: Array<{ mention: string; sourceSpan: string }> = []
   let unmatchedDropped = 0
+  let createdPersons = 0
 
-  for (const extraction of parsed.people) {
-    const resolved = resolvePerson(extraction, knownPeople, deps.config, deps.makePeopleKey)
+  const insertPerson =
+    deps.insertPerson ??
+    (async (input) => {
+      // Legacy persist-driven path: the helper ran (and assigned a
+      // lookupKey) but we route the row through `newPeople[]` so the
+      // existing persist stage's `upsertPerson` can de-dup against
+      // canonical_name (case-insensitive).
+      newPeople.push({
+        personKey: input.lookupKey,
+        canonicalName: input.canonicalName,
+        verified: input.status === 'verified',
+        status: input.status,
+      })
+    })
 
-    if (resolved.isNew) {
-      // No matching Person row — drop this mention. Do NOT add it to
-      // peopleMap (which would seed a FRAGMENT_MENTIONS_PERSON edge to
-      // a non-existent person) and do NOT push it onto newPeople
-      // (which would have persist.ts upsert a Person on its behalf).
+  const outcomes = await resolveOrDrop(
+    {
+      matched: buckets.matched,
+      candidates: buckets.candidates,
+    },
+    {
+      // Worker pipeline does not have a fragment id yet at extract
+      // time (fragments persist later in the same run). Pass null and
+      // let the persist stage backfill the linkage via FRAGMENT_MENTIONS_PERSON.
+      fragmentId: null,
+      autoAccept,
+      verifiedPeople,
+      pendingPeople,
+      makePersonKey: deps.makePeopleKey,
+      insertPerson,
+      resolutionConfig: deps.config,
+    }
+  )
+
+  for (const outcome of outcomes) {
+    if (outcome.kind === 'dropped') {
       unmatchedDropped++
       continue
     }
+    if (outcome.kind === 'created_pending' || outcome.kind === 'created_verified') {
+      createdPersons++
+    }
+    peopleMap.set(outcome.mention, outcome.lookupKey)
+    matchedExtractions.push({
+      mention: outcome.mention,
+      sourceSpan: outcome.sourceSpan.text,
+    })
+  }
 
-    peopleMap.set(extraction.mention, resolved.personKey)
-
-    if (resolved.newAlias) {
-      const existing = newAliases.get(resolved.personKey) ?? []
-      existing.push(resolved.newAlias)
-      newAliases.set(resolved.personKey, existing)
+  // Alias merging: matched + pending + verified outcomes whose mention
+  // surface form differs from the canonical name should be appended as
+  // aliases on the existing row. This preserves the v2 newAliases
+  // behaviour for downstream merging in the persist stage.
+  for (const outcome of outcomes) {
+    if (outcome.kind !== 'matched' && outcome.kind !== 'pending') continue
+    const known = [...verifiedPeople, ...pendingPeople].find(
+      (p) => p.lookupKey === outcome.lookupKey
+    )
+    if (!known) continue
+    const lower = outcome.mention.toLowerCase()
+    const isCanonical = known.canonicalName.toLowerCase() === lower
+    const isKnownAlias = known.aliases.some((a) => a.toLowerCase() === lower)
+    if (isCanonical || isKnownAlias) continue
+    const list = newAliases.get(outcome.lookupKey) ?? []
+    if (!list.some((a) => a.toLowerCase() === lower)) {
+      list.push(outcome.mention)
+      newAliases.set(outcome.lookupKey, list)
     }
   }
+
+  const denominator = rawMentionsSeen
+  const dropRatePct =
+    denominator > 0
+      ? Math.round(((denominator - peopleMap.size - createdPersons) / denominator) * 100)
+      : 0
 
   await deps.emitEvent({
     entryKey: input.entryKey,
@@ -200,9 +266,16 @@ export async function entityExtract(
     status: 'completed',
     metadata: {
       substage: 'entity-extract',
-      totalMentions: parsed.people.length,
+      // Stream P telemetry. `rawMentionsSeen` is what the LLM surfaced
+      // (matched + candidates). `dropRatePct` is the share of those
+      // mentions that did not become a graph edge (resolver
+      // disagreement only — created pending/verified count as kept).
+      rawMentionsSeen,
       matchedMentions: peopleMap.size,
+      createdPersons,
       unmatchedDropped,
+      dropRatePct,
+      autoAccept,
       newPeople: newPeople.length,
     },
   })
@@ -211,10 +284,7 @@ export async function entityExtract(
     data: {
       peopleMap,
       newAliases,
-      // Filter extractions down to those that matched so persist's
-      // mention-to-fragment edge logic can't re-introduce a dropped
-      // mention. Unmatched mentions never reach persist.
-      extractions: parsed.people.filter((e) => peopleMap.has(e.mention)),
+      extractions: matchedExtractions,
       newPeople,
     },
     durationMs: Date.now() - start,

--- a/packages/agent/src/stages/types.ts
+++ b/packages/agent/src/stages/types.ts
@@ -175,6 +175,30 @@ export interface KnownPerson {
 
 export interface EntityExtractDeps {
   loadAllPeople: () => Promise<KnownPerson[]>
+  /**
+   * Stream P (#PEOPLE-EXTRACT-Q). Pending persons participate in
+   * extract-time dedup so we do not mint duplicate rows for the same
+   * unknown name across fragments. Optional for backward compat: if
+   * undefined the resolver behaves as before (verified-only matcher
+   * with no quarantine).
+   */
+  loadPendingPeople?: () => Promise<KnownPerson[]>
+  /**
+   * Stream P. Insert a new person row directly from the extractor
+   * path. The implementation lives in core (it owns the schema and
+   * audit-log). Optional for callers that want the legacy behaviour
+   * where new people land in `newPeople[]` and the `persist` stage
+   * does the upsert.
+   */
+  insertPerson?: (input: {
+    lookupKey: string
+    canonicalName: string
+    status: 'verified' | 'pending'
+    createdVia: 'extractor_pending' | 'extractor_auto'
+    extractedFromFragmentId: string | null
+  }) => Promise<void>
+  /** Stream P. Read `app_settings.auto_accept_persons` once per run. */
+  loadAutoAcceptPersons?: () => Promise<boolean>
   llmCall: (system: string, user: string) => Promise<PeopleExtractionOutput>
   emitEvent: EmitEvent
   config: ResolutionConfig
@@ -184,6 +208,12 @@ export interface EntityExtractDeps {
 export interface EntityExtractResult {
   peopleMap: Map<string, string>
   newAliases: Map<string, string[]>
-  extractions: PeopleExtractionOutput['people']
-  newPeople: Array<{ personKey: string; canonicalName: string; verified: boolean }>
+  extractions: Array<{ mention: string; sourceSpan: string }>
+  newPeople: Array<{
+    personKey: string
+    canonicalName: string
+    verified: boolean
+    /** Stream P quarantine status, surfaced for telemetry only. */
+    status?: 'verified' | 'pending'
+  }>
 }

--- a/packages/shared/src/prompts/index.ts
+++ b/packages/shared/src/prompts/index.ts
@@ -22,8 +22,16 @@ export * from './models.js'
 // Schemas
 export { fragmentationSchema } from './specs/fragmentation.schema.js'
 export type { FragmentationOutput } from './specs/fragmentation.schema.js'
-export { peopleExtractionSchema } from './specs/people-extraction.schema.js'
-export type { PeopleExtractionOutput } from './specs/people-extraction.schema.js'
+export {
+  peopleExtractionSchema,
+  normalisePeopleExtraction,
+} from './specs/people-extraction.schema.js'
+export type {
+  PeopleExtractionOutput,
+  MatchedMention,
+  CandidateMention,
+  LegacyMention,
+} from './specs/people-extraction.schema.js'
 export { wikiClassificationSchema } from './specs/wiki-classification.schema.js'
 export type { WikiClassificationOutput } from './specs/wiki-classification.schema.js'
 export { wikiRelevanceSchema } from './specs/wiki-relevance.schema.js'

--- a/packages/shared/src/prompts/specs/people-extraction.schema.ts
+++ b/packages/shared/src/prompts/specs/people-extraction.schema.ts
@@ -63,8 +63,11 @@ export type LegacyMention = z.infer<typeof legacyMentionSchema>
 export function normalisePeopleExtraction(
   parsed: PeopleExtractionOutput
 ): { matched: MatchedMention[]; candidates: CandidateMention[] } {
-  const matched: MatchedMention[] = [...parsed.matched]
-  const candidates: CandidateMention[] = [...parsed.candidates]
+  // Defensive copies that tolerate mocked LLM payloads which only
+  // hand us the legacy `people` field. Real Zod-parsed payloads
+  // always carry `matched` and `candidates` arrays.
+  const matched: MatchedMention[] = parsed.matched ? [...parsed.matched] : []
+  const candidates: CandidateMention[] = parsed.candidates ? [...parsed.candidates] : []
   if (parsed.people && parsed.people.length > 0) {
     for (const p of parsed.people) {
       if (p.matchedKey !== null) {

--- a/packages/shared/src/prompts/specs/people-extraction.schema.ts
+++ b/packages/shared/src/prompts/specs/people-extraction.schema.ts
@@ -1,15 +1,89 @@
 import { z } from 'zod'
 
+/**
+ * v3 (Stream P, 2026-05-09): Elfie surfaces every person-like mention,
+ * split into two buckets. Matched entries point to a verified KNOWN
+ * PEOPLE row by key. Candidate entries are person-like mentions that
+ * had no match; the worker handles dedup against pending persons and
+ * creation downstream.
+ *
+ * The legacy `people` flat array (v2 shape with matchedKey: string|null)
+ * is preserved as an OPTIONAL passthrough for any caller still on the
+ * old contract (notably the entity-extract test fixtures). Consumers
+ * should read from `matched` and `candidates`; the synthetic `people`
+ * passthrough is filled in by code on top of the schema, not the
+ * schema itself, to keep input and output types matching.
+ */
+const matchedMentionSchema = z.object({
+  mention: z.string(),
+  inferredName: z.string(),
+  matchedKey: z.string(),
+  confidence: z.number(),
+  sourceSpan: z.string(),
+})
+
+const candidateMentionSchema = z.object({
+  mention: z.string(),
+  inferredName: z.string(),
+  confidence: z.number(),
+  sourceSpan: z.string(),
+})
+
+const legacyMentionSchema = z.object({
+  mention: z.string(),
+  inferredName: z.string(),
+  matchedKey: z.string().nullable(),
+  confidence: z.number(),
+  sourceSpan: z.string(),
+})
+
+// Both buckets are required at the schema level so consumer code can
+// rely on `parsed.matched` / `parsed.candidates` always being arrays.
+// The LLM is told to return both buckets in every payload (see the
+// people-extraction.yaml template). For legacy v2 fixtures that hand
+// us a flat `people` array we keep an optional passthrough; consumers
+// normalise via `normalisePeopleExtraction`.
 export const peopleExtractionSchema = z.object({
-  people: z.array(
-    z.object({
-      mention: z.string(),
-      inferredName: z.string(),
-      matchedKey: z.string().nullable(),
-      confidence: z.number(),
-      sourceSpan: z.string(),
-    })
-  ),
+  matched: z.array(matchedMentionSchema),
+  candidates: z.array(candidateMentionSchema),
+  people: z.array(legacyMentionSchema).optional(),
 })
 
 export type PeopleExtractionOutput = z.infer<typeof peopleExtractionSchema>
+export type MatchedMention = z.infer<typeof matchedMentionSchema>
+export type CandidateMention = z.infer<typeof candidateMentionSchema>
+export type LegacyMention = z.infer<typeof legacyMentionSchema>
+
+/**
+ * Normalise a parsed PeopleExtractionOutput into the canonical bucket
+ * shape. Reads the new `matched`/`candidates` buckets when present and
+ * also splits any legacy `people` entries by `matchedKey` nullability.
+ * Use this from any consumer that needs the canonical buckets.
+ */
+export function normalisePeopleExtraction(
+  parsed: PeopleExtractionOutput
+): { matched: MatchedMention[]; candidates: CandidateMention[] } {
+  const matched: MatchedMention[] = [...parsed.matched]
+  const candidates: CandidateMention[] = [...parsed.candidates]
+  if (parsed.people && parsed.people.length > 0) {
+    for (const p of parsed.people) {
+      if (p.matchedKey !== null) {
+        matched.push({
+          mention: p.mention,
+          inferredName: p.inferredName,
+          matchedKey: p.matchedKey,
+          confidence: p.confidence,
+          sourceSpan: p.sourceSpan,
+        })
+      } else {
+        candidates.push({
+          mention: p.mention,
+          inferredName: p.inferredName,
+          confidence: p.confidence,
+          sourceSpan: p.sourceSpan,
+        })
+      }
+    }
+  }
+  return { matched, candidates }
+}

--- a/packages/shared/src/prompts/specs/people-extraction.yaml
+++ b/packages/shared/src/prompts/specs/people-extraction.yaml
@@ -1,77 +1,93 @@
-name: ElfieTheMatcher
-version: 2
+name: ElfieTheExtractor
+version: 3
 category: extraction
 system_only: true
 task: people_extraction
-description: Matches person mentions in text to existing Person records (matcher-only — never proposes new people).
+description: Surfaces every person-like mention in a passage and splits them into matched (verified known person) and candidate (unknown) buckets. Downstream code handles dedup and creation.
 temperature: 0.0
 
 system_message: |
-  You are Elfie, a precise entity matcher. Your job is to find which of
-  the KNOWN PEOPLE are mentioned in a passage of text. You are
-  matcher-only: you NEVER propose new people. If a mention does not
-  correspond to an entry in KNOWN PEOPLE, you skip it. People records
-  are created elsewhere (manually by the user, or via dedicated
-  workflows) — your job is solely to match.
+  You are Elfie, a careful entity surfacer. Your job is to find every
+  person-like mention in a passage of text and report each one in one
+  of two buckets:
+
+    - matched: the mention maps to an entry in KNOWN PEOPLE.
+    - candidates: the mention does not map to anyone in KNOWN PEOPLE,
+      so the system needs to decide whether to create a new Person.
+
+  You do NOT decide whether to create. You do NOT silently drop
+  unmatched mentions. The pipeline downstream of you handles dedup
+  against pending persons and creation. Your job is to surface
+  every name-like span you see.
 
 template: |
   [MOCK ACKNOWLEDGMENT]
-  Understood. I am Elfie, the matcher. I only return people that
-  correspond to an entry in KNOWN PEOPLE. If a name or role in the
-  text has no match in KNOWN PEOPLE, I drop it silently. I never
-  invent new people, never propose creates, never set matchedKey to
-  null. When KNOWN PEOPLE is empty, I return an empty list.
+  Understood. I am Elfie, the surfacer. I return TWO buckets in one
+  payload: matched and candidates. Matched mentions point to a
+  KNOWN PEOPLE entry by key. Candidates are person-like mentions
+  with no entry in KNOWN PEOPLE. I never invent a key for a
+  candidate, and I never silently drop a mention. The system handles
+  what to do with each bucket downstream.
 
   [TASK]
-  Match the following text against the KNOWN PEOPLE list. Return only
-  the people that genuinely appear in BOTH.
+  Read the text below and return every person-like mention. Sort
+  each mention into exactly one of two buckets:
+
+    1. matched: this mention maps to a row in KNOWN PEOPLE
+       (by name, alias, or unambiguous role reference).
+    2. candidates: this mention is person-like but does NOT map to
+       any row in KNOWN PEOPLE. Do not invent a key.
 
   {{#if knownPeople}}
-  [KNOWN PEOPLE — the only valid match targets]
+  [KNOWN PEOPLE, the only valid match targets for the matched bucket]
   {{knownPeople}}
   {{else}}
   [KNOWN PEOPLE]
-  (empty — no matches are possible. Return an empty people list.)
+  (empty, every person-like mention belongs in candidates.)
   {{/if}}
 
-  [RULES — READ CAREFULLY]
-  1. MATCHER-ONLY. For every person you return, matchedKey MUST point
-     to an entry in KNOWN PEOPLE. Never set matchedKey to null.
-  2. If a mention in the text has NO entry in KNOWN PEOPLE — by name,
-     alias, role, or any other signal — DROP it silently. Do NOT
-     return it with matchedKey: null. Do NOT invent a key.
-  3. If KNOWN PEOPLE is empty, return an empty people list. There are
-     no possible matches.
-  4. Match by name, alias, or unambiguous role reference ("my manager"
+  [RULES]
+  1. Surface EVERY person-like mention. Do not silently drop names
+     just because they are unfamiliar. Unknown names go in candidates.
+  2. For matched entries, matchedKey MUST point to an entry in KNOWN
+     PEOPLE. Match by name, alias, or unambiguous role.
+  3. For candidate entries, do NOT set matchedKey. Provide mention,
+     inferredName (best guess at canonical form), confidence, and
+     sourceSpan.
+  4. Match by name, alias, or unambiguous role reference. "My manager"
      only matches a known person if the surrounding text or known
-     aliases make the link unambiguous).
+     aliases make the link unambiguous; otherwise leave it out
+     entirely.
   5. Preserve the exact surface form used in the text as the mention.
-  6. Do not merge two people unless the text explicitly states they are
-     the same person.
-  7. Do not match organizations, teams, or groups — only individuals.
-  8. Generic references ("someone", "people", "they" without antecedent)
-     never match.
+  6. Do not merge two people unless the text explicitly states they
+     are the same person.
+  7. Do NOT match organizations, teams, or groups, only individuals.
+  8. Generic references ("someone", "people", "they" without
+     antecedent) are NOT person-like and should be skipped.
+  9. Authorship for first-person pronouns is handled downstream by
+     the classifier's [AUTHORSHIP] block, leave I/me/my alone.
 
   [REINFORCEMENT]
-  Remember: you are Elfie the matcher, not an extractor. A spurious
-  match (returning someone the text doesn't refer to) corrupts the
-  graph. A dropped unmatched mention is the correct outcome — Person
-  creation is NOT your job. The right answer is always grounded in
-  BOTH the text and KNOWN PEOPLE. You are excellent at this.
+  Remember: you are Elfie the surfacer. Spurious matches corrupt the
+  graph. Silent drops corrupt the graph just as much. The right
+  answer is always grounded in the text: every name-like span
+  surfaces in one of the two buckets.
 
   [COMMON MISTAKES TO AVOID]
-  - Returning matchedKey: null for an unknown mention. Drop it instead.
-  - Treating company names as people ("Google said" — Google is not a person)
-  - Matching two different people with similar names without evidence
-  - Matching a role-only mention ("the CTO") to a known person without
-    explicit text-side evidence linking them
-  - Matching the author/owner via first-person pronouns. Authorship is
-    handled downstream — leave I/me/my alone here.
+  - Silently dropping an unfamiliar name. It belongs in candidates.
+  - Setting matchedKey on a candidate. Candidates have no key.
+  - Treating company names as people ("Google said", Google is not).
+  - Matching two different people with similar names without
+    evidence in the text.
+  - Matching a role-only mention ("the CTO") to a known person
+    without explicit text-side evidence linking them.
+  - Returning the author/owner via first-person pronouns; that is
+    handled downstream.
 
-  [TEXT TO MATCH AGAINST KNOWN PEOPLE]
+  [TEXT TO PROCESS]
   {{content}}
 
-  Return only people whose matchedKey is a valid KNOWN PEOPLE key.
+  Return both buckets in your structured output.
 
 input_variables:
   - name: content
@@ -80,7 +96,7 @@ input_variables:
   - name: knownPeople
     description: >
       JSON array of known people with key, canonicalName, and aliases
-      for matching.
+      for matching. Empty when no people exist yet.
     required: false
 
 output:
@@ -91,15 +107,30 @@ few_shot_examples:
       content: "Had coffee with Sarah. My manager wants us to ship by Friday."
       knownPeople: '[{"key": "person01A", "canonicalName": "Sarah Ouma", "aliases": ["Sarah"]}]'
     output: >
-      {"people": [{"mention": "Sarah", "inferredName": "Sarah Ouma", "matchedKey": "person01A",
-      "confidence": 0.9, "sourceSpan": "Had coffee with Sarah"}]}
-  - input: >
-      content: "Had coffee with Sarah."
-      knownPeople: '[]'
-    output: >
-      {"people": []}
+      {"matched": [{"mention": "Sarah", "inferredName": "Sarah Ouma",
+      "matchedKey": "person01A", "confidence": 0.9,
+      "sourceSpan": "Had coffee with Sarah"}], "candidates": []}
   - input: >
       content: "Bob said hello and Carol waved."
       knownPeople: '[{"key": "person01A", "canonicalName": "Sarah Ouma", "aliases": ["Sarah"]}]'
     output: >
-      {"people": []}
+      {"matched": [], "candidates": [
+        {"mention": "Bob", "inferredName": "Bob",
+         "confidence": 0.7, "sourceSpan": "Bob said hello"},
+        {"mention": "Carol", "inferredName": "Carol",
+         "confidence": 0.7, "sourceSpan": "Carol waved"}
+      ]}
+  - input: >
+      content: "Met with Sarah and Bob today."
+      knownPeople: '[{"key": "person01A", "canonicalName": "Sarah Ouma", "aliases": ["Sarah"]}]'
+    output: >
+      {"matched": [{"mention": "Sarah", "inferredName": "Sarah Ouma",
+      "matchedKey": "person01A", "confidence": 0.9,
+      "sourceSpan": "Met with Sarah and Bob today"}],
+      "candidates": [{"mention": "Bob", "inferredName": "Bob",
+      "confidence": 0.7, "sourceSpan": "Met with Sarah and Bob today"}]}
+  - input: >
+      content: "Just shipped the v2 release."
+      knownPeople: '[]'
+    output: >
+      {"matched": [], "candidates": []}


### PR DESCRIPTION
## Summary
- BREAKING: `people-extraction.yaml` flips from matcher-only to extractor; new persons created automatically with `status='pending'` (quarantine) by default
- Migration 0017 adds `people.status`, `created_via`, `extracted_from_fragment_id`, `context_notes` columns; seeds `app_settings.auto_accept_persons=false`
- Five new MCP tools: `create_person` (auto-verified), `update_person` (with explicit promote-from-quarantine flag), `add_relationship`, `list_pending_persons`, `set_auto_accept_persons`
- Two new HTTP endpoints: `POST /admin/people/:key/approve` and `POST /admin/people/:key/reject` (UI-only; no MCP approve/reject by design)
- Quarantine propagates: pending persons are excluded from hybrid search, Marcel auto-classification, Quill regen citations, and agent_schema rows; visible (with status field) in find_person, brief_person, GET /people, and FRAGMENT_MENTIONS_PERSON edge reads
- Shared `resolveOrDrop` helper unifies worker pipeline and MCP `log_fragment` paths; new `rawMentionsSeen` telemetry surfaces the real LLM drop rate
- Contract test pins the read-site exclusion matrix

Closes QA Issues 1, 2, 3 from notes 2026-05-08.

## What changed for the user
Robin now finds new people through ingest. Before: 534 fragments produced 0 new persons because the LLM was matcher-only. After: every name-like span surfaces as a candidate, and unknown names create a `status='pending'` row that operators triage via the `/settings/people` panel (Stream U). Auto-accept toggle in app_settings lets operators bypass quarantine when they trust the extractor. AI agents intentionally creating persons through MCP `create_person` skip quarantine entirely (those are explicit, operator-driven). `update_person` lets agents append context (aliases, notes, relationships) and optionally promote from quarantine in the same call. Pending persons render with a status field everywhere that surfaces them, so consumers can show a quarantine indicator. They do NOT participate in regen, classification, search ranking, or wiki-body generation until promoted.

## What was true before
The matcher-only contract plus zero seeded users meant the LLM never returned a candidate; the resolver never saw a mention; persist never created a Person row. The MCP `log_fragment` path inserted unmatched persons (inconsistent with the worker), and the worker silently dropped them. There was no `create_person` tool, no UI for adding people, and no telemetry on the silent-drop volume.

## Operational notes
- Migration: 0017 (additive). Existing rows default to `status='verified'`, so no behavior change for verified-only deployments.
- Five MCP tool registrations added. Approve and reject are HTTP-only by design; MCP is for agent-driven flows, approval is operator-deliberate.
- `auto_accept_persons` defaults to false. Operators toggle via `set_auto_accept_persons` MCP tool or via the `/settings/people` UI panel (Stream U).
- Quarantine is a graph constraint, not just a flag. The `quarantine-contract.test.ts` contract test pins the exclusion matrix.

## Test plan
- [ ] UAT plan: `.uat/plans/72-people-extractor-and-quarantine.md`
- [ ] Migration applies cleanly + idempotently
- [ ] `pnpm -C core typecheck` and `pnpm -C packages/agent typecheck` clean
- [ ] 32 new tests pass across MCP handlers, HTTP routes, and quarantine contract
- [ ] All 5 MCP tools registered and reachable
- [ ] Approve and reject are HTTP-only (no MCP equivalents exist)
- [ ] Hybrid search excludes pending persons entirely
- [ ] find_person returns pending with status field in payload
- [ ] regen prompt assembly filters FRAGMENT_MENTIONS_PERSON edges to pending
- [ ] agent_schema worker skips pending persons