### PR TITLE
feat(wiki): member-fragments management table and bouncer mode toggle

### DIFF
--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -3,14 +3,12 @@
 import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { Check, LinkIcon, RefreshCw, Trash2, X } from "lucide-react";
+import { Check, LinkIcon, RefreshCw, Trash2 } from "lucide-react";
 import { T } from "@/lib/typography";
 import { Spinner } from "@/components/ui/spinner";
 import { useWiki } from "@/hooks/useWiki";
 import { useRegenerateWiki } from "@/hooks/useRegenerateWiki";
 import { useDeleteWiki } from "@/hooks/useDeleteWiki";
-import { useAcceptFragment } from "@/hooks/useAcceptFragment";
-import { useRejectFragment } from "@/hooks/useRejectFragment";
 import { useQueryClient } from "@tanstack/react-query";
 import DestructiveConfirmDialog from "@/components/prompts/DestructiveConfirmDialog";
 import SectionEditor from "@/components/editor/SectionEditor";
@@ -25,6 +23,7 @@ import { WikiChip } from "@/components/wiki/WikiChip";
 import { WikiCitations } from "@/components/wiki/WikiCitations";
 import { WikiCitationsSection } from "@/components/wiki/WikiCitationsSection";
 import { WikiEditLink } from "@/components/wiki/WikiFurniture";
+import { MemberFragmentsManagementTable } from "@/components/wiki/MemberFragmentsManagementTable";
 import { SectionedMarkdownBody } from "./SectionedMarkdownBody";
 import {
   parseSectionsFromMarkdown,
@@ -127,8 +126,6 @@ export default function WikiDetailPage() {
   const wiki = _wiki as typeof _wiki & { bouncerMode?: string; description?: string; fragments?: Array<{ id: string; slug: string; title: string; snippet: string; edgeStatus?: string }> } | undefined;
   const regenerate = useRegenerateWiki();
   const deleteWiki = useDeleteWiki();
-  const acceptFragment = useAcceptFragment();
-  const rejectFragment = useRejectFragment();
   const queryClient = useQueryClient();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
@@ -539,76 +536,13 @@ export default function WikiDetailPage() {
         }}
       />
 
-      {wiki.fragments && wiki.fragments.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <WikiSectionH2 title="Member Fragments" count={wiki.fragments.length} />
-          <ul
-            style={{
-              ...bodyStyle,
-              listStyle: "decimal",
-              paddingLeft: 20,
-              margin: "12px 0 0 0",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
-            {wiki.fragments.map((frag) => (
-              <li key={frag.id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <Link
-                  href={ROUTES.fragment(frag.id)}
-                  style={{
-                    color: "var(--wiki-fragment-link)",
-                    textDecoration: "underline",
-                    textDecorationSkipInk: "none",
-                  }}
-                >
-                  {frag.title}
-                </Link>
-                {wiki.bouncerMode === "review" && (frag as typeof frag & { edgeStatus?: string }).edgeStatus === "pending" && (
-                  <span style={{ display: "inline-flex", gap: 4, alignItems: "center" }}>
-                    <button
-                      type="button"
-                      title="Accept fragment"
-                      onClick={() => acceptFragment.mutate({ id: frag.id, wikiId: wiki.id })}
-                      disabled={acceptFragment.isPending}
-                      style={{
-                        background: "none",
-                        border: "1px solid var(--wiki-card-border)",
-                        cursor: "pointer",
-                        padding: "2px 4px",
-                        display: "inline-flex",
-                        alignItems: "center",
-                        color: "green",
-                      }}
-                    >
-                      <Check size={12} strokeWidth={2} />
-                    </button>
-                    <button
-                      type="button"
-                      title="Reject fragment"
-                      onClick={() => rejectFragment.mutate({ id: frag.id, wikiId: wiki.id })}
-                      disabled={rejectFragment.isPending}
-                      style={{
-                        background: "none",
-                        border: "1px solid var(--wiki-card-border)",
-                        cursor: "pointer",
-                        padding: "2px 4px",
-                        display: "inline-flex",
-                        alignItems: "center",
-                        color: "red",
-                      }}
-                    >
-                      <X size={12} strokeWidth={2} />
-                    </button>
-                    <span style={{ fontSize: 10, color: "var(--wiki-count)", fontStyle: "italic" }}>pending</span>
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <WikiSectionH2 title="Member Fragments" count={wiki.fragments?.length ?? 0} />
+        <MemberFragmentsManagementTable
+          wikiId={wiki.id}
+          fragments={wiki.fragments ?? []}
+        />
+      </div>
 
       {wiki.people && wiki.people.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -24,6 +24,7 @@ import { WikiCitations } from "@/components/wiki/WikiCitations";
 import { WikiCitationsSection } from "@/components/wiki/WikiCitationsSection";
 import { WikiEditLink } from "@/components/wiki/WikiFurniture";
 import { MemberFragmentsManagementTable } from "@/components/wiki/MemberFragmentsManagementTable";
+import { BouncerModeToggle } from "@/components/wiki/BouncerModeToggle";
 import { SectionedMarkdownBody } from "./SectionedMarkdownBody";
 import {
   parseSectionsFromMarkdown,
@@ -329,7 +330,12 @@ export default function WikiDetailPage() {
       onSave={handleSaveToApi}
       customBottomSections={
         <>
-          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <BouncerModeToggle
+              wikiId={wiki.id}
+              bouncerMode={(wiki.bouncerMode as 'auto' | 'review') ?? 'auto'}
+            />
+            <span style={{ width: 1, height: 16, background: "var(--wiki-card-border)" }} />
             <button
               type="button"
               onClick={() => regenerate.mutate(wiki.id)}

--- a/wiki/src/components/ui/table.tsx
+++ b/wiki/src/components/ui/table.tsx
@@ -1,0 +1,99 @@
+import { cn } from "@/lib/utils"
+
+function Table({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableElement>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableRow({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableRowElement>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({
+  className,
+  ...props
+}: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({
+  className,
+  ...props
+}: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+}

--- a/wiki/src/components/wiki/BouncerModeToggle.tsx
+++ b/wiki/src/components/wiki/BouncerModeToggle.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { T, FONT } from "@/lib/typography";
+import { useToggleBouncerMode } from "@/hooks/useToggleBouncerMode";
+
+interface BouncerModeToggleProps {
+  wikiId: string;
+  bouncerMode: "auto" | "review";
+}
+
+/**
+ * Toggle between auto-accept and review mode for fragment attachments.
+ * Optimistic UI: flips the switch immediately and reverts on error.
+ */
+export function BouncerModeToggle({
+  wikiId,
+  bouncerMode,
+}: BouncerModeToggleProps) {
+  const toggle = useToggleBouncerMode();
+  const [optimistic, setOptimistic] = useState<"auto" | "review" | null>(null);
+
+  const effective = optimistic ?? bouncerMode;
+  const isAuto = effective === "auto";
+
+  const handleToggle = (checked: boolean) => {
+    const next = checked ? "auto" : "review";
+    setOptimistic(next);
+    toggle.mutate(
+      { id: wikiId, mode: next },
+      {
+        onSuccess: () => setOptimistic(null),
+        onError: () => setOptimistic(null),
+      },
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+      }}
+    >
+      <label
+        style={{
+          ...T.micro,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-article-text)",
+          cursor: "pointer",
+          userSelect: "none",
+          whiteSpace: "nowrap",
+        }}
+      >
+        Auto-accept fragments
+      </label>
+      <Switch
+        checked={isAuto}
+        onCheckedChange={handleToggle}
+        disabled={toggle.isPending}
+        size="sm"
+        aria-label="Toggle auto-accept fragments"
+      />
+    </div>
+  );
+}

--- a/wiki/src/components/wiki/MemberFragmentsManagementTable.tsx
+++ b/wiki/src/components/wiki/MemberFragmentsManagementTable.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Unlink } from "lucide-react";
+import { T, FONT } from "@/lib/typography";
+import { ROUTES } from "@/lib/routes";
+import { useDetachFragment } from "@/hooks/useDetachFragment";
+import ConfirmDialog from "@/components/prompts/ConfirmDialog";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+
+export interface MemberFragment {
+  id: string;
+  slug: string;
+  title: string;
+  snippet: string;
+  edgeStatus?: "active" | "pending";
+  createdAt?: string;
+}
+
+interface MemberFragmentsManagementTableProps {
+  wikiId: string;
+  fragments: MemberFragment[];
+}
+
+export function MemberFragmentsManagementTable({
+  wikiId,
+  fragments,
+}: MemberFragmentsManagementTableProps) {
+  const detach = useDetachFragment();
+  const [confirmTarget, setConfirmTarget] = useState<MemberFragment | null>(null);
+
+  if (fragments.length === 0) {
+    return (
+      <p
+        style={{
+          ...T.bodySmall,
+          color: "var(--wiki-article-text)",
+          opacity: 0.6,
+          fontStyle: "italic",
+          padding: "12px 0",
+        }}
+      >
+        No fragments attached to this wiki yet.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              style={{ ...T.micro, fontWeight: 600, fontFamily: FONT.SANS }}
+            >
+              Fragment
+            </TableHead>
+            <TableHead
+              style={{ ...T.micro, fontWeight: 600, fontFamily: FONT.SANS }}
+            >
+              Status
+            </TableHead>
+            <TableHead
+              style={{ ...T.micro, fontWeight: 600, fontFamily: FONT.SANS }}
+              className="text-right"
+            >
+              Actions
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {fragments.map((frag) => (
+            <TableRow key={frag.id}>
+              <TableCell>
+                <Link
+                  href={ROUTES.fragment(frag.id)}
+                  style={{
+                    ...T.bodySmall,
+                    color: "var(--wiki-fragment-link)",
+                    textDecoration: "underline",
+                    textDecorationSkipInk: "none",
+                  }}
+                >
+                  {frag.title}
+                </Link>
+                {frag.snippet && (
+                  <p
+                    style={{
+                      ...T.micro,
+                      color: "var(--wiki-article-text)",
+                      opacity: 0.6,
+                      margin: "2px 0 0 0",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      maxWidth: 400,
+                    }}
+                  >
+                    {frag.snippet}
+                  </p>
+                )}
+              </TableCell>
+              <TableCell>
+                <span
+                  style={{
+                    ...T.micro,
+                    color:
+                      frag.edgeStatus === "pending"
+                        ? "var(--wiki-count)"
+                        : "var(--wiki-article-text)",
+                    fontStyle:
+                      frag.edgeStatus === "pending" ? "italic" : "normal",
+                  }}
+                >
+                  {frag.edgeStatus === "pending" ? "pending" : "active"}
+                </span>
+              </TableCell>
+              <TableCell className="text-right">
+                <button
+                  type="button"
+                  title="Un-attach fragment"
+                  onClick={() => setConfirmTarget(frag)}
+                  disabled={detach.isPending}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    padding: "2px 8px",
+                    fontSize: 12,
+                    color: "var(--wiki-article-text)",
+                    background: "none",
+                    border: "1px solid var(--wiki-card-border)",
+                    cursor: detach.isPending ? "default" : "pointer",
+                    opacity: detach.isPending ? 0.5 : 1,
+                  }}
+                >
+                  <Unlink size={12} strokeWidth={1.5} />
+                  Un-attach
+                </button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmTarget(null);
+        }}
+        title="Un-attach fragment"
+        description={
+          confirmTarget
+            ? `Remove "${confirmTarget.title}" from this wiki? The fragment itself will not be deleted.`
+            : ""
+        }
+        confirmLabel="Un-attach"
+        destructive
+        onConfirm={() => {
+          if (confirmTarget) {
+            detach.mutate({
+              wikiId,
+              fragmentId: confirmTarget.id,
+            });
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/wiki/src/hooks/useDetachFragment.ts
+++ b/wiki/src/hooks/useDetachFragment.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+/**
+ * Un-attach a fragment from a wiki by soft-deleting the FRAGMENT_IN_WIKI edge.
+ * Calls DELETE /wikis/:id/fragments/:fragmentId (Stream E2).
+ *
+ * The endpoint is not yet in the OpenAPI spec / codegen, so we use fetch
+ * directly. The /api prefix is rewritten by the Next.js proxy to the core
+ * server, matching the pattern used by the generated SDK client (baseUrl: '/api').
+ */
+export function useDetachFragment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ wikiId, fragmentId }: { wikiId: string; fragmentId: string }) => {
+      const res = await fetch(`/api/wikis/${wikiId}/fragments/${fragmentId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        throw new Error(body || `Failed to un-attach fragment (${res.status})`)
+      }
+      return res.json()
+    },
+    onSuccess: (_data, { wikiId }) => {
+      queryClient.invalidateQueries({ queryKey: ['wiki', wikiId] })
+      queryClient.invalidateQueries({ queryKey: ['wikis'] })
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- E2: member-fragments management table on wiki detail page with un-attach action (calls `DELETE /wikis/:id/fragments/:fragmentId`)
- E9: bouncer mode toggle on wiki detail page header (auto/review via `PATCH /wikis/:id/bouncer`)

Part of #329.

## What changed for the user
Operators can see all fragments attached to a wiki in a structured table and un-attach individual fragments directly from the UI. The bouncer toggle lets operators switch between auto-accept (fragments route into the wiki automatically) and review mode (new attachments require manual approval) without leaving the wiki page.

## Test plan
- [ ] `pnpm -C wiki typecheck` clean
- [ ] `pnpm -C wiki test` 76/76 pass
- [ ] Fragments table renders on wiki detail page with un-attach action
- [ ] Bouncer toggle flips between auto/review with optimistic UI