### PR TITLE
fix(queue): evict completed/failed jobs before regen enqueue

### DIFF
--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -240,7 +240,19 @@ export class BullMQProducer implements QueueProducer {
     // Use wiki key as jobId for deduplication — BullMQ's add() returns the
     // existing job for ANY retained state (waiting, active, completed, failed),
     // so rapid fragment links to the same wiki only produce one regen job.
+    // This correctly collapses rapid-fire enqueues from fragment-attach storms
+    // (waiting/active), but completed/failed jobs must be evicted first or
+    // every wiki becomes permanently un-re-gennable after its first regen.
     const dedupeId = `regen-${job.objectKey}`
+
+    const existing = await queue.getJob(dedupeId)
+    if (existing) {
+      const state = await existing.getState()
+      if (state === 'completed' || state === 'failed') {
+        await existing.remove()
+      }
+    }
+
     const bullJob = await queue.add('regen', signJob(job), { jobId: dedupeId })
 
     // Manual triggers promote existing waiting jobs to higher priority so


### PR DESCRIPTION
## Summary

- Evict retained `completed`/`failed` BullMQ jobs before `enqueueRegen` so wikis can be regenerated more than once
- Dedup still collapses rapid-fire enqueues during `waiting`/`active` (fragment-attach storms)
- One extra `getJob` roundtrip per enqueue, negligible cost

Without this, every wiki that was ever successfully regenerated is permanently blocked from re-enqueuing because BullMQ's `add()` returns the retained completed job instead of creating a new one. The batch sweep, autoregen, and manual triggers all silently no-op.

## Test plan

- [ ] Regen a wiki, then dirty it (add a fragment), verify auto-regen fires
- [ ] Rapid fragment-attach to the same wiki still collapses to one regen job
- [ ] Manual regen on a previously-regenerated wiki enqueues successfully
- [ ] Queue `completed` count decreases by 1 per re-enqueue (eviction working)