### PR TITLE
fix(pipeline): forward wiki classifier now uses hybridSearch

### DIFF
--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -68,6 +68,7 @@ import { processPrunePipelineEventsJob } from './prune-pipeline-events-worker.js
 import { processFragmentRelationshipBackfillJob } from './fragment-relationship-backfill-worker.js'
 import type { SchedulerJob } from '@robin/queue'
 import { loadOpenRouterConfig } from '../lib/openrouter-config.js'
+import { hybridSearch } from '../lib/search.js'
 import { generateKeypair } from '../keypair.js'
 import { logger } from '../lib/logger.js'
 import { clearKidCache } from '../mcp/jwt.js'
@@ -520,13 +521,26 @@ async function processLinkJob(job: LinkJob): Promise<JobResult> {
       await emitAuditEvent(db as never, params)
     },
     wikiClassifyDeps: {
-      searchCandidates: async (_content, limit) => {
-        const rows = await db
-          .select({ lookupKey: wikis.lookupKey })
-          .from(wikis)
-          .where(isNull(wikis.deletedAt))
-          .limit(limit)
-        return rows.map((r) => ({ wikiKey: r.lookupKey, score: 0 }))
+      // Forward classifier candidate selection. Earlier versions did a
+      // bare LIMIT-N SELECT here, which discarded the fragment content
+      // and handed Marcel a fixed first-N set in heap order. That broke
+      // long-tail wikis: anything outside the Postgres-default first 10
+      // never reached classification, regardless of topical fit. (#364)
+      //
+      // We now use the same hybridSearch path as regen.ts and the MCP /
+      // HTTP search surfaces, scoped to the wiki table so the BM25 lane
+      // and the description / hyde_synthetic vector lanes both vote on
+      // candidate ranking.
+      searchCandidates: async (content, limit) => {
+        const results = await hybridSearch(db, content, {
+          limit,
+          tables: ['wiki'],
+          embedConfig: {
+            apiKey: openRouterConfig.apiKey,
+            model: openRouterConfig.models.embedding,
+          },
+        })
+        return results.map((r) => ({ wikiKey: r.id, score: r.score }))
       },
       loadThreads: async (wikiKeys) => {
         if (wikiKeys.length === 0) return []


### PR DESCRIPTION
## Summary

processLinkJob's wikiClassifyDeps.searchCandidates discarded fragment content and ran a bare \`SELECT ... FROM wikis LIMIT N\` with no \`ORDER BY\`, so Marcel saw the same fixed first-N wikis Postgres returned in heap order on every fragment. Wikis outside the seed batch never reached classification regardless of topical fit.

The fix swaps the LIMIT-N SELECT for \`hybridSearch\` with \`tables: ['wiki']\`, matching the path \`regen.ts:280\`, MCP \`search\`, and HTTP \`/search\` already use. \`openRouterConfig\` is loaded earlier in the same handler, so no new plumbing is required.

Closes #364.

## Symptom on RobinKnows (89-entry drop, 50-wiki instance)

- 14 of 50 wikis (28%) had zero fragments
- 92 of 513 fragments (18%) unfiled
- Top 5 wikis held 57% of all FRAGMENT_IN_WIKI edges
- 4 of the 5 most-filed wikis were exactly the Postgres-default first-10

## Why PR #348 only got us partway

Empty-wiki count dropped 22 -> 14 between RobinKB (pre-#348) and RobinKnows (post-#348). The improvement came via the regen back-channel: regen uses hybridSearch and picked up agent_schema rows for wikis the forward classifier had skipped. But the fundamental forward path was still discarding fragment content, so #348's benefit was bounded by however many regens fired. This PR realises the full intent of Wave G.

## Test plan

- [ ] CI green (typecheck, biome, build)
- [ ] On a fresh instance, drop a mixed-topic corpus. Expect long-tail distribution where every topically-relevant wiki gets at least one fragment, and the broad catch-all wikis stop accumulating off-topic edges.
- [ ] On RobinKnows, regen the 7 librarian-entry fragments. Expect:
  - "Robin is a Personal Library and Librarian" to file in The Librarian Problem (currently in Deep Work, wrong)
  - "Knowledge Began as Memory and Myth" to file (currently unfiled)
  - "The Library and Librarian as the Real Breakthrough" to file in The Librarian Problem (currently unfiled)
  - "Scaling Knowledge with Writing and Printing" to file in Writing Is Thinking (currently unfiled)

## Follow-up suggestion (not in this PR)

Add a log line in \`packages/agent/src/stages/wiki-classify.ts\` that emits the candidate wiki names alongside \`pipeline_event.metadata.candidateCount\`. Current telemetry says how many but not which, which is what hid this bug for as long as it did.