### PR TITLE
chore(openapi): restore wikis.structure on the three wiki schemas

### DIFF
--- a/core/openapi.json
+++ b/core/openapi.json
@@ -3555,6 +3555,10 @@
           "prompt": {
             "type": "string"
           },
+          "structure": {
+            "type": "string",
+            "default": ""
+          },
           "state": {
             "type": "string",
             "enum": [
@@ -3719,6 +3723,10 @@
           },
           "prompt": {
             "type": "string"
+          },
+          "structure": {
+            "type": "string",
+            "default": ""
           },
           "state": {
             "type": "string",
@@ -4062,6 +4070,10 @@
           },
           "prompt": {
             "type": "string"
+          },
+          "structure": {
+            "type": "string",
+            "default": ""
           },
           "state": {
             "type": "string",


### PR DESCRIPTION
## Summary

#359 added \`structure\` to \`wikiResponseSchema\`, \`wikiWithContentResponseSchema\`, and \`wikiDetailResponseSchema\` in \`openapi.json\`. The merge resolution on #363's settings-shell branch took \`--ours\` for \`openapi.json\` to keep that branch's backfill route additions, which inadvertently dropped #359's structure field at the same time.

## Fallout

The \`wiki build against core /openapi.json\` CI step regenerates \`wiki/src/lib/generated/types.gen.ts\` from \`openapi.json\`. Without \`structure\` in the documented schema, the regenerated SDK drops \`structure?: string\` from \`WikiDetailResponseSchema\`, and \`wiki/src/app/(shell)/wiki/[id]/page.tsx\` fails type-check at line 302 because it reads \`wiki.structure\`.

## Fix

Add \`structure\` back to all three wiki response schemas in \`openapi.json\`. The runtime Zod schema in \`core/src/schemas/wikis.schema.ts\` already carries it, so this just brings the documented OpenAPI surface back in sync.

## Unblocks

- #365 (forward classifier hybrid search) — currently red CI in the wiki build step for the same reason.

## Test plan

- [ ] CI green
- [ ] After merge, rebase #365 onto main and confirm wiki build step passes there too.