### PR TITLE
fix(regen): derive citations server-side from inline tokens

### DIFF
--- a/core/src/lib/citations-from-markdown.ts
+++ b/core/src/lib/citations-from-markdown.ts
@@ -1,0 +1,117 @@
+/**
+ * Server-side citation derivation from inline [[fragment:slug]] tokens.
+ *
+ * Walks the wiki markdown, tracks the current heading anchor, and collects
+ * every [[fragment:slug]] token grouped by the section it appears in.
+ * Resolves slugs to fragment lookupKeys via a caller-supplied map, then
+ * returns WikiCitationDeclaration[] matching the shape stored in
+ * wikis.citationDeclarations.
+ *
+ * The heading slugification replicates core/src/lib/wikiSidecar.ts and
+ * wiki/src/lib/sectionEdit.ts exactly so anchors are consistent across
+ * the server read path and the frontend renderer.
+ */
+
+import type { WikiCitationDeclaration } from '@robin/shared/schemas/sidecar'
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/
+const FRAGMENT_TOKEN_RE = /\[\[fragment:([a-z0-9-]+)\]\]/g
+
+/**
+ * Slugify a heading string identically to wikiSidecar.ts and sectionEdit.ts:
+ * lowercase, replace non-alphanumeric runs with hyphens, trim leading/trailing hyphens.
+ */
+function slugifyHeading(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export interface FragmentSlugMap {
+  /** Map from fragment slug to fragment lookupKey. */
+  slugToKey: Map<string, string>
+  /** Map from fragment lookupKey to itself (identity, for lookupKey-shaped references). */
+  keySet: Set<string>
+}
+
+/**
+ * Derive citation declarations by walking the markdown body.
+ *
+ * Scans for ATX headings (building disambiguated anchors) and collects
+ * [[fragment:slug]] tokens under each heading. Tokens appearing before the
+ * first heading are grouped under a synthetic `_preamble` anchor that will
+ * not match any real section; buildSidecar's attachCitations silently
+ * drops unmatched anchors, so preamble citations are harmless.
+ *
+ * The `fragmentMap` resolves slug strings (and, as a fallback, lookupKey
+ * strings) to the canonical lookupKey stored in citationDeclarations.
+ * This handles both slug-referenced tokens (the normal case) and
+ * lookupKey-shaped references from older wikis.
+ */
+export function deriveCitationDeclarations(
+  markdown: string,
+  fragmentMap: FragmentSlugMap
+): WikiCitationDeclaration[] {
+  const lines = markdown.split('\n')
+  const anchorCount = new Map<string, number>()
+
+  // Current section anchor. Tokens before the first heading land here.
+  let currentAnchor = '_preamble'
+
+  // Accumulator: anchor -> ordered unique fragmentIds (lookupKeys)
+  const sectionFragments = new Map<string, string[]>()
+  const sectionFragmentSeen = new Map<string, Set<string>>()
+
+  for (const line of lines) {
+    // Check for heading
+    const headingMatch = line.match(HEADING_RE)
+    if (headingMatch) {
+      const heading = headingMatch[2].trim()
+      const base = slugifyHeading(heading)
+      if (base) {
+        const prev = anchorCount.get(base) ?? 0
+        anchorCount.set(base, prev + 1)
+        currentAnchor = prev === 0 ? base : `${base}-${prev}`
+      }
+    }
+
+    // Collect fragment tokens from this line
+    for (const match of line.matchAll(FRAGMENT_TOKEN_RE)) {
+      const slug = match[1]
+
+      // Resolve slug to lookupKey. Try slug map first, then check if
+      // the token itself is a lookupKey (older wikis may reference by key).
+      let lookupKey = fragmentMap.slugToKey.get(slug)
+      if (!lookupKey && fragmentMap.keySet.has(slug)) {
+        lookupKey = slug
+      }
+      if (!lookupKey) continue
+
+      // Add to section, preserving order and deduplicating
+      let list = sectionFragments.get(currentAnchor)
+      let seen = sectionFragmentSeen.get(currentAnchor)
+      if (!list || !seen) {
+        list = []
+        seen = new Set()
+        sectionFragments.set(currentAnchor, list)
+        sectionFragmentSeen.set(currentAnchor, seen)
+      }
+      if (!seen.has(lookupKey)) {
+        seen.add(lookupKey)
+        list.push(lookupKey)
+      }
+    }
+  }
+
+  // Build the declarations array, skipping the synthetic preamble anchor
+  // and sections with no fragment references.
+  const declarations: WikiCitationDeclaration[] = []
+  for (const [anchor, fragmentIds] of sectionFragments) {
+    if (anchor === '_preamble') continue
+    if (fragmentIds.length === 0) continue
+    declarations.push({ sectionAnchor: anchor, fragmentIds })
+  }
+
+  return declarations
+}

--- a/core/src/lib/regen.ts
+++ b/core/src/lib/regen.ts
@@ -48,6 +48,7 @@ import {
   resolveRetrievalIndexModel,
 } from './wiki-agent-schema.js'
 import { emitUsageEvent } from '../db/usage-events.js'
+import { deriveCitationDeclarations, type FragmentSlugMap } from './citations-from-markdown.js'
 
 const log = logger.child({ component: 'regen' })
 
@@ -621,6 +622,12 @@ export async function regenerateWiki(
   let fragmentCount = 0
   let triggeringFragments: TriggeringFragments | undefined
   let skipped = false
+  // Slug-to-lookupKey map for server-side citation derivation. Populated
+  // inside the fragment-gather block, consumed after the LLM call.
+  const fragmentSlugMap: FragmentSlugMap = {
+    slugToKey: new Map(),
+    keySet: new Set(),
+  }
 
   if (fragmentKeys.length > 0 || removedRows.length > 0) {
     // Hydrate the live fragments. The fragments table carries updated_at,
@@ -638,6 +645,12 @@ export async function regenerateWiki(
           .from(fragments)
           .where(and(inArray(fragments.lookupKey, fragmentKeys), isNull(fragments.deletedAt)))
       : []
+
+    // Build slug-to-lookupKey map for citation derivation after the LLM call.
+    for (const f of fragRows) {
+      fragmentSlugMap.slugToKey.set(f.slug, f.lookupKey)
+      fragmentSlugMap.keySet.add(f.lookupKey)
+    }
 
     // Partition into NEW / UPDATED / INTEGRATED. INTEGRATED is physically
     // absent from the prompt — it's the architectural enforcement of the
@@ -939,7 +952,13 @@ export async function regenerateWiki(
   const llmMs = performance.now() - tLlm0
   const markdown = llmOutput.markdown
   const llmInfobox: WikiInfobox | null = llmOutput.infobox ?? null
-  const llmCitations: WikiCitationDeclaration[] = llmOutput.citations ?? []
+
+  // Derive citation declarations from inline [[fragment:slug]] tokens rather
+  // than relying on the LLM's structured citations field (emitted ~85% of
+  // the time). The walker parses the markdown, groups tokens by heading
+  // anchor, and resolves slugs to lookupKeys. This guarantees every wiki
+  // gets a populated bibliography and sequential inline numbering.
+  const derivedCitations = deriveCitationDeclarations(markdown, fragmentSlugMap)
 
   // Merge LLM-emitted infobox into wikis.metadata (preserving any other
   // structured sidecar fields we may bundle into metadata in the future).
@@ -964,7 +983,7 @@ export async function regenerateWiki(
     .set({
       content: markdown,
       metadata: mergedMetadata,
-      citationDeclarations: llmCitations,
+      citationDeclarations: derivedCitations,
       dirtySince: null,
       lastRebuiltAt: partitionNow,
       lastRegenAt: completedAt,

--- a/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
+++ b/packages/shared/src/__tests__/prompts/wiki-generation-specs.test.ts
@@ -98,7 +98,6 @@ describe('wiki-types specs', () => {
         const result = loadWikiGenerationSpec(type, wikiFixtures)
         expect(result.user).toContain('[LINKING SYNTAX — USE EXACTLY]')
         expect(result.user).toContain('[INFOBOX]')
-        expect(result.user).toContain('[CITATIONS — PER SECTION, STRUCTURED FIELD]')
       })
     })
   }

--- a/packages/shared/src/prompts/specs/wiki-types/agent.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/agent.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Agent"
 display_description: "Documentation for a configured AI assistant's purpose, behavior, and capabilities"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/belief.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/belief.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Belief"
 display_description: "A synthesis of a held position, mental model, or worldview with supporting evidence"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/decision.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/decision.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Decision"
 display_description: "A record of a discrete choice, its context, alternatives considered, and reasoning"
@@ -103,7 +103,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -126,42 +126,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/log.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/log.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Log"
 display_description: "A chronological synthesis of events, observations, and activities over time"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/objective.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/objective.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Objective"
 display_description: "A high-level objective with measurable milestones and progress tracking"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/principle.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/principle.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Principle"
 display_description: "A document of an operating rule, value, or commitment that guides behavior"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/project.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/project.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Project"
 display_description: "A living document tracking an active initiative, its goals, progress, and status"
@@ -106,7 +106,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -129,42 +129,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/research.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/research.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Research"
 display_description: "A curated library of references, sources, and findings on a topic"
@@ -97,7 +97,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -120,42 +120,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/skill.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/skill.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Skill"
 display_description: "A knowledge base documenting a capability being developed or maintained"
@@ -105,7 +105,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -128,42 +128,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:

--- a/packages/shared/src/prompts/specs/wiki-types/voice.yaml
+++ b/packages/shared/src/prompts/specs/wiki-types/voice.yaml
@@ -1,5 +1,5 @@
 name: QuillTheWriter
-version: 6
+version: 7
 category: generation
 display_label: "Voice"
 display_description: "A style guide capturing communication patterns, tone preferences, and voice identity"
@@ -100,7 +100,7 @@ template: |
      contradicts the structure.
   3. Write claims, not citations. Each sentence should state something
      directly. Fragment tokens [[fragment:<slug>]] follow the claim as
-     trailing citations (see Rule 13). Never write 'the fragments suggest
+     trailing citations (see Rule 12). Never write 'the fragments suggest
      X' or 'the inputs indicate Y' — just write X or Y. If the inputs are
      too thin to assert, write 'No clear position emerges yet' or 'Limited
      evidence so far' rather than 'The fragments do not address this.'
@@ -123,42 +123,20 @@ template: |
       chip, list item, or inline mention in the markdown body. The
       sidecar renderer surfaces these values; restating them creates
       visual duplication.
-  11. Emit citations as a structured field (see [CITATIONS]); never add
-      inline [^cite:...] markers in the markdown.
-  12. Typography — never emit straight ASCII double-quote characters
+  11. Typography — never emit straight ASCII double-quote characters
       (the U+0022 "). For prose, replace them with single quotes ('like
       this') or italics (*like this*). When the body contains HTML or
       embedded markup with attribute values, use curly quotes (“…”)
       or the &quot; entity so attribute round-trip stays safe. This rule
       keeps the renderer's smart-quote pairing from colliding with raw
       quotes in user-edit content.
-  13. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
+  12. Fragment tokens (\`[[fragment:slug]]\`) are TRAILING CITATIONS, not
       subjects or named attributions.
       - RIGHT: "claim sentence. [[fragment:slug]]"
       - WRONG: "[[fragment:slug]] points to..."
       - WRONG: "as noted in [[fragment:slug]], ..."
       Never use a fragment token as a grammatical subject or object. Always
       place it after the claim it supports, as a trailing reference.
-
-  [CITATIONS — PER SECTION, STRUCTURED FIELD]
-  In the 'citations' output field, declare which fragments back each
-  section you wrote. Use the section's slugified heading as
-  sectionAnchor. List only fragment ids actually used to ground
-  claims in that section. Do NOT insert citation markers anywhere
-  in the markdown body.
-
-  Example output:
-    citations: [
-      { sectionAnchor: "progress", fragmentIds: ["library-and-librarian-as-the-real-breakthrough", "betting-on-specialists-who-redefine-scope"] },
-      { sectionAnchor: "blockers", fragmentIds: ["friction-in-the-handoff-loop"] }
-    ]
-
-  Rules:
-  - fragmentIds MUST be drawn from the fragment inputs. Do not invent.
-  - sectionAnchor MUST correspond to a heading you wrote. Slugify
-    by lowercasing, trimming, and replacing spaces/punctuation with hyphens.
-  - Omit a section from citations if no fragment grounds it.
-  - Do NOT add inline [^cite:...] markers in the markdown.
 
   [INFOBOX]
   Emit an infobox with these rows when the fragments support them:


### PR DESCRIPTION
## Summary

- Add server-side markdown walker that derives `citationDeclarations` from inline `[[fragment:slug]]` tokens
- Remove the `[CITATIONS — PER SECTION, STRUCTURED FIELD]` prompt block from all 10 wiki-type YAMLs
- Wire the walker into the regen pipeline so every wiki gets a populated bibliography

Fixes the ~15% of wikis that rendered without citations because the LLM skipped the structured field.

## Test plan

- [ ] Regenerate a wiki and verify `citationDeclarations` is populated from inline tokens
- [ ] Bibliography section renders on every wiki
- [ ] Inline `[N]` numbering is sequential and matches the bibliography
- [ ] Heading anchors in derived citations match the frontend's slugification

Closes #387