### PR TITLE
fix(wiki): show type default as editable content in settings textareas

### DIFF
--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -646,41 +646,16 @@ export default function AddWikiModal({
               </button>
             </div>
             <Textarea
-              value={wikiStructure}
+              value={wikiStructure || activeTypeDefaultStructure}
               onChange={(e) => {
                 const next = e.target.value;
                 setWikiStructure(next);
                 setWikiStructureEdited(next.trim().length > 0);
               }}
-              placeholder={
-                activeTypeDefaultStructure ||
-                "# Section\n- bullet\n## Another section"
-              }
               rows={6}
               disabled={locked || !wikiType}
               className="min-h-[120px] resize-none font-mono"
             />
-            <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
-              {wikiStructureEdited
-                ? "Custom format overrides the type's default structure at regen time."
-                : activeTypeDefaultStructure
-                  ? <>
-                      Showing the type default.{" "}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setWikiStructure(activeTypeDefaultStructure);
-                          setWikiStructureEdited(true);
-                        }}
-                        disabled={locked}
-                        className="text-[11px] leading-4 underline disabled:opacity-50"
-                        style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked ? "default" : "pointer" }}
-                      >
-                        Start from default
-                      </button>
-                    </>
-                  : "Empty, uses the wiki type's default structure."}
-            </span>
           </div>
 
           {/* Collections — visible in both create and settings mode. In create
@@ -802,41 +777,16 @@ export default function AddWikiModal({
               </button>
             </div>
             <Textarea
-              value={wikiPrompt}
+              value={wikiPrompt || activeTypeDefaultSystemMessage}
               onChange={(e) => {
                 const next = e.target.value;
                 setWikiPrompt(next);
                 setWikiPromptEdited(next.trim().length > 0);
               }}
-              placeholder={
-                activeTypeDefaultSystemMessage ||
-                "Tone, voice, and persona instructions for this wiki."
-              }
               rows={6}
               disabled={locked || !wikiType}
               className="min-h-[120px] resize-none font-mono"
             />
-            <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
-              {wikiPromptEdited
-                ? "Custom style overrides the type's tone and voice at regen time."
-                : activeTypeDefaultSystemMessage
-                  ? <>
-                      Showing the type&apos;s tone and voice.{" "}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setWikiPrompt(activeTypeDefaultSystemMessage);
-                          setWikiPromptEdited(true);
-                        }}
-                        disabled={locked}
-                        className="text-[11px] leading-4 underline disabled:opacity-50"
-                        style={{ color: "var(--wiki-link)", background: "none", border: "none", padding: 0, cursor: locked ? "default" : "pointer" }}
-                      >
-                        Start from default
-                      </button>
-                    </>
-                  : "Empty, uses the wiki type's tone and voice."}
-            </span>
           </div>
 
           {/* Fragment Review Mode toggle -- settings mode only */}


### PR DESCRIPTION
## Summary

- Drop the `placeholder` prop and the inline "Start from default" hint span on the Document Format and Wiki Style textareas
- When the override is empty, the textarea now renders the active type default as its `value` -- making it immediately editable in place
- No two-step flow (no button to click to seed the field); editing the default text is the default interaction
- "Revert to default" button still works -- clears the override, default re-appears via the same fallback path
- Save semantics unchanged: empty `wikiStructure` / `wikiPrompt` still serialises as `""` to the server = "use type default"

## Why

PR #392 added a "Start from default" inline link so operators could seed the field with the active type default, but the link sits in the hint span beneath the textarea and is easy to miss. Operators wanting to evolve the default (tweak one section, add one rule) get a faded shadow they cannot directly edit; clicking the field clears the placeholder, leaving an empty buffer.

This change makes the textarea show the default as actual content the moment the modal opens, so editing the default is the default interaction.

Net change: +2 / -52 in `AddWikiModal.tsx`.

## Test plan

- [ ] Open settings on an unmodified wiki of any built-in type. Document Format and Wiki Style textareas show the type default as actual editable content (not a placeholder).
- [ ] Edit one of them. The change is reflected in the textarea.
- [ ] Save and reopen. The customised value is shown.
- [ ] Click "Revert to default". The textarea clears the override; the default re-appears (via the value fallback).
- [ ] On a brand-new wiki of a type without a default, the textarea renders empty (no fallback to apply).
