### PR TITLE
fix(wiki): add 'Start from default' to wiki settings textareas

### DIFF
--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -664,7 +664,21 @@ export default function AddWikiModal({
               {wikiStructureEdited
                 ? "Custom format overrides the type's default structure at regen time."
                 : activeTypeDefaultStructure
-                  ? "Showing the type default. Type to override."
+                  ? <>
+                      Showing the type default.{" "}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setWikiStructure(activeTypeDefaultStructure);
+                          setWikiStructureEdited(true);
+                        }}
+                        disabled={locked}
+                        className="text-[11px] leading-4 underline disabled:opacity-50"
+                        style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked ? "default" : "pointer" }}
+                      >
+                        Start from default
+                      </button>
+                    </>
                   : "Empty, uses the wiki type's default structure."}
             </span>
           </div>
@@ -806,7 +820,21 @@ export default function AddWikiModal({
               {wikiPromptEdited
                 ? "Custom style overrides the type's tone and voice at regen time."
                 : activeTypeDefaultSystemMessage
-                  ? "Showing the type's tone and voice. Type to override."
+                  ? <>
+                      Showing the type&apos;s tone and voice.{" "}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setWikiPrompt(activeTypeDefaultSystemMessage);
+                          setWikiPromptEdited(true);
+                        }}
+                        disabled={locked}
+                        className="text-[11px] leading-4 underline disabled:opacity-50"
+                        style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked ? "default" : "pointer" }}
+                      >
+                        Start from default
+                      </button>
+                    </>
                   : "Empty, uses the wiki type's tone and voice."}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- Add a "Start from default" button to Document Format and Wiki Style textareas in the wiki settings modal
- Seeds the field with the type default so operators can edit incrementally
- Button only appears when the field is empty and a default exists

## Test plan

- [ ] Button appears when textarea is empty and type has a default
- [ ] Clicking seeds the field with the default text
- [ ] Button disappears after seeding (field is now non-empty)
- [ ] "Revert to default" still clears the field back to placeholder mode

Closes #390