### PR TITLE
fix(regen): allow lock acquisition from RESOLVED state

### DIFF
--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -44,7 +44,7 @@ export async function processRegenJob(job: RegenJob): Promise<JobResult> {
       await wikiRegenLock.using(
         {
           key: job.objectKey,
-          fromState: 'PENDING',
+          fromState: ['PENDING', 'RESOLVED'],
           toState: 'LINKING',
           successState: 'RESOLVED',
           failureState: 'PENDING',

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -730,7 +730,7 @@ wikisRouter.post('/:id/regenerate', async (c) => {
     await wikiRegenLock.using(
       {
         key: id,
-        fromState: 'PENDING',
+        fromState: ['PENDING', 'RESOLVED'],
         toState: 'LINKING',
         successState: 'RESOLVED',
         failureState: 'PENDING',

--- a/packages/caslock/src/cas-lock.ts
+++ b/packages/caslock/src/cas-lock.ts
@@ -16,7 +16,7 @@ export interface CasLockConfig<TTable extends PgTable> {
 
 export interface AcquireParams {
   key: string
-  fromState: string
+  fromState: string | string[]
   toState: string
   lockedBy: string
 }
@@ -74,6 +74,13 @@ export class CasLock<
   async acquire(params: AcquireParams): Promise<LockedRow<TRow> | null> {
     const { key, fromState, toState, lockedBy } = params
 
+    // Build the fromState predicate: single value uses =, array uses IN (...)
+    const states = Array.isArray(fromState) ? fromState : [fromState]
+    const fromStatePredicate =
+      states.length === 1
+        ? sql`${this.table}.${this.stateId} = ${states[0]}`
+        : sql`${this.table}.${this.stateId} IN (${sql.join(states.map(s => sql`${s}`), sql`, `)})`
+
     let result: unknown
     try {
       result = await this.db.execute(
@@ -86,7 +93,7 @@ export class CasLock<
                   FROM ${this.table}
                   WHERE ${this.keyId} = ${key}) AS old
             WHERE ${this.table}.${this.keyId} = ${key}
-              AND (${this.table}.${this.stateId} = ${fromState}
+              AND (${fromStatePredicate}
                    OR (${this.table}.${this.stateId} = ${toState}
                        AND ${this.table}.${this.lockedAtId} < NOW() - INTERVAL ${this.ttlInterval}))
             RETURNING ${this.table}.*, old.${PREV_ID}`

--- a/packages/caslock/src/events.ts
+++ b/packages/caslock/src/events.ts
@@ -13,7 +13,7 @@ export type CasLockEventName = (typeof CasLockEvents)[keyof typeof CasLockEvents
 export interface AcquiredEvent {
   key: string
   lockedBy: string
-  fromState: string
+  fromState: string | string[]
   toState: string
 }
 
@@ -25,7 +25,7 @@ export interface StolenEvent {
 
 export interface ContendedEvent {
   key: string
-  fromState: string
+  fromState: string | string[]
 }
 
 export interface ReleasedEvent {


### PR DESCRIPTION
## Summary

- `CasLock.fromState` now accepts a string or array of strings
- HTTP regen route and worker both accept `['PENDING', 'RESOLVED']`
- Wikis can be regenerated multiple times via the UI

Regression from #385: `successState: 'RESOLVED'` left wikis permanently locked out since the CAS required `fromState: 'PENDING'`.

## Test plan

- [ ] Regen a wiki via POST, verify 200
- [ ] Regen the same wiki again, verify 200 (not 409)
- [ ] Concurrent regens still produce one 200 + one 409

Closes #386