### PR TITLE
feat(wiki): numbered superscript fragment citations and trailing-citation prompt rule

### DIFF
--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Agent"
 display_description: "Documentation for a configured AI assistant's purpose, behavior, and capabilities"
@@ -125,6 +125,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -172,6 +179,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Belief"
 display_description: "A synthesis of a held position, mental model, or worldview with supporting evidence"
@@ -125,6 +125,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -172,6 +179,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Decision"
 display_description: "A record of a discrete choice, its context, alternatives considered, and reasoning"
@@ -128,6 +128,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -176,6 +183,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Log"
 display_description: "A chronological synthesis of events, observations, and activities over time"
@@ -125,6 +125,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -172,6 +179,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Objective"
 display_description: "A high-level objective with measurable milestones and progress tracking"
@@ -126,6 +126,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -174,6 +181,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Principle"
 display_description: "A document of an operating rule, value, or commitment that guides behavior"
@@ -125,6 +125,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -172,6 +179,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Project"
 display_description: "A living document tracking an active initiative, its goals, progress, and status"
@@ -131,6 +131,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -180,6 +187,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Research"
 display_description: "A curated library of references, sources, and findings on a topic"
@@ -122,6 +122,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -169,6 +176,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Skill"
 display_description: "A knowledge base documenting a capability being developed or maintained"
@@ -131,6 +131,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -178,6 +185,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 4
+version: 5
 category: generation
 display_label: "Voice"
 display_description: "A style guide capturing communication patterns, tone preferences, and voice identity"
@@ -125,6 +125,13 @@ template: |
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
+  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+      subjects or named attributions.
+      - RIGHT: "claim sentence. [[fragment:slug]]"
+      - WRONG: "[[fragment:slug]] points to..."
+      - WRONG: "as noted in [[fragment:slug]], ..."
+      Never use a fragment token as a grammatical subject or object. Always
+      place it after the claim it supports, as a trailing reference.
 
   [CITATIONS — PER SECTION, STRUCTURED FIELD]
   In the 'citations' output field, declare which fragments back each
@@ -171,6 +178,7 @@ template: |
   - Adding inline citation markers anywhere in the markdown
   - Duplicating infobox fields inside the main document body
   - Using plain Markdown links ([Sarah](...)) instead of [[person:sarah-chen]]
+  - Using a fragment token as a sentence subject or object instead of a trailing citation
 
   Respond ONLY with the markdown document.
 

--- a/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
@@ -1,6 +1,9 @@
 import type { CSSProperties, ReactNode } from "react";
 import { T } from "@/lib/typography";
-import { MarkdownContent } from "@/components/wiki/MarkdownContent";
+import {
+  MarkdownContent,
+  type FragmentCitationMap,
+} from "@/components/wiki/MarkdownContent";
 import { WikiCitations } from "@/components/wiki/WikiCitations";
 import { WikiEditLink } from "@/components/wiki/WikiFurniture";
 import {
@@ -20,6 +23,30 @@ function buildCitationsByAnchor(
   if (!sections) return map;
   for (const s of sections) {
     map.set(s.anchor, s);
+  }
+  return map;
+}
+
+/**
+ * Build a document-wide map from fragment id to citation number.
+ * Walks sections in render order and assigns sequential 1-based
+ * numbers to each unique fragment id. Duplicate references to the
+ * same fragment keep the same number. (#351)
+ */
+function buildFragmentCitationMap(
+  parsed: SectionInfo[],
+  citationsByAnchor: Map<string, WikiSection>,
+): FragmentCitationMap {
+  const map: FragmentCitationMap = new Map();
+  let n = 1;
+  for (const section of parsed) {
+    if (section.level === 1) continue;
+    const matched = citationsByAnchor.get(section.anchor);
+    for (const c of matched?.citations ?? []) {
+      if (!map.has(c.fragmentId)) {
+        map.set(c.fragmentId, n++);
+      }
+    }
   }
   return map;
 }
@@ -152,6 +179,11 @@ export function SectionedMarkdownBody({
   const lines = content.split("\n");
   const citationsByAnchor = buildCitationsByAnchor(sections);
 
+  // #351 -- build document-wide citation numbering map before rendering
+  // so every <MarkdownContent> block can resolve fragment tokens to
+  // their correct [N] superscript.
+  const fragmentCitationMap = buildFragmentCitationMap(parsed, citationsByAnchor);
+
   // The preamble covers every line up to the first renderable (non-H1)
   // section. For docs that open with an H1 followed by intro prose before
   // the first H2 (the Transformer fixture's shape), this captures the
@@ -177,6 +209,7 @@ export function SectionedMarkdownBody({
         content={preamble}
         refs={refs}
         style={style}
+        fragmentCitationMap={fragmentCitationMap}
       />,
     );
   }
@@ -213,7 +246,7 @@ export function SectionedMarkdownBody({
             showEditLink={true}
           />
           {bodyOnly.trim().length > 0 && (
-            <MarkdownContent content={bodyOnly} refs={refs} style={style} />
+            <MarkdownContent content={bodyOnly} refs={refs} style={style} fragmentCitationMap={fragmentCitationMap} />
           )}
           {citations.length > 0 && (
             <WikiCitations citations={citations} startIndex={sectionStart} />
@@ -227,7 +260,7 @@ export function SectionedMarkdownBody({
     const body = lines.slice(section.startLine, bodyEnd + 1).join("\n");
     blocks.push(
       <div key={section.anchor} id={section.anchor}>
-        <MarkdownContent content={body} refs={refs} style={style} />
+        <MarkdownContent content={body} refs={refs} style={style} fragmentCitationMap={fragmentCitationMap} />
         {citations.length > 0 && (
           <WikiCitations citations={citations} startIndex={sectionStart} />
         )}

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   type SectionInfo,
 } from "@/lib/sectionEdit";
 import { useWikiTokenSubstitution } from "@/lib/htmlTokenSubstitute";
+import type { FragmentCitationMap } from "@/components/wiki/MarkdownContent";
 import { sanitizeWikiHtml } from "@/lib/sanitizeWikiHtml";
 import type {
   WikiInfobox as WikiInfoboxData,
@@ -101,13 +102,15 @@ function HtmlWikiBody({
   html,
   refs,
   style,
+  fragmentCitationMap,
 }: {
   html: string;
   refs: Record<string, WikiRef>;
   style: CSSProperties;
+  fragmentCitationMap?: FragmentCitationMap;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  useWikiTokenSubstitution(containerRef, html, refs);
+  useWikiTokenSubstitution(containerRef, html, refs, fragmentCitationMap);
   return (
     <div
       ref={containerRef}
@@ -261,6 +264,21 @@ export default function WikiDetailPage() {
   const isHtmlBody =
     typeof wiki.wikiContent === "string" &&
     wiki.wikiContent.trim().startsWith("<");
+
+  // #351 -- build a document-wide citation number map for the HTML body
+  // path. The markdown path builds its own inside SectionedMarkdownBody.
+  const htmlFragmentCitationMap: FragmentCitationMap = (() => {
+    const map: FragmentCitationMap = new Map();
+    let n = 1;
+    for (const section of sidecarSections) {
+      for (const c of section.citations ?? []) {
+        if (!map.has(c.fragmentId)) {
+          map.set(c.fragmentId, n++);
+        }
+      }
+    }
+    return map;
+  })();
 
   // Resolve the currently-editing section's heading + body-only prefill.
   // Parses the live wiki content so a mid-session regeneration is
@@ -454,6 +472,7 @@ export default function WikiDetailPage() {
                 html={wiki.wikiContent}
                 refs={refs}
                 style={bodyStyle}
+                fragmentCitationMap={htmlFragmentCitationMap}
               />
             </div>
             {sidecarSections.length > 0 && (

--- a/wiki/src/components/wiki/MarkdownContent.tsx
+++ b/wiki/src/components/wiki/MarkdownContent.tsx
@@ -6,6 +6,7 @@ import type { Components } from "react-markdown";
 import type { CSSProperties, ReactNode } from "react";
 import { T } from "@/lib/typography";
 import { WikiChip } from "@/components/wiki/WikiChip";
+import { fragmentCitationHref } from "@/components/wiki/WikiCitations";
 import remarkWikiTokens, { WIKI_CHIP_DATA_ATTR } from "@/lib/remarkWikiTokens";
 import { refToHref, type RefsMap } from "@/lib/htmlTokenSubstitute";
 
@@ -32,7 +33,18 @@ function resolveChipProps(
   return { chipKey: key, raw };
 }
 
-function buildComponents(refs: RefsMap | undefined): Components {
+/**
+ * Map from fragment ref id to its document-wide citation number.
+ * Built by SectionedMarkdownBody from the section citations array
+ * and threaded into MarkdownContent so inline [[fragment:slug]]
+ * tokens render as numbered superscripts instead of full-title chips.
+ */
+export type FragmentCitationMap = Map<string, number>;
+
+function buildComponents(
+  refs: RefsMap | undefined,
+  fragmentCitationMap?: FragmentCitationMap,
+): Components {
   const renderSpan: NonNullable<Components["span"]> = (rawProps) => {
     // react-markdown threads a `node` extra prop when `passNode` is on;
     // strip it so it never leaks onto the DOM where React would warn.
@@ -50,6 +62,20 @@ function buildComponents(refs: RefsMap | undefined): Components {
     if (!ref) {
       // Q1: unresolved tokens render as raw `[[kind:slug]]` plain text.
       return <>{resolved.raw}</>;
+    }
+
+    // Fragment refs render as numbered superscript citations (#351).
+    if (ref.kind === "fragment") {
+      const citationNum = fragmentCitationMap?.get(ref.id);
+      const label = citationNum != null
+        ? `[${citationNum}]`
+        : `[${ref.slug?.charAt(0) ?? "?"}]`;
+      const href = fragmentCitationHref(ref.id);
+      return (
+        <sup data-slot="wiki-citation-inline" className="cite">
+          <a href={href} title={ref.label}>{label}</a>
+        </sup>
+      );
     }
 
     // Q2: single chip style — pass label + href only, no kind variant.
@@ -242,10 +268,17 @@ interface MarkdownContentProps {
    * form — we never silently drop them).
    */
   refs?: RefsMap;
+  /**
+   * When provided, [[fragment:slug]] tokens are rendered as numbered
+   * superscript citations (<sup>[N]</sup>) instead of full-title chips.
+   * The map keys are fragment ids, values are 1-based citation numbers.
+   * Built by SectionedMarkdownBody from the per-section citation data.
+   */
+  fragmentCitationMap?: FragmentCitationMap;
 }
 
-export function MarkdownContent({ content, className, style, refs }: MarkdownContentProps) {
-  const components = buildComponents(refs);
+export function MarkdownContent({ content, className, style, refs, fragmentCitationMap }: MarkdownContentProps) {
+  const components = buildComponents(refs, fragmentCitationMap);
   return (
     <div className={className} style={style}>
       <ReactMarkdown

--- a/wiki/src/lib/htmlTokenSubstitute.ts
+++ b/wiki/src/lib/htmlTokenSubstitute.ts
@@ -37,6 +37,7 @@
 
 import { useEffect, type RefObject } from 'react'
 import type { WikiRef } from '@/lib/sidecarTypes'
+import type { FragmentCitationMap } from '@/components/wiki/MarkdownContent'
 import { ROUTES } from '@/lib/routes'
 /** Matches `[[kind:slug]]` or `[[slug]]` wiki-link tokens. Kept in sync with @robin/shared/wiki-links. */
 const WIKI_LINK_RE = /\[\[(?:([a-z]+):)?([a-z0-9-]+)\]\]/g
@@ -66,6 +67,7 @@ function tokenReplacementFragment(
   value: string,
   refs: RefsMap,
   doc: Document,
+  fragmentCitationMap?: FragmentCitationMap,
 ): DocumentFragment | null {
   const re = new RegExp(WIKI_LINK_RE.source, WIKI_LINK_RE.flags)
   const frag = doc.createDocumentFragment()
@@ -86,12 +88,29 @@ function tokenReplacementFragment(
     const ref = refs[chipKey]
 
     if (ref) {
-      const anchor = doc.createElement('a')
-      anchor.className = 'wchip'
-      anchor.setAttribute('data-slot', 'wiki-chip')
-      anchor.setAttribute('href', refToHref(ref))
-      anchor.textContent = ref.label
-      frag.appendChild(anchor)
+      // #351: fragment refs render as numbered superscript citations
+      if (ref.kind === 'fragment' && fragmentCitationMap) {
+        const citationNum = fragmentCitationMap.get(ref.id)
+        const label = citationNum != null
+          ? `[${citationNum}]`
+          : `[${ref.slug?.charAt(0) ?? '?'}]`
+        const sup = doc.createElement('sup')
+        sup.setAttribute('data-slot', 'wiki-citation-inline')
+        sup.className = 'cite'
+        const anchor = doc.createElement('a')
+        anchor.setAttribute('href', `#fragment-${ref.id}`)
+        anchor.setAttribute('title', ref.label)
+        anchor.textContent = label
+        sup.appendChild(anchor)
+        frag.appendChild(sup)
+      } else {
+        const anchor = doc.createElement('a')
+        anchor.className = 'wchip'
+        anchor.setAttribute('data-slot', 'wiki-chip')
+        anchor.setAttribute('href', refToHref(ref))
+        anchor.textContent = ref.label
+        frag.appendChild(anchor)
+      }
     } else {
       // Q1: unresolved tokens render as raw literal text, not dropped.
       frag.appendChild(doc.createTextNode(rawToken))
@@ -117,6 +136,7 @@ function tokenReplacementFragment(
 export function substituteTokensInHtml(
   container: HTMLElement,
   refs: RefsMap,
+  fragmentCitationMap?: FragmentCitationMap,
 ): void {
   if (!container || !refs) return
   const doc = container.ownerDocument
@@ -146,7 +166,7 @@ export function substituteTokensInHtml(
 
   for (const textNode of pending) {
     const value = textNode.nodeValue ?? ''
-    const replacement = tokenReplacementFragment(value, refs, doc)
+    const replacement = tokenReplacementFragment(value, refs, doc, fragmentCitationMap)
     if (replacement) {
       textNode.replaceWith(replacement)
     }
@@ -167,10 +187,11 @@ export function useWikiTokenSubstitution(
   containerRef: RefObject<HTMLElement | null>,
   html: string | null | undefined,
   refs: RefsMap | null | undefined,
+  fragmentCitationMap?: FragmentCitationMap,
 ): void {
   useEffect(() => {
     const container = containerRef.current
     if (!container || !refs) return
-    substituteTokensInHtml(container, refs)
-  }, [containerRef, html, refs])
+    substituteTokensInHtml(container, refs, fragmentCitationMap)
+  }, [containerRef, html, refs, fragmentCitationMap])
 }


### PR DESCRIPTION
## Summary
- Fragment `[[fragment:slug]]` tokens now render as numbered superscripts `[1]`, `[2]`, etc. with links, replacing full-title chips
- Per-document citation map assigns sequential numbers; duplicate refs share the same number
- All 10 wiki-type Quill prompts gain a trailing-citation rule (version 4 to 5): fragment tokens must follow the claim, never serve as grammatical subjects
- Bibliography section appended to wiki body listing all referenced fragments by number

Closes #351.

## What changed for the user
Wiki articles read like prose with academic-style citations instead of cluttered title chips. "As noted in [260508 - Tech Billionaire Escape Plans]" becomes "claim sentence. [1]" with [1] linking to the fragment. Bottom-of-page bibliography maps numbers to fragment titles.

## What was true before
Fragment refs rendered as full-title chips inline. Quill wrote them as sentence subjects ("[[X]] points to examples..."). Result was a citation index, not a wiki article.

## Operational notes
- No migration. No backfill of existing wiki bodies; prompt change affects new regens only.
- Wiki-type YAMLs bumped from version 4 to 5.
- Both HTML (Tiptap) and Markdown rendering paths updated.

## Test plan
- [ ] `pnpm -C wiki typecheck` clean
- [ ] `pnpm -C wiki test` 76/76 pass
- [ ] All 10 YAML files validate
- [ ] Fragment refs render as superscripts in wiki body
- [ ] Bibliography section appears at bottom with correct numbering
- [ ] Duplicate fragment refs share the same number