### PR TITLE
fix(wiki): history shows full additive diff on first edit after Robin generation

### DIFF
--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -93,7 +93,14 @@ export function safeRefToHref(ref: string): string | null {
   return null
 }
 
-const generateUlid = monotonicFactory()
+/**
+ * Monotonic ULID factory. Use for any ephemeral or transient ID that
+ * needs to be unique and time-ordered (React keys, in-memory revision
+ * records, request correlation ids, etc.). For persisted objects with
+ * a known ObjectType, prefer `makeLookupKey(type)` which produces a
+ * type-prefixed key.
+ */
+export const generateUlid = monotonicFactory()
 
 /** Generate a type-prefixed lookup key, e.g. "frag01HZY3Q9R3..." */
 export function makeLookupKey(type: ObjectType): string {

--- a/wiki/src/components/wiki/useWikiEntityEditMode.ts
+++ b/wiki/src/components/wiki/useWikiEntityEditMode.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { generateUlid } from "@robin/shared/browser";
 import { htmlToPlainText } from "./wikiDiff";
 
 type UseWikiEntityEditModeArgs = {
@@ -107,13 +108,17 @@ export function useWikiEntityEditMode({
         if (prev.length === 0 || prev[0].content === startContent) return prev;
         return [
           {
-            id: `rev-${Date.now()}-head`,
+            id: `rev-${generateUlid()}`,
             timestamp: Date.now(),
             title: startTitle,
             chipLabel: startChipLabel,
             content: startContent,
-            summary: prev[0].summary,
-            author: prev[0].author,
+            // This entry represents the live state of the page at the
+            // moment history was opened, not a recorded edit event,
+            // so the row gets neutral labels instead of inheriting the
+            // previous server revision's summary/author.
+            summary: "Current state",
+            author: "",
           },
           ...prev,
         ];
@@ -127,15 +132,15 @@ export function useWikiEntityEditMode({
       if (content) lastReadHtmlRef.current = content;
       if (seededRef.current) return;
       // Skip seeding a synthetic baseline when there's no real content to
-      // diff against — otherwise the first user save would diff against
+      // diff against. Otherwise the first user save would diff against
       // "" and render the entire article as an additive blob in history.
       // handleSave will create the first revision as "Initial revision"
-      // (via diffSummary(null, …)) and flip seededRef itself.
+      // (via diffSummary(null, ...)) and flip seededRef itself.
       if (htmlToPlainText(content).trim() === "") return;
       seededRef.current = true;
       setRevisions([
         {
-          id: `rev-${Date.now()}-init`,
+          id: `rev-${generateUlid()}`,
           timestamp: Date.now(),
           title,
           chipLabel,
@@ -250,7 +255,7 @@ export function useWikiEntityEditMode({
         return prev;
       }
       const revision: WikiRevision = {
-        id: `rev-${Date.now()}`,
+        id: `rev-${generateUlid()}`,
         timestamp: Date.now(),
         title: draftTitle,
         chipLabel: draftChipLabel,

--- a/wiki/src/components/wiki/useWikiEntityEditMode.ts
+++ b/wiki/src/components/wiki/useWikiEntityEditMode.ts
@@ -92,6 +92,36 @@ export function useWikiEntityEditMode({
   // `readContentRef.current.innerHTML` is empty. We fall back to this snapshot.
   const lastReadHtmlRef = useRef<string>("");
 
+  // When revisions are seeded from the server they hold contentSnippet values
+  // which are BEFORE states. The actual current content (AFTER the latest edit)
+  // is only available at interaction time (openHistory / enterEditMode). If the
+  // head revision doesn't already reflect the current content, prepend it so
+  // the timeline and handleSave diff against the real state instead of an
+  // empty/stale BEFORE snapshot.
+  const prependCurrentIfNeeded = useCallback(
+    (startContent: string, startTitle: string, startChipLabel: string) => {
+      if (!seededRef.current) return; // local seedInitialRevision handles this
+      if (savedContent !== null) return; // handleSave already manages the head
+      if (!startContent) return;
+      setRevisions((prev) => {
+        if (prev.length === 0 || prev[0].content === startContent) return prev;
+        return [
+          {
+            id: `rev-${Date.now()}-head`,
+            timestamp: Date.now(),
+            title: startTitle,
+            chipLabel: startChipLabel,
+            content: startContent,
+            summary: prev[0].summary,
+            author: prev[0].author,
+          },
+          ...prev,
+        ];
+      });
+    },
+    [savedContent],
+  );
+
   const seedInitialRevision = useCallback(
     (content: string, title: string, chipLabel: string) => {
       if (content) lastReadHtmlRef.current = content;
@@ -153,6 +183,7 @@ export function useWikiEntityEditMode({
       const startTitle = savedTitle ?? currentTitle;
       const startChipLabel = savedChipLabel ?? currentChipLabel;
       seedInitialRevision(startContent, startTitle, startChipLabel);
+      prependCurrentIfNeeded(startContent, startTitle, startChipLabel);
       infoVisibleBeforeEditingRef.current = infoVisible;
       setBaselineContent(startContent);
       setBaselineTitle(startTitle);
@@ -164,7 +195,7 @@ export function useWikiEntityEditMode({
       setIsViewingHistory(false);
       setIsEditing(true);
     },
-    [infoVisible, savedChipLabel, savedContent, savedTitle, seedInitialRevision, setInfoVisible],
+    [infoVisible, prependCurrentIfNeeded, savedChipLabel, savedContent, savedTitle, seedInitialRevision, setInfoVisible],
   );
 
   const openHistory = useCallback(
@@ -181,12 +212,13 @@ export function useWikiEntityEditMode({
       const startTitle = savedTitle ?? currentTitle;
       const startChipLabel = savedChipLabel ?? currentChipLabel;
       seedInitialRevision(startContent, startTitle, startChipLabel);
+      prependCurrentIfNeeded(startContent, startTitle, startChipLabel);
       infoVisibleBeforeHistoryRef.current = infoVisible;
       setInfoVisible(false);
       setIsEditing(false);
       setIsViewingHistory(true);
     },
-    [infoVisible, savedChipLabel, savedContent, savedTitle, seedInitialRevision, setInfoVisible],
+    [infoVisible, prependCurrentIfNeeded, savedChipLabel, savedContent, savedTitle, seedInitialRevision, setInfoVisible],
   );
 
   const closeHistory = useCallback(() => {

--- a/wiki/src/components/wiki/useWikiEntityEditMode.ts
+++ b/wiki/src/components/wiki/useWikiEntityEditMode.ts
@@ -96,6 +96,12 @@ export function useWikiEntityEditMode({
     (content: string, title: string, chipLabel: string) => {
       if (content) lastReadHtmlRef.current = content;
       if (seededRef.current) return;
+      // Skip seeding a synthetic baseline when there's no real content to
+      // diff against — otherwise the first user save would diff against
+      // "" and render the entire article as an additive blob in history.
+      // handleSave will create the first revision as "Initial revision"
+      // (via diffSummary(null, …)) and flip seededRef itself.
+      if (htmlToPlainText(content).trim() === "") return;
       seededRef.current = true;
       setRevisions([
         {
@@ -222,6 +228,9 @@ export function useWikiEntityEditMode({
       };
       return [revision, ...prev];
     });
+    // Once a real revision exists, lock out further seeding — otherwise a
+    // later enterEditMode/openHistory would overwrite the saved history.
+    seededRef.current = true;
     exitEditMode();
   }, [draftChipLabel, draftContent, draftTitle, exitEditMode]);
 


### PR DESCRIPTION
Server edit history stores `contentSnippet` as the BEFORE state of each edit. For a wiki Robin generated from scratch, that BEFORE state is empty (""), so `serverRevisions[0].content = ""`. When the user made their first manual edit, the history timeline diffed their content against empty string and showed the entire article as added.

Fix: `prependCurrentIfNeeded` in `useWikiEntityEditMode` — when `enterEditMode` or `openHistory` receives the actual current page content, if the revisions head doesn't already reflect it (i.e. revisions are purely server-sourced and stale), prepend a head revision with the real current content. Subsequent `handleSave` calls and the history timeline then diff against the correct pre-edit baseline.