### PR TITLE
fix: v0.2.2 review follow-ups (citationSpan validation, soft-delete guard, doc + type cleanup)

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -151,10 +151,11 @@ const faviconBuf = readFileSync(new URL('../favicon.ico', import.meta.url))
  * surface matches that constant — adding a route here without updating
  * PUBLIC_ROUTES (or self-applying session middleware) fails the test.
  *
- * Two narrow exceptions self-apply session middleware INSIDE this block and
- * are NOT in PUBLIC_ROUTES:
+ * Three narrow exceptions self-apply session middleware INSIDE this block
+ * and are NOT in PUBLIC_ROUTES:
  *   - /admin/*        (adminRoutes.use('*', sessionMiddleware))
  *   - /admin/queues/* (app.use('/admin/queues/*', sessionMiddleware) below)
+ *   - /admin/graph/*  (adminGraphStatsRoutes.use('*', sessionMiddleware))
  ***********************************************************************/
 
 // Backend-root landing page. Users who deploy via Railway and click the

--- a/core/src/lib/wiki-agent-schema.ts
+++ b/core/src/lib/wiki-agent-schema.ts
@@ -12,7 +12,7 @@
 // per-kind helpers below are kept module-private so the contract test
 // can assert that no INSERT into wiki_agent_schema escapes this file.
 
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { embedText, type OpenRouterConfig } from '@robin/agent'
 import type { DB } from '../db/client.js'
 import { wikis, wikiTypes, wikiAgentSchema } from '../db/schema.js'
@@ -357,7 +357,7 @@ async function loadWikiRow(database: DB, wikiKey: string): Promise<WikiRow | nul
       content: wikis.content,
     })
     .from(wikis)
-    .where(eq(wikis.lookupKey, wikiKey))
+    .where(and(eq(wikis.lookupKey, wikiKey), isNull(wikis.deletedAt)))
   return row ?? null
 }
 

--- a/core/src/routes/admin/graph-stats.ts
+++ b/core/src/routes/admin/graph-stats.ts
@@ -256,7 +256,6 @@ adminGraphStatsRoutes.get('/stats', async (c) => {
       raw_mentions_seen: string | null
       matched: string | null
       dropped: string | null
-      telemetry_started: Date | string | null
     }>(sql`
       SELECT
         COALESCE(SUM((metadata->>'rawMentionsSeen')::bigint), 0) AS raw_mentions_seen,

--- a/packages/shared/src/prompts/specs/wiki-classification.schema.ts
+++ b/packages/shared/src/prompts/specs/wiki-classification.schema.ts
@@ -7,11 +7,26 @@ import { z } from 'zod'
  * persist path validate this invariant before storing the spans on the
  * FRAGMENT_IN_WIKI edge `attrs`. Bad spans are dropped, not coerced.
  */
-export const citationSpanSchema = z.object({
+/**
+ * Base shape for a citation span (no cross-field refinements). Used inside
+ * wikiClassificationSchema so the LLM-facing structured-output schema stays
+ * serializable and a single malformed span cannot reject the full parse.
+ */
+const citationSpanBaseSchema = z.object({
   start: z.number().int().nonnegative(),
   end: z.number().int().positive(),
   text: z.string().min(1),
 })
+
+/**
+ * Full citation span schema with cross-field validation. Use this for
+ * standalone validation (e.g. safeParse on individual spans) outside the
+ * LLM structured-output path. The refine rejects spans where end < start.
+ */
+export const citationSpanSchema = citationSpanBaseSchema.refine(
+  (span) => span.end >= span.start,
+  { message: 'citationSpan.end must be >= start' }
+)
 export type CitationSpan = z.infer<typeof citationSpanSchema>
 
 export const wikiClassificationSchema = z.object({
@@ -25,7 +40,11 @@ export const wikiClassificationSchema = z.object({
       // the schema permissive when the LLM omits the field on a
       // borderline assignment. Consumers should treat empty/missing as
       // "fall back to post-hoc reconstruction" (see Step 3).
-      citationSpans: z.array(citationSpanSchema).optional(),
+      //
+      // Uses the base shape (without cross-field refine) so a single bad
+      // span cannot reject the entire classification parse. The classify
+      // stage's validateSpans() filters end < start post-parse.
+      citationSpans: z.array(citationSpanBaseSchema).optional(),
     })
   ),
   noMatchReason: z.string().optional(),


### PR DESCRIPTION
## Summary
- citationSpanSchema gains `.refine(end >= start)` cross-field validation; malformed LLM spans are dropped, not written to attrs
- `ensureAgentSchema` skips soft-deleted wikis via `deleted_at IS NULL` guard on the wiki lookup
- SEC-DESIGN-DEFAULT-DENY comment updated to list `/admin/graph/*` as the third self-gating exception
- Stale `telemetry_started` field removed from `extractRow` type annotation in graph-stats route

Four mechanical fixes from v0.2.2 Wave 3 code review.

## Test plan
- [ ] `pnpm -C core typecheck` clean
- [ ] `pnpm -C packages/shared typecheck` clean
- [ ] No test regressions