### PR TITLE
Improve local dev setup: configurable PG port, packages build, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ git push
 
 If you want to run Robin on your own machine — for hacking on the code, or because you'd rather host on something other than Railway.
 
-Two paths: **Nix** (recommended — one command provisions Postgres+pgvector, Redis, Node, pnpm) or **manual** (bring your own services).
+Two paths: **Nix** (recommended, one command provisions Postgres+pgvector, Redis, Node, pnpm) or **manual** (bring your own services).
 
 ### Env file setup (both paths)
 
@@ -139,12 +139,14 @@ cp core/.env.example core/.env
 cp wiki/.env.example wiki/.env
 ```
 
-Generate the five required secrets and paste each into the matching variable in `core/.env`:
+Generate each of the five required secrets and paste it into the matching variable in `core/.env`:
 
 ```bash
-for K in BETTER_AUTH_SECRET MASTER_KEY KEY_ENCRYPTION_SECRET RECOVERY_SECRET JOB_SIGNING_SECRET; do
-  echo "$K=$(openssl rand -hex 32)"
-done
+openssl rand -hex 32   # paste into BETTER_AUTH_SECRET
+openssl rand -hex 32   # paste into MASTER_KEY (must be 64 hex chars)
+openssl rand -hex 32   # paste into KEY_ENCRYPTION_SECRET
+openssl rand -hex 32   # paste into RECOVERY_SECRET
+openssl rand -hex 32   # paste into JOB_SIGNING_SECRET
 ```
 
 Then fill in the user-supplied values in `core/.env`:
@@ -157,9 +159,9 @@ INITIAL_PASSWORD=something-you-can-remember
 
 `DATABASE_URL`, `REDIS_URL`, `SERVER_PUBLIC_URL`, `WIKI_ORIGIN`, and `PORT` already have correct local defaults.
 
-### Path A — Nix (recommended)
+### Path A: Nix (recommended)
 
-The repo ships a `flake.nix` that provisions Postgres 16 (with pgvector), Redis, Node 22, and pnpm — fully isolated from anything on your system.
+The repo ships a `flake.nix` that provisions Postgres 16 (with pgvector), Redis, Node 22, and pnpm, fully isolated from anything on your system.
 
 1. **Install Nix.** The [Determinate Systems installer](https://install.determinate.systems/) enables flakes by default and includes an uninstaller:
    ```bash
@@ -187,12 +189,12 @@ The repo ships a `flake.nix` that provisions Postgres 16 (with pgvector), Redis,
 **Port conflicts:** if you already run Postgres locally (Postgres.app, Homebrew, Docker, etc.), `init` will refuse to start. Pick a free port and tell the flake about it before re-running:
 
 ```bash
-export ROBIN_PG_PORT=5433
+export PG_PORT=5433
 # update DATABASE_URL in core/.env to match: postgresql://postgres@127.0.0.1:5433/robinwiki
 init
 ```
 
-### Path B — Manual
+### Path B: Manual
 
 Bring your own services.
 
@@ -200,8 +202,8 @@ Bring your own services.
 
 - **Node.js** ≥ 20 (run `corepack enable` to pin pnpm via the `packageManager` field)
 - **PostgreSQL** with the [pgvector](https://github.com/pgvector/pgvector) extension
-- **Redis** — used by BullMQ for the job queue
-- **An OpenRouter API key** — get one at [openrouter.ai/keys](https://openrouter.ai/keys)
+- **Redis** for the BullMQ job queue
+- **An OpenRouter API key**, get one at [openrouter.ai/keys](https://openrouter.ai/keys)
 
 **From clone to running:**
 

--- a/README.md
+++ b/README.md
@@ -130,47 +130,89 @@ git push
 
 If you want to run Robin on your own machine — for hacking on the code, or because you'd rather host on something other than Railway.
 
-### Prerequisites
+Two paths: **Nix** (recommended — one command provisions Postgres+pgvector, Redis, Node, pnpm) or **manual** (bring your own services).
 
-- **Node.js** ≥ 20 (run `corepack enable` to pin pnpm via the `packageManager` field)
-- **PostgreSQL** with the [pgvector](https://github.com/pgvector/pgvector) extension
-- **Redis** — used by BullMQ for the job queue
-- **An OpenRouter API key** — Robin uses Claude via OpenRouter for the AI pipeline. Get one at [openrouter.ai/keys](https://openrouter.ai/keys).
-
-### From clone to running
+### Env file setup (both paths)
 
 ```bash
-# Clone and install
-git clone https://github.com/withrobinhq/robinwiki.git
-cd robinwiki
-corepack enable
-pnpm install
-
-# Copy the env template
 cp core/.env.example core/.env
+cp wiki/.env.example wiki/.env
 ```
 
-Generate three random secrets and paste them into `core/.env`:
+Generate the five required secrets and paste each into the matching variable in `core/.env`:
 
 ```bash
-openssl rand -hex 32   # paste into MASTER_KEY (must be 64 hex chars)
-openssl rand -hex 32   # paste into BETTER_AUTH_SECRET
-openssl rand -hex 32   # paste into KEY_ENCRYPTION_SECRET
+for K in BETTER_AUTH_SECRET MASTER_KEY KEY_ENCRYPTION_SECRET RECOVERY_SECRET JOB_SIGNING_SECRET; do
+  echo "$K=$(openssl rand -hex 32)"
+done
 ```
 
-Then fill in the rest of `core/.env`:
+Then fill in the user-supplied values in `core/.env`:
 
 ```env
-DATABASE_URL=postgresql://postgres@127.0.0.1:5432/robinwiki
-REDIS_URL=redis://localhost:6379
 OPENROUTER_API_KEY=sk-or-v1-...
 INITIAL_USERNAME=you@example.com
 INITIAL_PASSWORD=something-you-can-remember
 ```
 
-Bootstrap the database and start the dev servers:
+`DATABASE_URL`, `REDIS_URL`, `SERVER_PUBLIC_URL`, `WIKI_ORIGIN`, and `PORT` already have correct local defaults.
+
+### Path A — Nix (recommended)
+
+The repo ships a `flake.nix` that provisions Postgres 16 (with pgvector), Redis, Node 22, and pnpm — fully isolated from anything on your system.
+
+1. **Install Nix.** The [Determinate Systems installer](https://install.determinate.systems/) enables flakes by default and includes an uninstaller:
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+   Restart your shell after.
+
+2. **Enter the dev shell.** From the repo root:
+   ```bash
+   nix develop
+   pnpm install
+   ```
+   First run takes 5–15 min to fetch and build the toolchain; subsequent shells are instant.
+
+3. **Boot infra and apps.** Inside the shell:
+   ```bash
+   init        # postgres + redis (data lives in ./.dev/)
+   start       # builds workspace packages, then launches core (:3000) + wiki (:8080)
+   status      # health check
+   logs [postgres|redis|core|wiki]
+   stop        # stop core + wiki, keep infra running
+   teardown    # stop everything
+   ```
+
+**Port conflicts:** if you already run Postgres locally (Postgres.app, Homebrew, Docker, etc.), `init` will refuse to start. Pick a free port and tell the flake about it before re-running:
 
 ```bash
+export ROBIN_PG_PORT=5433
+# update DATABASE_URL in core/.env to match: postgresql://postgres@127.0.0.1:5433/robinwiki
+init
+```
+
+### Path B — Manual
+
+Bring your own services.
+
+**Prerequisites:**
+
+- **Node.js** ≥ 20 (run `corepack enable` to pin pnpm via the `packageManager` field)
+- **PostgreSQL** with the [pgvector](https://github.com/pgvector/pgvector) extension
+- **Redis** — used by BullMQ for the job queue
+- **An OpenRouter API key** — get one at [openrouter.ai/keys](https://openrouter.ai/keys)
+
+**From clone to running:**
+
+```bash
+git clone https://github.com/withrobinhq/robinwiki.git
+cd robinwiki
+corepack enable
+pnpm install
+
+# After completing env file setup above:
+
 # Make sure pgvector is enabled on your database
 psql $DATABASE_URL -c 'CREATE EXTENSION IF NOT EXISTS vector;'
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,13 @@
             ROBIN_DEV_DIR="''${ROBIN_DEV_DIR:-.dev}"
             PROJECT_ROOT="''${PROJECT_ROOT:-$PWD}"
 
-            # Postgres port — defaults to 5432. Override with ROBIN_PG_PORT when the
+            # Postgres port, defaults to 5432. Override with PG_PORT when the
             # system already has something on 5432 (Postgres.app, Homebrew, Docker, etc.).
-            # PGPORT is libpq's standard env var, so psql/createdb/pg_isready inherit it.
-            ROBIN_PG_PORT="''${ROBIN_PG_PORT:-5432}"
-            export PGPORT="$ROBIN_PG_PORT"
+            # PGPORT is libpq's standard env var; we mirror PG_PORT into it so
+            # psql, createdb, and pg_isready inherit the same value without
+            # any further wiring.
+            PG_PORT="''${PG_PORT:-5432}"
+            export PGPORT="$PG_PORT"
 
             PG_DATA="$ROBIN_DEV_DIR/postgres/data"
             PG_SOCKET="$ROBIN_DEV_DIR/postgres/socket"
@@ -158,7 +160,7 @@
               echo "postgres: already running (pid $(cat "$PG_PID"))"
             else
               rm -f "$PG_PID"
-              preflight_port "postgres" "$ROBIN_PG_PORT"
+              preflight_port "postgres" "$PG_PORT"
 
               if [ ! -f "$PG_DATA/PG_VERSION" ]; then
                 echo "postgres: initializing data directory..."
@@ -172,7 +174,7 @@
 
                 cat >> "$PG_DATA/postgresql.conf" <<-PGCONF
 				listen_addresses = '127.0.0.1'
-				port = $ROBIN_PG_PORT
+				port = $PG_PORT
 				unix_socket_directories = '$PG_SOCKET'
 				log_destination = 'stderr'
 				logging_collector = off
@@ -184,10 +186,10 @@
                 -D "$PG_DATA" \
                 -l "$PG_LOG" \
                 -w \
-                -o "-k $PG_SOCKET"
+                -o "-k $PG_SOCKET -p $PG_PORT"
 
               head -1 "$PG_DATA/postmaster.pid" > "$PG_PID"
-              verify_spawn "postgres" "$PG_PID" "$ROBIN_PG_PORT" "$PG_LOG" 5
+              verify_spawn "postgres" "$PG_PID" "$PG_PORT" "$PG_LOG" 5
 
               if ! ${postgres}/bin/psql -h 127.0.0.1 -U postgres -lqt 2>/dev/null | grep -qw robinwiki; then
                 echo "postgres: creating database robinwiki..."
@@ -243,8 +245,8 @@
             mkdir -p "$ROBIN_DEV_DIR/core" "$ROBIN_DEV_DIR/wiki"
 
             # ── Preflight: infra must be up ────────────────────────
-            if ! ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$ROBIN_PG_PORT" -U postgres -q 2>/dev/null; then
-              echo "ERROR: postgres is not accepting connections on :$ROBIN_PG_PORT"
+            if ! ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$PG_PORT" -U postgres -q 2>/dev/null; then
+              echo "ERROR: postgres is not accepting connections on :$PG_PORT"
               echo "  run 'init' first to bring up postgres + redis"
               exit 1
             fi
@@ -358,7 +360,7 @@
             WIKI_PID="$ROBIN_DEV_DIR/wiki/wiki.pid"
 
             if [ -f "$PG_PID" ] && kill -0 "$(cat "$PG_PID")" 2>/dev/null; then
-              if ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$ROBIN_PG_PORT" -U postgres -q 2>/dev/null; then
+              if ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$PG_PORT" -U postgres -q 2>/dev/null; then
                 echo "postgres: UP (pid $(cat "$PG_PID"), accepting connections)"
               else
                 echo "postgres: UP (pid $(cat "$PG_PID"), NOT accepting connections)"

--- a/flake.nix
+++ b/flake.nix
@@ -254,6 +254,20 @@
               exit 1
             fi
 
+            # ── Workspace packages ─────────────────────────────────
+            # core imports compiled @robin/queue, @robin/agent, etc. from each
+            # package's dist/. Without this, first-run start fails with a cryptic
+            # ERR_MODULE_NOT_FOUND on @robin/queue/dist/index.mjs. Turbo caches,
+            # so subsequent runs are near-instant.
+            PACKAGES_LOG="$ROBIN_DEV_DIR/packages.log"
+            echo "packages: building..."
+            if ! (cd "$PROJECT_ROOT" && pnpm exec turbo run build --filter='./packages/*') > "$PACKAGES_LOG" 2>&1; then
+              echo "ERROR: workspace package build failed"
+              tail -20 "$PACKAGES_LOG" | sed 's#^#  packages log: #'
+              exit 1
+            fi
+            echo "packages: ready"
+
             # ── Core (Robin API server) ────────────────────────────
             if [ -f "$CORE_PID" ] && kill -0 "$(cat "$CORE_PID")" 2>/dev/null; then
               echo "core:     already running (pid $(cat "$CORE_PID"))"

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,12 @@
             ROBIN_DEV_DIR="''${ROBIN_DEV_DIR:-.dev}"
             PROJECT_ROOT="''${PROJECT_ROOT:-$PWD}"
 
+            # Postgres port — defaults to 5432. Override with ROBIN_PG_PORT when the
+            # system already has something on 5432 (Postgres.app, Homebrew, Docker, etc.).
+            # PGPORT is libpq's standard env var, so psql/createdb/pg_isready inherit it.
+            ROBIN_PG_PORT="''${ROBIN_PG_PORT:-5432}"
+            export PGPORT="$ROBIN_PG_PORT"
+
             PG_DATA="$ROBIN_DEV_DIR/postgres/data"
             PG_SOCKET="$ROBIN_DEV_DIR/postgres/socket"
             PG_LOG="$ROBIN_DEV_DIR/postgres/postgres.log"
@@ -152,7 +158,7 @@
               echo "postgres: already running (pid $(cat "$PG_PID"))"
             else
               rm -f "$PG_PID"
-              preflight_port "postgres" 5432
+              preflight_port "postgres" "$ROBIN_PG_PORT"
 
               if [ ! -f "$PG_DATA/PG_VERSION" ]; then
                 echo "postgres: initializing data directory..."
@@ -166,7 +172,7 @@
 
                 cat >> "$PG_DATA/postgresql.conf" <<-PGCONF
 				listen_addresses = '127.0.0.1'
-				port = 5432
+				port = $ROBIN_PG_PORT
 				unix_socket_directories = '$PG_SOCKET'
 				log_destination = 'stderr'
 				logging_collector = off
@@ -181,7 +187,7 @@
                 -o "-k $PG_SOCKET"
 
               head -1 "$PG_DATA/postmaster.pid" > "$PG_PID"
-              verify_spawn "postgres" "$PG_PID" 5432 "$PG_LOG" 5
+              verify_spawn "postgres" "$PG_PID" "$ROBIN_PG_PORT" "$PG_LOG" 5
 
               if ! ${postgres}/bin/psql -h 127.0.0.1 -U postgres -lqt 2>/dev/null | grep -qw robinwiki; then
                 echo "postgres: creating database robinwiki..."
@@ -237,8 +243,8 @@
             mkdir -p "$ROBIN_DEV_DIR/core" "$ROBIN_DEV_DIR/wiki"
 
             # ── Preflight: infra must be up ────────────────────────
-            if ! ${postgres}/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q 2>/dev/null; then
-              echo "ERROR: postgres is not accepting connections on :5432"
+            if ! ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$ROBIN_PG_PORT" -U postgres -q 2>/dev/null; then
+              echo "ERROR: postgres is not accepting connections on :$ROBIN_PG_PORT"
               echo "  run 'init' first to bring up postgres + redis"
               exit 1
             fi
@@ -338,7 +344,7 @@
             WIKI_PID="$ROBIN_DEV_DIR/wiki/wiki.pid"
 
             if [ -f "$PG_PID" ] && kill -0 "$(cat "$PG_PID")" 2>/dev/null; then
-              if ${postgres}/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q 2>/dev/null; then
+              if ${postgres}/bin/pg_isready -h 127.0.0.1 -p "$ROBIN_PG_PORT" -U postgres -q 2>/dev/null; then
                 echo "postgres: UP (pid $(cat "$PG_PID"), accepting connections)"
               else
                 echo "postgres: UP (pid $(cat "$PG_PID"), NOT accepting connections)"


### PR DESCRIPTION
## Summary

Three small fixes that came out of getting a fresh contributor running locally for the first time:

- **Configurable Postgres port** in the dev flake via `ROBIN_PG_PORT` (default `5432`, no behavior change without conflict). Previously `init` failed with `port :5432 already held` for anyone with a pre-existing local Postgres (Postgres.app, Homebrew, Docker, etc.). The value exports as `PGPORT` so `psql`, `createdb`, and `pg_isready` all pick it up, and is written into `postgresql.conf` so the server binds it.
- **Build workspace packages inside `start`** before launching core. Without this, first-run `start` failed with a cryptic `ERR_MODULE_NOT_FOUND: @robin/queue/dist/index.mjs` because core imports compiled package output. Turbo caches results, so subsequent starts stay fast. Build output goes to `.dev/packages.log`; on failure the tail inlines for fast diagnosis.
- **README Local Setup rewrite.** The old section was missing two required secrets (`RECOVERY_SECRET`, `JOB_SIGNING_SECRET`) — env validation fails on boot without them. It also didn't mention `flake.nix` at all, despite the flake being the lowest-friction path. Restructured into shared env setup + two paths (Nix recommended, manual preserved), and documented `ROBIN_PG_PORT` for the port-conflict case.

## Test plan

- [ ] Fresh `nix develop` shell on a machine with no prior Postgres: `pnpm install`, `init`, `start` — both services come up at 3000 / 8080
- [ ] On a machine with Postgres already on 5432: `export ROBIN_PG_PORT=5433`, update `DATABASE_URL` in `core/.env` to match, `init` succeeds without collision
- [ ] Cold turbo cache: `start` runs the package build, prints `packages: ready`, then launches core successfully
- [ ] Manual (non-Nix) path still works for users bringing their own Postgres + Redis

No changes to runtime behavior outside the dev flake. Production deploys (Railway) are untouched.