### PR TITLE
feat(wiki): regen timeline, read-only diff viewer, and editorial-state dot

### DIFF
--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -33,6 +33,8 @@ import {
 } from "@/lib/sectionEdit";
 import { useWikiTokenSubstitution } from "@/lib/htmlTokenSubstitute";
 import { sanitizeWikiHtml } from "@/lib/sanitizeWikiHtml";
+import { EditorialStateDot } from "@/components/wiki/EditorialStateDot";
+import WikiRegenTimeline from "@/components/wiki/WikiRegenTimeline";
 import type {
   WikiInfobox as WikiInfoboxData,
   WikiRef,
@@ -329,6 +331,12 @@ export default function WikiDetailPage() {
           : undefined
       }
       wikiId={wiki.id}
+      editorialStateDot={{
+        editorialState: wiki.editorialState,
+        state: wiki.state,
+        dirtySince: wiki.dirtySince,
+        lastRebuiltAt: wiki.lastRebuiltAt,
+      }}
       onSave={handleSaveToApi}
       customBottomSections={
         <>
@@ -641,6 +649,11 @@ export default function WikiDetailPage() {
           </ul>
         </div>
       )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <WikiSectionH2 title="Timeline" />
+        <WikiRegenTimeline wikiId={wiki.id} />
+      </div>
     </WikiEntityArticle>
   );
 }

--- a/wiki/src/components/wiki/BrowseByType.tsx
+++ b/wiki/src/components/wiki/BrowseByType.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { FONT, T } from "@/lib/typography";
 import { useWikis } from "@/hooks/useWikis";
 import { useWikiTypesList } from "@/hooks/useWikiTypesList";
+import { EditorialStateDot } from "@/components/wiki/EditorialStateDot";
+import type { EditorialStateSchema } from "@/lib/generated/types.gen";
 
 function timeAgo(dateStr: string): string {
   const diffMs = Date.now() - new Date(dateStr).getTime();
@@ -62,6 +64,7 @@ interface WikiItem {
   title: string;
   date: string;
   href: string;
+  editorialState?: EditorialStateSchema;
 }
 
 interface WikiCategory {
@@ -127,7 +130,11 @@ function CategorySection({ category }: { category: WikiCategory }) {
                 flexShrink: 0,
               }}
             >
-              <BulletDot />
+              {item.editorialState ? (
+                <EditorialStateDot editorialState={item.editorialState} />
+              ) : (
+                <BulletDot />
+              )}
             </div>
             <div
               style={{
@@ -200,6 +207,7 @@ export default function BrowseByType() {
         title: t.name,
         date: timeAgo(t.updatedAt),
         href: `/wiki/${t.lookupKey}`,
+        editorialState: t.editorialState,
       });
     }
 

--- a/wiki/src/components/wiki/EditorialStateDot.tsx
+++ b/wiki/src/components/wiki/EditorialStateDot.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { EditorialStateSchema } from "@/lib/generated/types.gen";
+
+type EditorialState = EditorialStateSchema;
+
+const STATE_COLORS: Record<EditorialState, string> = {
+  empty: "var(--wiki-editorial-empty, #9ca3af)",
+  learning: "var(--wiki-editorial-learning, #f59e0b)",
+  dreaming: "var(--wiki-editorial-dreaming, #3b82f6)",
+  filed: "var(--wiki-editorial-filed, #22c55e)",
+};
+
+/**
+ * Derive editorial state client-side when the server-computed field is
+ * missing (e.g. stale SDK). Mirrors the backend editorialStateOf().
+ */
+function deriveEditorialState(wiki: {
+  state?: string;
+  dirtySince?: string | null;
+  lastRebuiltAt?: string | null;
+}): EditorialState {
+  if (!wiki.state || wiki.state === "PENDING") return "empty";
+  if (wiki.state === "DIRTY" || wiki.dirtySince) return "learning";
+  if (wiki.state === "LINKING") return "dreaming";
+  return "filed";
+}
+
+export type EditorialStateDotProps = {
+  /** Server-computed editorial state. Takes priority when present. */
+  editorialState?: EditorialState;
+  /** Fallback fields for client-side derivation when editorialState is absent. */
+  state?: string;
+  dirtySince?: string | null;
+  lastRebuiltAt?: string | null;
+  /** Dot diameter in pixels. Defaults to 8. */
+  size?: number;
+};
+
+export function EditorialStateDot({
+  editorialState,
+  state,
+  dirtySince,
+  lastRebuiltAt,
+  size = 8,
+}: EditorialStateDotProps) {
+  const resolved =
+    editorialState ?? deriveEditorialState({ state, dirtySince, lastRebuiltAt });
+  const color = STATE_COLORS[resolved];
+
+  return (
+    <span
+      aria-label={`Editorial state: ${resolved}`}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        backgroundColor: color,
+        flexShrink: 0,
+      }}
+    />
+  );
+}

--- a/wiki/src/components/wiki/RecentlyUpdated.tsx
+++ b/wiki/src/components/wiki/RecentlyUpdated.tsx
@@ -4,6 +4,8 @@ import { useMemo } from "react";
 import Link from "next/link";
 import { T } from "@/lib/typography";
 import { useWikis } from "@/hooks/useWikis";
+import { EditorialStateDot } from "@/components/wiki/EditorialStateDot";
+import type { EditorialStateSchema } from "@/lib/generated/types.gen";
 
 function timeAgo(dateStr: string): string {
   const diffMs = Date.now() - new Date(dateStr).getTime();
@@ -32,12 +34,18 @@ const BulletDot = () => (
   </svg>
 );
 
+interface RecentItem {
+  title: string;
+  updatedAgo: string;
+  href: string;
+  editorialState?: EditorialStateSchema;
+}
+
 export default function RecentlyUpdated() {
   const wikisQuery = useWikis();
 
-  const items = useMemo(() => {
+  const items = useMemo<RecentItem[]>(() => {
     const threads = wikisQuery.data?.wikis ?? [];
-    // Sort by updatedAt descending and take the first 5
     return [...threads]
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
       .slice(0, 5)
@@ -45,6 +53,7 @@ export default function RecentlyUpdated() {
         title: t.name,
         updatedAgo: timeAgo(t.updatedAt),
         href: `/wiki/${t.lookupKey}`,
+        editorialState: t.editorialState,
       }));
   }, [wikisQuery.data]);
 
@@ -103,7 +112,11 @@ export default function RecentlyUpdated() {
                   flexShrink: 0,
                 }}
               >
-                <BulletDot />
+                {item.editorialState ? (
+                  <EditorialStateDot editorialState={item.editorialState} />
+                ) : (
+                  <BulletDot />
+                )}
               </div>
               <div
                 style={{

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -35,6 +35,7 @@ import { sanitizeWikiHtml } from "@/lib/sanitizeWikiHtml";
 import {
   type LucideIcon,
 } from "lucide-react";
+import { EditorialStateDot, type EditorialStateDotProps } from "@/components/wiki/EditorialStateDot";
 
 function EyeOpenIcon() {
   return (
@@ -300,6 +301,8 @@ export type WikiEntityArticleProps = {
   onSave?: (data: { title: string; chipLabel: string; content: string }) => void;
   /** Custom settings click handler — when provided, the header gear calls this instead of opening AddWikiModal. */
   onSettingsClick?: () => void;
+  /** Editorial state dot rendered inline with the title. */
+  editorialStateDot?: EditorialStateDotProps;
   children: ReactNode;
 };
 
@@ -351,6 +354,7 @@ export function WikiEntityArticle({
   collections,
   onSave,
   onSettingsClick: onSettingsClickProp,
+  editorialStateDot,
   children,
 }: WikiEntityArticleProps) {
   const [infoVisible, setInfoVisible] = useState(true);
@@ -583,9 +587,15 @@ export function WikiEntityArticle({
                       whiteSpace: titleEllipsis ? "nowrap" : undefined,
                       minWidth: 0,
                       flex: 1,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
                     }}
                   >
                     {displayTitle}
+                    {editorialStateDot && (
+                      <EditorialStateDot {...editorialStateDot} />
+                    )}
                   </h1>
                 )}
                 {/* Private badge — visible whenever the wiki is unpublished.

--- a/wiki/src/components/wiki/WikiRegenTimeline.tsx
+++ b/wiki/src/components/wiki/WikiRegenTimeline.tsx
@@ -1,0 +1,598 @@
+"use client";
+
+import { useState } from "react";
+import { T, FONT } from "@/lib/typography";
+import { Spinner } from "@/components/ui/spinner";
+import { useWikiTimeline } from "@/hooks/useWikiTimeline";
+import { useWikiEditHistory } from "@/hooks/useWikiEditHistory";
+import { diffWords, diffStats, type DiffPart } from "./wikiDiff";
+import type {
+  AuditEventSchema,
+  EditRecordSchema,
+} from "@/lib/generated/types.gen";
+
+const formatAbsolute = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+const formatRelative = (iso: string) => {
+  const seconds = Math.max(
+    1,
+    Math.floor((Date.now() - new Date(iso).getTime()) / 1000),
+  );
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+};
+
+function sourceLabel(source: string): string {
+  switch (source) {
+    case "scheduler":
+      return "Scheduled";
+    case "manual":
+      return "Manual";
+    case "on_demand":
+      return "On demand";
+    case "regen":
+      return "Regeneration";
+    case "user":
+      return "User edit";
+    default:
+      return source;
+  }
+}
+
+function eventTypeLabel(eventType: string): string {
+  switch (eventType) {
+    case "wiki.regenerated":
+      return "Regenerated";
+    case "wiki.created":
+      return "Created";
+    case "wiki.updated":
+      return "Updated";
+    case "wiki.published":
+      return "Published";
+    case "wiki.unpublished":
+      return "Unpublished";
+    case "fragment.created":
+      return "Fragment created";
+    case "fragment.filed":
+      return "Fragment filed";
+    case "fragment.updated":
+      return "Fragment updated";
+    case "fragment.accepted":
+      return "Fragment accepted";
+    case "fragment.rejected":
+      return "Fragment rejected";
+    default:
+      return eventType.replace(/\./g, " ");
+  }
+}
+
+function extractDetailCounts(detail: unknown): {
+  newCount?: number;
+  updatedCount?: number;
+  removedCount?: number;
+  integratedCount?: number;
+} | null {
+  if (!detail || typeof detail !== "object") return null;
+  const d = detail as Record<string, unknown>;
+  const counts: Record<string, number> = {};
+  if (typeof d.newCount === "number") counts.newCount = d.newCount;
+  if (typeof d.updatedCount === "number") counts.updatedCount = d.updatedCount;
+  if (typeof d.removedCount === "number") counts.removedCount = d.removedCount;
+  if (typeof d.integratedCount === "number")
+    counts.integratedCount = d.integratedCount;
+  if (typeof d.new_count === "number") counts.newCount = d.new_count;
+  if (typeof d.updated_count === "number")
+    counts.updatedCount = d.updated_count;
+  if (typeof d.removed_count === "number")
+    counts.removedCount = d.removed_count;
+  if (typeof d.integrated_count === "number")
+    counts.integratedCount = d.integrated_count;
+
+  if (Object.keys(counts).length === 0) return null;
+  return counts;
+}
+
+const diffStyles = {
+  added: {
+    backgroundColor: "var(--diff-added-bg, rgba(34,197,94,0.15))",
+    color: "var(--diff-added-text, #16a34a)",
+    textDecoration: "none" as const,
+    padding: "0 1px",
+    borderRadius: 2,
+  },
+  removed: {
+    backgroundColor: "var(--diff-removed-bg, rgba(239,68,68,0.15))",
+    color: "var(--diff-removed-text, #dc2626)",
+    textDecoration: "line-through" as const,
+    padding: "0 1px",
+    borderRadius: 2,
+  },
+  equal: {
+    color: "var(--wiki-sidebar-text)",
+  },
+} as const;
+
+function DiffInline({ parts }: { parts: DiffPart[] }) {
+  return (
+    <>
+      {parts.map((p, i) => (
+        <span key={i} style={diffStyles[p.type]}>
+          {p.value}
+        </span>
+      ))}
+    </>
+  );
+}
+
+function EditDiffEntry({
+  edit,
+  previousEdit,
+  defaultExpanded,
+}: {
+  edit: EditRecordSchema;
+  previousEdit: EditRecordSchema | null;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (!previousEdit) {
+    return (
+      <div
+        style={{
+          ...T.caption,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-sidebar-text)",
+          marginTop: 4,
+        }}
+      >
+        Initial version
+      </div>
+    );
+  }
+
+  const parts = diffWords(previousEdit.contentSnippet, edit.contentSnippet);
+  const stats = diffStats(parts);
+  const hasChanges = stats.added > 0 || stats.removed > 0;
+
+  if (!hasChanges) {
+    return (
+      <div
+        style={{
+          ...T.caption,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-sidebar-text)",
+          marginTop: 4,
+        }}
+      >
+        No text changes in preview
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 6 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            ...T.caption,
+            fontFamily: FONT.SANS,
+            color: "var(--wiki-link, var(--wiki-article-link))",
+          }}
+        >
+          {expanded ? "Hide diff" : "Show diff"}
+        </button>
+        <span
+          style={{
+            ...T.caption,
+            fontFamily: FONT.SANS,
+            color: "var(--wiki-sidebar-text)",
+            display: "inline-flex",
+            gap: 6,
+          }}
+        >
+          <span style={{ color: "var(--diff-added-text, #16a34a)" }}>
+            +{stats.added}
+          </span>
+          <span style={{ color: "var(--diff-removed-text, #dc2626)" }}>
+            -{stats.removed}
+          </span>
+        </span>
+      </div>
+      {expanded && (
+        <pre
+          style={{
+            ...T.bodySmall,
+            fontFamily: FONT.SANS,
+            marginTop: 6,
+            padding: "10px 12px",
+            border: "1px solid var(--wiki-card-border)",
+            borderRadius: 4,
+            background: "var(--code-block-bg, var(--surface-subtle))",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            lineHeight: "22px",
+            color: "var(--wiki-article-text)",
+          }}
+        >
+          <DiffInline parts={parts} />
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function TimelineEvent({ event }: { event: AuditEventSchema }) {
+  const [expanded, setExpanded] = useState(false);
+  const counts = extractDetailCounts(event.detail);
+
+  return (
+    <div style={{ position: "relative", paddingBottom: 20 }}>
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          left: -26,
+          top: 4,
+          width: 11,
+          height: 11,
+          borderRadius: "50%",
+          background: "var(--background)",
+          border: "2px solid var(--wiki-meta-line)",
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <span
+          style={{
+            ...T.bodySmall,
+            fontFamily: FONT.SANS,
+            fontWeight: 600,
+            color: "var(--wiki-title)",
+          }}
+        >
+          {eventTypeLabel(event.eventType)}
+        </span>
+        <span
+          style={{
+            ...T.caption,
+            fontFamily: FONT.SANS,
+            padding: "1px 6px",
+            borderRadius: 3,
+            border: "1px solid var(--wiki-chip-border, var(--wiki-card-border))",
+            background: "var(--wiki-chip-bg, var(--surface-subtle))",
+            color: "var(--wiki-chip-text, var(--wiki-sidebar-text))",
+          }}
+        >
+          {sourceLabel(event.source)}
+        </span>
+        {counts && (
+          <span
+            style={{
+              ...T.caption,
+              fontFamily: FONT.SANS,
+              color: "var(--wiki-sidebar-text)",
+              display: "inline-flex",
+              gap: 6,
+            }}
+          >
+            {counts.newCount != null && counts.newCount > 0 && (
+              <span style={{ color: "var(--diff-added-text, #16a34a)" }}>
+                +{counts.newCount} new
+              </span>
+            )}
+            {counts.updatedCount != null && counts.updatedCount > 0 && (
+              <span>{counts.updatedCount} updated</span>
+            )}
+            {counts.removedCount != null && counts.removedCount > 0 && (
+              <span style={{ color: "var(--diff-removed-text, #dc2626)" }}>
+                -{counts.removedCount} removed
+              </span>
+            )}
+            {counts.integratedCount != null && counts.integratedCount > 0 && (
+              <span>{counts.integratedCount} integrated</span>
+            )}
+          </span>
+        )}
+      </div>
+      <div
+        style={{
+          ...T.caption,
+          fontFamily: FONT.SANS,
+          color: "var(--wiki-sidebar-text)",
+          marginTop: 2,
+        }}
+      >
+        <span title={formatAbsolute(event.createdAt)}>
+          {formatRelative(event.createdAt)} . {formatAbsolute(event.createdAt)}
+        </span>
+      </div>
+      {event.summary && (
+        <div style={{ marginTop: 4 }}>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            style={{
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              ...T.caption,
+              fontFamily: FONT.SANS,
+              color: "var(--wiki-link, var(--wiki-article-link))",
+            }}
+          >
+            {expanded ? "Hide details" : "Show details"}
+          </button>
+          {expanded && (
+            <p
+              style={{
+                ...T.bodySmall,
+                fontFamily: FONT.SANS,
+                color: "var(--wiki-article-text)",
+                marginTop: 4,
+                padding: "8px 12px",
+                border: "1px solid var(--wiki-card-border)",
+                borderRadius: 4,
+                background: "var(--code-block-bg, var(--surface-subtle))",
+              }}
+            >
+              {event.summary}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function WikiRegenTimeline({ wikiId }: { wikiId: string }) {
+  const [activeTab, setActiveTab] = useState<"events" | "edits">("events");
+  const timeline = useWikiTimeline(wikiId);
+  const history = useWikiEditHistory(wikiId);
+
+  const events = timeline.data?.events ?? [];
+  const edits = history.data?.edits ?? [];
+
+  const isLoading = timeline.isLoading || history.isLoading;
+
+  if (isLoading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "24px 0",
+        }}
+      >
+        <Spinner className="size-5" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          borderBottom: "1px solid var(--wiki-meta-line)",
+        }}
+      >
+        {(["events", "edits"] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setActiveTab(tab)}
+            style={{
+              background: "none",
+              border: "none",
+              borderBottom:
+                activeTab === tab
+                  ? "2px solid var(--foreground)"
+                  : "2px solid transparent",
+              cursor: "pointer",
+              ...T.bodySmall,
+              fontFamily: FONT.SANS,
+              fontWeight: activeTab === tab ? 600 : 400,
+              color:
+                activeTab === tab
+                  ? "var(--wiki-title)"
+                  : "var(--wiki-sidebar-text)",
+              paddingBottom: 8,
+            }}
+          >
+            {tab === "events"
+              ? `Audit Events (${events.length})`
+              : `Edit History (${edits.length})`}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "events" && (
+        <div
+          style={{
+            position: "relative",
+            paddingLeft: 20,
+            borderLeft: "1px solid var(--wiki-meta-line)",
+            marginTop: 8,
+          }}
+        >
+          {events.length === 0 ? (
+            <div
+              style={{
+                ...T.bodySmall,
+                fontFamily: FONT.SANS,
+                color: "var(--wiki-sidebar-text)",
+                padding: "12px 0",
+              }}
+            >
+              No audit events recorded yet.
+            </div>
+          ) : (
+            events.map((event) => (
+              <TimelineEvent key={event.id} event={event} />
+            ))
+          )}
+        </div>
+      )}
+
+      {activeTab === "edits" && (
+        <div
+          style={{
+            position: "relative",
+            paddingLeft: 20,
+            borderLeft: "1px solid var(--wiki-meta-line)",
+            marginTop: 8,
+          }}
+        >
+          {edits.length === 0 ? (
+            <div
+              style={{
+                ...T.bodySmall,
+                fontFamily: FONT.SANS,
+                color: "var(--wiki-sidebar-text)",
+                padding: "12px 0",
+              }}
+            >
+              No edit history recorded yet.
+            </div>
+          ) : (
+            edits.map((edit, idx) => {
+              const isLatest = idx === 0;
+              const previousEdit =
+                idx < edits.length - 1 ? edits[idx + 1] : null;
+
+              return (
+                <div
+                  key={edit.id}
+                  style={{
+                    position: "relative",
+                    paddingBottom: idx === edits.length - 1 ? 0 : 20,
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      position: "absolute",
+                      left: -26,
+                      top: 4,
+                      width: 11,
+                      height: 11,
+                      borderRadius: "50%",
+                      background: isLatest
+                        ? "var(--foreground)"
+                        : "var(--background)",
+                      border: "2px solid var(--wiki-meta-line)",
+                    }}
+                  />
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <span
+                      style={{
+                        ...T.bodySmall,
+                        fontFamily: FONT.SANS,
+                        fontWeight: 600,
+                        color: "var(--wiki-title)",
+                      }}
+                    >
+                      {sourceLabel(edit.source)}
+                    </span>
+                    {isLatest && (
+                      <span
+                        style={{
+                          ...T.caption,
+                          fontFamily: FONT.SANS,
+                          padding: "1px 6px",
+                          borderRadius: 3,
+                          border:
+                            "1px solid var(--wiki-chip-border, var(--wiki-card-border))",
+                          background:
+                            "var(--wiki-chip-bg, var(--surface-subtle))",
+                          color:
+                            "var(--wiki-chip-text, var(--wiki-sidebar-text))",
+                        }}
+                      >
+                        current
+                      </span>
+                    )}
+                    <span
+                      style={{
+                        ...T.caption,
+                        fontFamily: FONT.SANS,
+                        padding: "1px 6px",
+                        borderRadius: 3,
+                        border:
+                          "1px solid var(--wiki-chip-border, var(--wiki-card-border))",
+                        background:
+                          "var(--wiki-chip-bg, var(--surface-subtle))",
+                        color:
+                          "var(--wiki-chip-text, var(--wiki-sidebar-text))",
+                      }}
+                    >
+                      {edit.type}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      ...T.caption,
+                      fontFamily: FONT.SANS,
+                      color: "var(--wiki-sidebar-text)",
+                      marginTop: 2,
+                    }}
+                  >
+                    <span title={formatAbsolute(edit.timestamp)}>
+                      {formatRelative(edit.timestamp)} .{" "}
+                      {formatAbsolute(edit.timestamp)}
+                    </span>
+                  </div>
+                  <EditDiffEntry
+                    edit={edit}
+                    previousEdit={previousEdit}
+                    defaultExpanded={isLatest}
+                  />
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/wiki/src/hooks/useWikiTimeline.ts
+++ b/wiki/src/hooks/useWikiTimeline.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { getWikiTimeline } from '@/lib/api'
+
+export function useWikiTimeline(id: string | undefined) {
+  return useQuery({
+    queryKey: ['wiki-timeline', id],
+    queryFn: async () => {
+      const { data } = await getWikiTimeline({ path: { id: id! } })
+      return data
+    },
+    enabled: !!id,
+  })
+}


### PR DESCRIPTION
## Summary
- E4: regen timeline view on wiki detail page with two tabs (audit events + edit history), showing timestamps, trigger reasons, and fragment counts
- E7: read-only word-level diff viewer using the `diff` npm package; shows green/red spans for additions/deletions between consecutive wiki body versions
- E8 (redesigned post-T4): editorial-state colored dot indicator on wiki title and list items. Gray=empty, amber=learning, blue=dreaming, green=filed. No text, no animation, no tooltip (deferred until tooltip rendering bug is fixed). aria-label for accessibility. Falls back to client-side derivation when server field is absent.

Part of #329.

## What changed for the user
Operators see regen history and what changed per revision directly on the wiki page. The editorial-state dot provides at-a-glance visibility into where each wiki is in the regen lifecycle without cognitive overhead of text labels.

## Operational notes
- `diff` package added to wiki workspace (`diff: ^9.0.0`). Lightweight text diff engine; no heavy UI dependency.
- `editorialState` field already in SDK types from T4's openapi refresh. `EditorialStateDot` includes a client-side derivation fallback for older backends.

## Test plan
- [ ] `pnpm -C wiki typecheck` clean
- [ ] `pnpm -C wiki test` 76/76 pass
- [ ] Timeline shows audit events and edit history on wiki detail page
- [ ] Diff viewer shows word-level colored spans between consecutive versions
- [ ] Editorial-state dot renders correct color per state on wiki title and list items
- [ ] Dot has aria-label for accessibility