### PR TITLE
chore(governance): add CODEOWNERS with @koolamusic as default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS for Robin
+#
+# Reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Pattern matching follows .gitignore-style globs, BUT the LAST matching rule
+# wins (opposite of .gitignore). Add more specific rules below the default.
+#
+# To enforce: Settings, Branches, branch protection rule on `main`, tick
+# "Require review from Code Owners".
+
+# Default owner for everything in the repo.
+*                       @koolamusic
+
+# Apps
+/core/                  @koolamusic
+/wiki/                  @koolamusic
+
+# Workspace packages. Catch-all for now; split per-package when reviewers
+# come on board for specific areas.
+/packages/              @koolamusic
+
+# Governance and CI surface stays with the maintainer regardless of any
+# future per-package delegation.
+/.github/               @koolamusic
+/LICENSE                @koolamusic
+/CODE_OF_CONDUCT.md     @koolamusic


### PR DESCRIPTION
## Summary

Adds \`.github/CODEOWNERS\` so future PRs auto-request review from the right person per touched area. Default owner is @koolamusic across the board; structure leaves room to delegate per-area reviewers (e.g. \`/wiki/\` to a frontend reviewer, \`/core/src/mcp/\` to a protocol reviewer) without rewriting anything.

## Activation

CODEOWNERS auto-requests review the moment this PR merges. To actually *gate* merge on a code owner approval, tick "Require review from Code Owners" on the \`main\` branch protection rule, Settings, Branches.

## Test plan

- [ ] After merge, open a small follow-up PR touching any file and confirm @koolamusic is auto-added as a reviewer
- [ ] Check Settings, Code security, Branch rules for any CODEOWNERS syntax errors (none expected, no team handles used)