### PR TITLE
feat(wiki): shell cleanup — sidebar, home page, read-mode affordances

### DIFF
--- a/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx
@@ -4,7 +4,6 @@ import {
   MarkdownContent,
   type FragmentCitationMap,
 } from "@/components/wiki/MarkdownContent";
-import { WikiCitations } from "@/components/wiki/WikiCitations";
 import { WikiEditLink } from "@/components/wiki/WikiFurniture";
 import {
   parseSectionsFromMarkdown,
@@ -142,9 +141,10 @@ function SectionHeadingWithEdit({
 
 /**
  * Render the markdown body as a sequence of section-scoped
- * `<MarkdownContent>` blocks, each followed by its `<WikiCitations>`
- * superscripts. Preamble before the first heading (if any) renders as
- * an unattributed leading block.
+ * `<MarkdownContent>` blocks. Inline `[N]` superscripts are the only
+ * citation surface; the document-wide bibliography lives at the
+ * article foot via `<WikiCitationsSection>`. Preamble before the first
+ * heading (if any) renders as an unattributed leading block.
  *
  * If the body has no headings, falls back to a single whole-body render.
  *
@@ -219,9 +219,6 @@ export function SectionedMarkdownBody({
     // double-rendering all H2+ content. See module docstring above.
     if (section.level === 1) continue;
 
-    const matched = citationsByAnchor.get(section.anchor);
-    const citations = matched?.citations ?? [];
-
     const canExtractHeading =
       section.level >= 2 && section.level <= 4 && onEditSection !== undefined;
 
@@ -240,9 +237,6 @@ export function SectionedMarkdownBody({
           {bodyOnly.trim().length > 0 && (
             <MarkdownContent content={bodyOnly} refs={refs} style={style} fragmentCitationMap={fragmentCitationMap} />
           )}
-          {citations.length > 0 && (
-            <WikiCitations citations={citations} citationMap={fragmentCitationMap} />
-          )}
         </div>,
       );
       continue;
@@ -253,9 +247,6 @@ export function SectionedMarkdownBody({
     blocks.push(
       <div key={section.anchor} id={section.anchor}>
         <MarkdownContent content={body} refs={refs} style={style} fragmentCitationMap={fragmentCitationMap} />
-        {citations.length > 0 && (
-          <WikiCitations citations={citations} citationMap={fragmentCitationMap} />
-        )}
       </div>,
     );
   }

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -20,7 +20,6 @@ import { getWikiTypeIcon } from "@/components/wiki/WikiTypeBadge";
 import { MarkdownContent } from "@/components/wiki/MarkdownContent";
 import { WikiInfobox } from "@/components/wiki/WikiInfobox";
 import { WikiChip } from "@/components/wiki/WikiChip";
-import { WikiCitations } from "@/components/wiki/WikiCitations";
 import { WikiCitationsSection } from "@/components/wiki/WikiCitationsSection";
 import { WikiEditLink } from "@/components/wiki/WikiFurniture";
 import { MemberFragmentsManagementTable } from "@/components/wiki/MemberFragmentsManagementTable";
@@ -520,32 +519,6 @@ export default function WikiDetailPage() {
                 fragmentCitationMap={htmlFragmentCitationMap}
               />
             </div>
-            {sidecarSections.length > 0 && (
-              <div
-                style={{
-                  marginTop: 16,
-                  paddingTop: 12,
-                  borderTop: "1px solid var(--wiki-card-border)",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 6,
-                }}
-              >
-                {sidecarSections
-                  .filter((section) => (section.citations ?? []).length > 0)
-                  .map((section) => (
-                    <div
-                      key={section.anchor}
-                      style={{ ...bodyStyle, display: "flex", gap: 8, alignItems: "baseline" }}
-                    >
-                      <span style={{ opacity: 0.7 }}>
-                        {section.heading}
-                      </span>
-                      <WikiCitations citations={section.citations ?? []} citationMap={htmlFragmentCitationMap} />
-                    </div>
-                  ))}
-              </div>
-            )}
           </>
         ) : (
           // Markdown body (LLM-emitted): `<MarkdownContent>` owns token
@@ -566,10 +539,6 @@ export default function WikiDetailPage() {
               refs={refs}
               sections={sidecarSections}
               style={bodyStyle}
-              onEditSection={(sectionId) => {
-                setSectionSaveError(null);
-                setEditingSectionId(sectionId);
-              }}
             />
           </div>
         )

--- a/wiki/src/app/(shell)/wiki/page.tsx
+++ b/wiki/src/app/(shell)/wiki/page.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import FeaturedArticle from "@/components/wiki/FeaturedArticle";
-import RecentlyUpdated from "@/components/wiki/RecentlyUpdated";
-import BrowseByType from "@/components/wiki/BrowseByType";
-import WikiFragments from "@/components/wiki/WikiFragments";
 import WikiHomeHero from "@/components/wiki/WikiHomeHero";
+import { CollectionsHome } from "@/components/wiki/CollectionsHome";
 
 export default function WikiArticlePage() {
   return (
@@ -20,16 +17,7 @@ export default function WikiArticlePage() {
           gap: 24,
         }}
       >
-        <div className="wiki-cards-row">
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <FeaturedArticle />
-          </div>
-          <RecentlyUpdated />
-        </div>
-
-        <BrowseByType />
-
-        <WikiFragments />
+        <CollectionsHome />
       </div>
     </div>
   );

--- a/wiki/src/components/layout/Sidebar.tsx
+++ b/wiki/src/components/layout/Sidebar.tsx
@@ -7,8 +7,6 @@ import { T } from "@/lib/typography";
 import { ROUTES } from "@/lib/routes";
 import { useEntries } from "@/hooks/useEntries";
 import { useWikis } from "@/hooks/useWikis";
-import { useCollections } from "@/hooks/useCollections";
-import { useAddWiki } from "@/components/layout/AddWikiContext";
 
 const ACTIVE_COLOR = "#000000";
 const ACTIVE_WEIGHT = 700;
@@ -58,7 +56,6 @@ const navigationData: SidebarSectionData = {
   items: [
     { label: "Main page", arrow: "none", href: ROUTES.home },
     { label: "Explorer", arrow: "none", href: ROUTES.explorer },
-    { label: "Knowledge Graph", arrow: "none", href: ROUTES.graph },
   ],
 };
 
@@ -77,22 +74,6 @@ function useEntriesData(): SidebarSectionData {
   }, [data]);
 
   return { title: "Entries", items, emptyText: "no entries added" };
-}
-
-function useCollectionsData(): SidebarSectionData {
-  const { data } = useCollections();
-  const items = useMemo<NavItem[]>(() => {
-    const collections = data;
-    if (!collections || collections.length === 0) return [];
-    return collections.map((c) => ({
-      label: c.name,
-      arrow: "none" as ArrowState,
-      count: c.wikiCount,
-      href: `${ROUTES.explorer}?collection=${encodeURIComponent(c.id)}`,
-    }));
-  }, [data]);
-
-  return { title: "Collections", items, emptyText: "no collections yet" };
 }
 
 function useContentsData(): SidebarSectionData {
@@ -133,12 +114,14 @@ function SidebarSection({
   section,
   borderColor,
   sectionId,
+  defaultVisible = true,
 }: {
   section: SidebarSectionData;
   borderColor: string;
   sectionId: string;
+  defaultVisible?: boolean;
 }) {
-  const [sectionVisible, setSectionVisible] = useState(true);
+  const [sectionVisible, setSectionVisible] = useState(defaultVisible);
   const pathname = usePathname();
   const isActiveHref = (href?: string) => !!href && pathname === href;
 
@@ -471,46 +454,14 @@ function SidebarSection({
   );
 }
 
-// Sidebar shortcut for opening the Add Wiki modal. The canonical trigger
-// is the Header dropdown (see Header.tsx); this entry just dispatches into
-// the same shared AddWikiContext for users who reach for the sidebar.
-function AddWikiTrigger() {
-  const { openModal } = useAddWiki();
-  return (
-    <div
-      style={{
-        paddingLeft: 44,
-        paddingRight: 16,
-        paddingTop: 8,
-        paddingBottom: 8,
-      }}
-    >
-      <button
-        type="button"
-        onClick={openModal}
-        style={{
-          ...T.bodySmall,
-          lineHeight: "20px",
-          color: "var(--wiki-link)",
-          background: "none",
-          border: "none",
-          padding: 0,
-          margin: 0,
-          cursor: "pointer",
-          font: "inherit",
-          textAlign: "left",
-        }}
-      >
-        + Add Wiki
-      </button>
-    </div>
-  );
-}
-
 export default function Sidebar() {
   const entriesData = useEntriesData();
-  const collectionsData = useCollectionsData();
   const contentsData = useContentsData();
+
+  // Non-navigation sections (Entries, Contents) start collapsed so the
+  // first view is short and undistracted. Users still expand any section
+  // via its [hide]/[show] toggle.
+  const nonNavDefaultVisible = false;
 
   return (
     <nav>
@@ -519,21 +470,17 @@ export default function Sidebar() {
         section={navigationData}
         borderColor="var(--wiki-nav-border)"
       />
-      <AddWikiTrigger />
-      <SidebarSection
-        sectionId="collections"
-        section={collectionsData}
-        borderColor="var(--wiki-nav-border)"
-      />
       <SidebarSection
         sectionId="entries"
         section={entriesData}
         borderColor="var(--wiki-nav-border)"
+        defaultVisible={nonNavDefaultVisible}
       />
       <SidebarSection
         sectionId="types"
         section={contentsData}
         borderColor="var(--wiki-toc-border)"
+        defaultVisible={nonNavDefaultVisible}
       />
     </nav>
   );

--- a/wiki/src/components/wiki/CollectionsHome.tsx
+++ b/wiki/src/components/wiki/CollectionsHome.tsx
@@ -7,6 +7,7 @@ import { ChevronRight } from 'lucide-react';
 import { useCollections } from '@/hooks/useCollections';
 import { ROUTES } from '@/lib/routes';
 import { T } from '@/lib/typography';
+import AddCollectionModal from '@/components/layout/AddCollectionModal';
 
 interface GroupWiki {
   lookupKey: string;
@@ -169,6 +170,7 @@ function CollectionCard({
 
 export function CollectionsHome() {
   const { data: collections, isLoading } = useCollections();
+  const [addCollectionOpen, setAddCollectionOpen] = useState(false);
 
   if (isLoading) {
     return (
@@ -178,11 +180,64 @@ export function CollectionsHome() {
     );
   }
 
+  // Empty state: the home page is organised entirely by collections, so a
+  // workspace that has none has nothing to render. Explain what collections
+  // do and offer a one-click path to create one. AddCollectionModal is the
+  // same modal the header `+ New → Collection` menu opens.
   if (!collections || collections.length === 0) {
     return (
-      <p style={{ ...T.bodySmall, color: 'var(--wiki-count)' }}>
-        No collections yet.
-      </p>
+      <>
+        <section
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: 12,
+            padding: '24px 0',
+          }}
+        >
+          <p
+            style={{
+              ...T.bodySmall,
+              color: 'var(--wiki-article-text)',
+              margin: 0,
+            }}
+          >
+            Add Collections to build your Wiki Homepage.
+          </p>
+          <p
+            style={{
+              ...T.micro,
+              color: 'var(--wiki-count)',
+              margin: 0,
+              maxWidth: 540,
+            }}
+          >
+            Collections group your wikis by theme. Once you create one, the
+            homepage organises every wiki into its collection so you can
+            browse from here.
+          </p>
+          <button
+            type="button"
+            onClick={() => setAddCollectionOpen(true)}
+            style={{
+              ...T.bodySmall,
+              color: 'var(--wiki-link)',
+              background: 'none',
+              border: '1px solid var(--wiki-card-border)',
+              padding: '6px 14px',
+              cursor: 'pointer',
+              font: 'inherit',
+            }}
+          >
+            + Add Collection
+          </button>
+        </section>
+        <AddCollectionModal
+          open={addCollectionOpen}
+          onClose={() => setAddCollectionOpen(false)}
+        />
+      </>
     );
   }
 

--- a/wiki/src/components/wiki/CollectionsHome.tsx
+++ b/wiki/src/components/wiki/CollectionsHome.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight } from 'lucide-react';
+import { useCollections } from '@/hooks/useCollections';
+import { ROUTES } from '@/lib/routes';
+import { T } from '@/lib/typography';
+
+interface GroupWiki {
+  lookupKey: string;
+  slug: string;
+  name: string;
+  type: string;
+  fragmentCount: number;
+}
+
+function CollectionCard({
+  id,
+  name,
+  color,
+  wikiCount,
+}: {
+  id: string;
+  name: string;
+  color: string;
+  wikiCount: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const { data, isLoading } = useQuery({
+    queryKey: ['group-wikis', id],
+    queryFn: async () => {
+      const r = await fetch(`/api/groups/${id}/wikis`, { credentials: 'include' });
+      if (!r.ok) throw new Error('failed');
+      const json = await r.json();
+      const wikis = (json.wikis ?? []) as GroupWiki[];
+      return wikis.sort((a, b) => b.fragmentCount - a.fragmentCount);
+    },
+    enabled: expanded,
+    staleTime: 60_000,
+  });
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--card-border)',
+        borderRadius: 8,
+        background: 'var(--bg)',
+        overflow: 'hidden',
+        transition: 'box-shadow 0.15s ease',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          padding: '14px 18px',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+          borderLeft: `4px solid ${color}`,
+        }}
+      >
+        <ChevronRight
+          size={18}
+          style={{
+            color: 'var(--wiki-count)',
+            transform: expanded ? 'rotate(90deg)' : 'rotate(0)',
+            transition: 'transform 0.15s ease',
+            flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            ...T.h4,
+            color: 'var(--heading-color)',
+            flex: 1,
+            fontWeight: 600,
+          }}
+        >
+          {name}
+        </span>
+        <span
+          style={{
+            ...T.micro,
+            color: 'var(--wiki-count)',
+            background: 'var(--card-border)',
+            padding: '3px 10px',
+            borderRadius: 12,
+            fontWeight: 500,
+          }}
+        >
+          {wikiCount} wiki{wikiCount === 1 ? '' : 's'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div
+          style={{
+            padding: '4px 18px 14px 36px',
+            borderTop: '1px solid var(--card-border)',
+            background: 'var(--bg)',
+          }}
+        >
+          {isLoading && (
+            <p style={{ ...T.bodySmall, color: 'var(--wiki-count)', margin: '10px 0' }}>
+              Loading…
+            </p>
+          )}
+          {!isLoading && data && data.length === 0 && (
+            <p style={{ ...T.bodySmall, color: 'var(--wiki-count)', margin: '10px 0' }}>
+              No wikis in this collection.
+            </p>
+          )}
+          {!isLoading && data && data.length > 0 && (
+            <ul
+              style={{
+                margin: '8px 0 0',
+                padding: 0,
+                listStyle: 'none',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 6,
+              }}
+            >
+              {data.map((w) => (
+                <li key={w.lookupKey}>
+                  <Link
+                    href={ROUTES.wiki(w.lookupKey)}
+                    style={{
+                      ...T.bodySmall,
+                      color: 'var(--wiki-link)',
+                      textDecoration: 'none',
+                      display: 'flex',
+                      alignItems: 'baseline',
+                      gap: 10,
+                      padding: '4px 0',
+                    }}
+                  >
+                    <span style={{ flex: 1 }}>{w.name}</span>
+                    {w.fragmentCount > 0 && (
+                      <span
+                        style={{
+                          ...T.micro,
+                          color: 'var(--wiki-count)',
+                          flexShrink: 0,
+                        }}
+                      >
+                        {w.fragmentCount}
+                      </span>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CollectionsHome() {
+  const { data: collections, isLoading } = useCollections();
+
+  if (isLoading) {
+    return (
+      <p style={{ ...T.bodySmall, color: 'var(--wiki-count)' }}>
+        Loading collections…
+      </p>
+    );
+  }
+
+  if (!collections || collections.length === 0) {
+    return (
+      <p style={{ ...T.bodySmall, color: 'var(--wiki-count)' }}>
+        No collections yet.
+      </p>
+    );
+  }
+
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <h2
+        style={{
+          ...T.h3,
+          color: 'var(--heading-color)',
+          margin: '0 0 8px',
+        }}
+      >
+        Browse by collection
+      </h2>
+      {collections.map((c) => (
+        <CollectionCard
+          key={c.id}
+          id={c.id}
+          name={c.name}
+          color={c.color || 'var(--wiki-link)'}
+          wikiCount={c.wikiCount}
+        />
+      ))}
+    </section>
+  );
+}

--- a/wiki/src/hooks/useWikis.ts
+++ b/wiki/src/hooks/useWikis.ts
@@ -7,7 +7,12 @@ export function useWikis() {
   return useQuery({
     queryKey: ['wikis'],
     queryFn: async () => {
-      const { data } = await listWikis()
+      // Backend default is 50; bump to the schema's effective ceiling so the
+      // sidebar + Browse views surface every wiki in the deployment. The
+      // generated SDK marks `query: never` because the OpenAPI spec omits
+      // the documented `limit/offset/type` params, so the cast is the
+      // minimum-friction workaround until the spec is regenerated.
+      const { data } = await listWikis({ query: { limit: 200 } } as unknown as Parameters<typeof listWikis>[0])
       return data
     },
   })


### PR DESCRIPTION
## Summary

UX cleanup pass across the app shell. No data flow restructure — just removes or replaces affordances that no longer earn their space.

- **Sidebar**: drop `+ Add Wiki`, drop Knowledge Graph nav link, drop Collections section, collapse Entries + Contents by default.
- **Home page**: replace the Featured / Recently Updated / Browse-By-Type / Wiki Fragments card stack with a single `CollectionsHome` browser organised by group membership.
- **Wiki list**: raise the default page size to 200 so deployments larger than a handful surface every wiki.
- **Read mode**: drop per-section `[edit]` links and per-section citation cluster rows.

## Why

### Sidebar
- **`+ Add Wiki`** duplicated the header `+ New` menu one click further away. Two triggers for the same action.
- **Knowledge Graph** link pointed at `/graph`, which isn't wired to anything that ships. Promising a feature the codebase doesn't deliver is worse than not having the link.
- **Collections** section in the sidebar mirrored the same data the home page now organises better (see below). A collapsing list of group names doesn't add navigation reach.
- **Non-nav sections collapsed by default** — the first view is short and undistracted; users still expand any section via its `[hide]/[show]` toggle.

### Home page
The card-stack repeated the same wikis across three surfaces (Featured + Recently Updated + Browse-By-Type), and "Wiki Fragments" was a separate snippet feed not connected to the wikis. The new `CollectionsHome` surfaces each wiki exactly once, organised by the curation the user already did when filing wikis into groups.

### Wiki list cap
The prior default page size was hidden truncation for any workspace with more than a handful of wikis. The sidebar Contents section silently dropped overflow; Explorer paginated but the sidebar didn't. 200 is large enough that real workspaces don't truncate.

### Read-mode affordances
- **Per-section `[edit]` links** — editing now lives at the page level (Edit tab, in the follow-up PR). The per-section affordance was a partially-finished section-scoped edit feature; removing it clears the deck for the page-level Edit work.
- **Per-section citation cluster rows** — each section already has inline `[N]` superscripts, and a document-wide Citations list at the bottom of the body draws from the same data. The per-section cluster was a third surface that duplicated both, adding visual noise without information.

## Files

- `wiki/src/components/layout/Sidebar.tsx`
- `wiki/src/app/(shell)/wiki/page.tsx` — home page
- `wiki/src/components/wiki/CollectionsHome.tsx` — **new file** (217 lines, self-contained)
- `wiki/src/hooks/useWikis.ts` — page size to 200
- `wiki/src/app/(shell)/wiki/[id]/page.tsx` — drop `onEditSection` prop + per-section citation cluster JSX
- `wiki/src/app/(shell)/wiki/[id]/SectionedMarkdownBody.tsx` — drop unused `WikiCitations` reference + tighten JSDoc

## Test plan

- [ ] Sidebar — `+ Add Wiki` is gone; KG link is gone; Collections section is gone; Entries + Contents collapsed by default; toggles still work
- [ ] Home page — renders CollectionsHome (collapsing per-collection list of wikis); no Featured / Recently Updated / BrowseByType / WikiFragments cards
- [ ] A workspace with >10 wikis surfaces all of them in the sidebar Contents section + Explorer
- [ ] Read mode — no `[edit]` bracket next to section headings; no per-section citation cluster row between body and the bottom Citations list; the bottom Citations list still renders
- [ ] Inline `[N]` superscripts still resolve to the right fragment in the bottom Citations list
- [ ] `pnpm --filter @robin/wiki typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
