### PR TITLE
feat(wiki): tabbed sub-pages — Read / Edit / Fragments / History / Settings

### DIFF
--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { Check, LinkIcon, RefreshCw, Trash2 } from "lucide-react";
-import { T } from "@/lib/typography";
+import { T, FONT } from "@/lib/typography";
 import { Spinner } from "@/components/ui/spinner";
 import { useWiki } from "@/hooks/useWiki";
 import { useRegenerateWiki } from "@/hooks/useRegenerateWiki";
@@ -34,7 +34,6 @@ import { useWikiTokenSubstitution } from "@/lib/htmlTokenSubstitute";
 import type { FragmentCitationMap } from "@/components/wiki/MarkdownContent";
 import { sanitizeWikiHtml } from "@/lib/sanitizeWikiHtml";
 import { EditorialStateDot } from "@/components/wiki/EditorialStateDot";
-import WikiRegenTimeline from "@/components/wiki/WikiRegenTimeline";
 import type {
   WikiInfobox as WikiInfoboxData,
   WikiRef,
@@ -168,6 +167,10 @@ export default function WikiDetailPage() {
   const queryClient = useQueryClient();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
+  // Phase 2: Fragments tab edit mode toggle. When false, fragment actions
+  // (un-attach, attach) and Regenerate are hidden. Mirrors the view-to-edit
+  // pattern used for Settings.
+  const [fragmentsManageMode, setFragmentsManageMode] = useState(false);
 
   // Section-scoped edit state. `editingSectionId` doubles as the
   // "dialog open" indicator — non-null ⇒ open. The anchor id is stable
@@ -313,6 +316,12 @@ export default function WikiDetailPage() {
     return map;
   })();
 
+  // Set of fragment IDs that are cited anywhere in the current wiki body.
+  // Drives the Fragments-tab status column (cited vs uncited) so the user
+  // can tell which attached fragments are actually doing work in this wiki
+  // and which are dormant.
+  const citedFragmentIds = new Set<string>(htmlFragmentCitationMap.keys());
+
   // Resolve the currently-editing section's heading + body-only prefill.
   // Parses the live wiki content so a mid-session regeneration is
   // detected at dialog-open time — if the anchor no longer resolves,
@@ -345,6 +354,7 @@ export default function WikiDetailPage() {
       : sectionSaveError;
 
   return (
+    <>
     <WikiEntityArticle
       chipIcon={getWikiTypeIcon(typeLabel)}
       chipLabel={typeLabel}
@@ -380,6 +390,9 @@ export default function WikiDetailPage() {
           : undefined
       }
       wikiId={wiki.id}
+      onDeleteWiki={() => setShowDeleteConfirm(true)}
+      onRegenerateWiki={() => regenerate.mutate(wiki.id)}
+      regenerateBusy={regenerate.isPending}
       editorialStateDot={{
         editorialState: wiki.editorialState,
         state: wiki.state,
@@ -387,58 +400,92 @@ export default function WikiDetailPage() {
         lastRebuiltAt: wiki.lastRebuiltAt,
       }}
       onSave={handleSaveToApi}
+      fragmentsTabContent={
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {/* Manage / Done toggle gates fragment-write actions and the
+              Regenerate button. Read mode shows the list only. The tab
+              label already says "Fragments", so no in-content heading. */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <span style={{ ...T.bodySmall, fontFamily: FONT.SANS, color: "var(--wiki-count)" }}>
+              {wiki.fragments?.length ?? 0} fragments
+            </span>
+            <div style={{ flex: 1 }} />
+            {fragmentsManageMode ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => regenerate.mutate(wiki.id)}
+                  disabled={regenerate.isPending}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "6px 16px",
+                    fontSize: 13,
+                    fontFamily: FONT.SANS,
+                    color: "#fff",
+                    background: "var(--wiki-link)",
+                    border: "1px solid var(--wiki-link)",
+                    cursor: regenerate.isPending ? "default" : "pointer",
+                    opacity: regenerate.isPending ? 0.6 : 1,
+                  }}
+                >
+                  <RefreshCw
+                    size={14}
+                    strokeWidth={1.5}
+                    style={regenerate.isPending ? { animation: "spin 1s linear infinite" } : undefined}
+                  />
+                  {regenerate.isPending ? "Regenerating..." : "Regenerate"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFragmentsManageMode(false)}
+                  style={{
+                    padding: "6px 16px",
+                    fontSize: 13,
+                    fontFamily: FONT.SANS,
+                    color: "var(--wiki-article-text)",
+                    background: "none",
+                    border: "1px solid var(--wiki-card-border)",
+                    cursor: "pointer",
+                  }}
+                >
+                  Done
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setFragmentsManageMode(true)}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 13,
+                  fontFamily: FONT.SANS,
+                  color: "#fff",
+                  background: "var(--wiki-link)",
+                  border: "1px solid var(--wiki-link)",
+                  cursor: "pointer",
+                }}
+              >
+                Manage Fragments
+              </button>
+            )}
+          </div>
+          <MemberFragmentsManagementTable
+            wikiId={wiki.id}
+            fragments={wiki.fragments ?? []}
+            manageMode={fragmentsManageMode}
+            citedFragmentIds={citedFragmentIds}
+          />
+        </div>
+      }
       customBottomSections={
         <>
+          {/* Phase 2: BouncerModeToggle, Regenerate, and Delete Wiki moved
+              off Read: BouncerModeToggle + Delete go into Settings; Regenerate
+              moves to the Fragments tab (Manage mode). Share link stays here
+              for now since it's a Read-mode discoverability action. */}
           <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-            <BouncerModeToggle
-              wikiId={wiki.id}
-              bouncerMode={(wiki.bouncerMode as 'auto' | 'review') ?? 'auto'}
-            />
-            <span style={{ width: 1, height: 16, background: "var(--wiki-card-border)" }} />
-            <button
-              type="button"
-              onClick={() => regenerate.mutate(wiki.id)}
-              disabled={regenerate.isPending}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 6,
-                padding: "4px 10px",
-                fontSize: 12,
-                color: "var(--wiki-article-text)",
-                background: "none",
-                border: "1px solid var(--wiki-card-border)",
-                cursor: regenerate.isPending ? "default" : "pointer",
-                opacity: regenerate.isPending ? 0.6 : 1,
-              }}
-            >
-              <RefreshCw
-                size={14}
-                strokeWidth={1.5}
-                style={regenerate.isPending ? { animation: "spin 1s linear infinite" } : undefined}
-              />
-              {regenerate.isPending ? "Regenerating..." : "Regenerate"}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={deleteWiki.isPending}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 6,
-                padding: "4px 10px",
-                fontSize: 12,
-                color: "red",
-                background: "none",
-                border: "1px solid var(--wiki-card-border)",
-                cursor: deleteWiki.isPending ? "default" : "pointer",
-                opacity: deleteWiki.isPending ? 0.6 : 1,
-              }}
-            >
-              <Trash2 size={14} strokeWidth={1.5} />
-              {deleteWiki.isPending ? "Deleting..." : "Delete Wiki"}
-            </button>
             {wiki.published && wiki.publishedSlug && (
               <button
                 type="button"
@@ -484,19 +531,9 @@ export default function WikiDetailPage() {
               </span>
             )}
           </div>
-          <DestructiveConfirmDialog
-            open={showDeleteConfirm}
-            onOpenChange={setShowDeleteConfirm}
-            title="Delete Wiki"
-            description="Are you sure? This permanently deletes this wiki."
-            confirmText={wiki.name}
-            confirmLabel="Delete"
-            onConfirm={() => {
-              deleteWiki.mutate(wiki.id, {
-                onSuccess: () => router.push("/wiki"),
-              });
-            }}
-          />
+          {/* DestructiveConfirmDialog moved to a sibling of WikiEntityArticle
+              below so it stays mounted when the user clicks Delete from the
+              Settings tab (customBottomSections unmounts on Settings). */}
         </>
       }
     >
@@ -548,11 +585,35 @@ export default function WikiDetailPage() {
           dedups by lookupKey internally so a fragment cited from
           multiple sections appears once at the bottom and every
           superscript anchor lands on the same row. */}
-      {sidecarSections.length > 0 && (
-        <WikiCitationsSection
-          citations={sidecarSections.flatMap((s) => s.citations ?? [])}
-        />
-      )}
+      {(() => {
+        const allCitations = sidecarSections.flatMap((s) => s.citations ?? []);
+        if (allCitations.length === 0) return null;
+        return (
+          <details style={{ paddingTop: 20, width: "100%" }}>
+            <summary
+              style={{
+                cursor: "pointer",
+                margin: 0,
+                ...T.h2,
+                color: "var(--wiki-article-h2)",
+                display: "flex",
+                alignItems: "baseline",
+                gap: 8,
+                userSelect: "none",
+                listStyle: "revert",
+              }}
+            >
+              <span>Citations</span>
+              <span style={{ ...T.bodySmall, fontFamily: FONT.SANS, fontWeight: 400, color: "var(--wiki-count)" }}>
+                ({new Set(allCitations.map((c) => c.fragmentId)).size})
+              </span>
+            </summary>
+            <div style={{ marginTop: 8 }}>
+              <WikiCitationsSection heading="" citations={allCitations} />
+            </div>
+          </details>
+        );
+      })()}
       <SectionEditor
         open={editingSectionId !== null}
         onOpenChange={(next) => {
@@ -572,17 +633,28 @@ export default function WikiDetailPage() {
         }}
       />
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <WikiSectionH2 title="Member Fragments" count={wiki.fragments?.length ?? 0} />
-        <MemberFragmentsManagementTable
-          wikiId={wiki.id}
-          fragments={wiki.fragments ?? []}
-        />
-      </div>
+      {/* Member Fragments moved to the dedicated Fragments tab. */}
 
       {wiki.people && wiki.people.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <WikiSectionH2 title="Mentioned People" count={wiki.people.length} />
+        <details style={{ paddingTop: 20, width: "100%" }}>
+          <summary
+            style={{
+              cursor: "pointer",
+              margin: 0,
+              ...T.h2,
+              color: "var(--wiki-article-h2)",
+              display: "flex",
+              alignItems: "baseline",
+              gap: 8,
+              userSelect: "none",
+              listStyle: "revert",
+            }}
+          >
+            <span>Mentioned People</span>
+            <span style={{ ...T.bodySmall, fontFamily: FONT.SANS, fontWeight: 400, color: "var(--wiki-count)" }}>
+              ({wiki.people.length})
+            </span>
+          </summary>
           <ul
             style={{
               ...bodyStyle,
@@ -609,13 +681,24 @@ export default function WikiDetailPage() {
               </li>
             ))}
           </ul>
-        </div>
+        </details>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <WikiSectionH2 title="Timeline" />
-        <WikiRegenTimeline wikiId={wiki.id} />
-      </div>
+      {/* Timeline moved into the History tab (merged with revisions). */}
     </WikiEntityArticle>
+    <DestructiveConfirmDialog
+      open={showDeleteConfirm}
+      onOpenChange={setShowDeleteConfirm}
+      title="Delete Wiki"
+      description="Are you sure? This permanently deletes this wiki."
+      confirmText={wiki.name}
+      confirmLabel="Delete"
+      onConfirm={() => {
+        deleteWiki.mutate(wiki.id, {
+          onSuccess: () => router.push("/wiki"),
+        });
+      }}
+    />
+    </>
   );
 }

--- a/wiki/src/components/layout/AddWikiModal.tsx
+++ b/wiki/src/components/layout/AddWikiModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { T } from "@/lib/typography";
@@ -38,6 +38,51 @@ export interface AddWikiModalProps {
   prefill?: WikiSettingsPrefill | null;
   /** Wiki id for settings-mode PUT. 'preview' or undefined → skip network call (prototype pages). */
   wikiId?: string;
+  /**
+   * When true, render the form as an inline panel (no Dialog/Modal
+   * chrome). Used by the wiki page's Settings tab so the form appears
+   * inside the article column instead of as a popup. The page already
+   * supplies a title h1 + tab bar; embedded mode skips the
+   * DialogHeader and DialogFooter button-row alignment.
+   *
+   * `open` is ignored in embedded mode; visibility is controlled by
+   * the parent mounting / unmounting this component.
+   */
+  embedded?: boolean;
+  /**
+   * Optional delete-wiki callback. When provided AND the form is in
+   * settings mode (prefill !== null) AND fields are unlocked (Edit
+   * Wiki Settings clicked), a red Delete Wiki button renders inside
+   * the form body. The host owns the confirm dialog + mutation; this
+   * component just triggers the host's handler.
+   */
+  onDelete?: () => void;
+  /**
+   * When true, omit the in-form primary action button (Save / Edit Wiki
+   * Settings / Create). The parent renders its own button somewhere
+   * else (e.g. above the embedded panel in WikiEntityArticle) and
+   * triggers the action via the forwarded ref's `submit()` method.
+   */
+  hideFooter?: boolean;
+  /**
+   * Fired whenever the form's primary-action state changes:
+   *  - "view"       → fields locked (settings prefill loaded, no edit)
+   *  - "edit"       → fields unlocked, ready to Save
+   *  - "submitting" → save / create in flight
+   * Lets a parent that hides the footer render the right button label.
+   */
+  onModeChange?: (mode: WikiSettingsFormMode) => void;
+}
+
+export type WikiSettingsFormMode = "view" | "edit" | "submitting";
+
+/**
+ * Imperative handle exposed via forwardRef so a parent can trigger the
+ * primary action (Save / Edit Wiki Settings / Create) without keeping
+ * its own copy of the form state.
+ */
+export interface WikiSettingsFormHandle {
+  submit: () => void;
 }
 
 function InfoIcon({ className }: { className?: string }) {
@@ -73,14 +118,18 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
 }
 
 
-export default function AddWikiModal({
+const AddWikiModal = forwardRef<WikiSettingsFormHandle, AddWikiModalProps>(function AddWikiModal({
   open,
   onClose,
   title = "Create New Wiki",
   confirmLabel = "Create Wiki",
   prefill = null,
   wikiId,
-}: AddWikiModalProps) {
+  embedded = false,
+  onDelete,
+  hideFooter = false,
+  onModeChange,
+}, ref) {
   const wasOpen = useRef(false);
   const [name, setName] = useState("");
   const [wikiType, setWikiType] = useState("");
@@ -152,8 +201,12 @@ export default function AddWikiModal({
   const activeTypeDefaultStructure = activeType?.defaultStructure ?? "";
   const activeTypeDefaultSystemMessage = activeType?.defaultSystemMessage ?? "";
 
+  // In embedded mode the form is always considered "open"; the parent
+  // controls visibility by mounting/unmounting. `wasOpen` still tracks
+  // the open/close/open cycle so prefill reloads on a fresh open.
+  const effectivelyOpen = open || embedded;
   useEffect(() => {
-    if (open) {
+    if (effectivelyOpen) {
       if (!wasOpen.current) {
         setShowSavedToast(false);
         setSubmitError(null);
@@ -217,7 +270,7 @@ export default function AddWikiModal({
     } else {
       wasOpen.current = false;
     }
-  }, [open, prefill]);
+  }, [effectivelyOpen, prefill]);
 
   useEffect(() => {
     return () => {
@@ -511,45 +564,63 @@ export default function AddWikiModal({
     }
   };
 
-  return (
+  // Imperative handle: lets a parent (e.g. Settings tab) trigger the
+  // primary action button without owning a copy of the form state.
+  useImperativeHandle(ref, () => ({
+    submit: () => handleConfirm(),
+  }));
+
+  // Notify parent of mode transitions so it can render the right button
+  // label outside the form (Edit Wiki Settings / Save / Saving…).
+  useEffect(() => {
+    if (!onModeChange) return;
+    const mode: WikiSettingsFormMode = submitting
+      ? "submitting"
+      : locked
+        ? "view"
+        : "edit";
+    onModeChange(mode);
+  }, [submitting, locked, onModeChange]);
+
+  // Form body + footer extracted so they can render inside either a
+  // Dialog (modal mode) or a plain div (embedded, i.e. Settings tab on
+  // the wiki page). In embedded mode the parent already supplies the page
+  // title + tab bar, so the DialogHeader is omitted.
+  const formHeader = !embedded ? (
     <>
-      <Dialog
-        open={open}
-        onOpenChange={(next) => {
-          if (!next) onClose();
-        }}
-      >
-        <DialogContent
-          className="p-0 sm:max-w-[571px] gap-0 rounded-2xl border-black/10 flex flex-col"
-          style={{ maxHeight: "min(631px, 90vh)", overflow: "hidden" }}
+      <DialogHeader className="px-5 pt-5 pb-2 shrink-0">
+        <DialogTitle
+          style={{
+            ...T.h1,
+            color: "#111111",
+            fontWeight: 400,
+            margin: 0,
+          }}
         >
-          <DialogHeader className="px-5 pt-5 pb-2 shrink-0">
-            <DialogTitle
-              style={{
-                ...T.h1,
-                color: "#111111",
-                fontWeight: 400,
-                margin: 0,
-              }}
-            >
-              {title}
-            </DialogTitle>
-            <DialogDescription
-              style={{
-                ...T.micro,
-                lineHeight: "19px",
-                color: "#676d76",
-                margin: 0,
-              }}
-            >
-              {subtitle ?? "Create a new wiki to organize your knowledge."}
-            </DialogDescription>
-          </DialogHeader>
+          {title}
+        </DialogTitle>
+        <DialogDescription
+          style={{
+            ...T.micro,
+            lineHeight: "19px",
+            color: "#676d76",
+            margin: 0,
+          }}
+        >
+          {subtitle ?? "Create a new wiki to organize your knowledge."}
+        </DialogDescription>
+      </DialogHeader>
 
-          <div className="h-px w-full bg-[#e5e5e5] shrink-0" />
+      <div className="h-px w-full bg-[#e5e5e5] shrink-0" />
+    </>
+  ) : null;
 
-          {/* Scrollable body */}
-          <div className="flex-1 min-h-0 overflow-y-auto">
+  const formContents = (
+    <>
+      {formHeader}
+
+      {/* Scrollable body */}
+      <div className={embedded ? "" : "flex-1 min-h-0 overflow-y-auto"}>
 
           {/* Name */}
           <div className="px-5 pt-4 flex flex-col gap-2">
@@ -789,27 +860,12 @@ export default function AddWikiModal({
             />
           </div>
 
-          {/* Fragment Review Mode toggle -- settings mode only */}
-          {isSettingsView && (
-            <div className="px-5 pt-4 flex items-center justify-between gap-3">
-              <div className="flex flex-col gap-0.5">
-                <FieldLabel>Fragment Review Mode</FieldLabel>
-                <span className="text-[11px] leading-4" style={{ color: "#676d76" }}>
-                  {bouncerMode === "review"
-                    ? "New fragments require manual approval"
-                    : "Fragments auto-accepted into this wiki"}
-                </span>
-              </div>
-              <Switch
-                checked={bouncerMode === "review"}
-                onCheckedChange={(checked: boolean) =>
-                  setBouncerMode(checked ? "review" : "auto")
-                }
-                disabled={locked}
-                size="sm"
-              />
-            </div>
-          )}
+          {/* Fragment Review Mode toggle hidden: the bouncer-mode pipeline
+              isn't wired through end-to-end yet, so the switch was making
+              promises the system couldn't keep. State + prefill + save
+              path stay in place (silently no-ops if bouncerMode matches
+              the prefill) so re-enabling is a one-line UI restore once
+              the backend lands. */}
 
           {/* #255: Publish/unpublish toggle — settings mode only.
               Calls the existing /wikis/:id/publish + /unpublish endpoints
@@ -919,6 +975,22 @@ export default function AddWikiModal({
             </div>
           )}
 
+          {/* Delete Wiki: settings mode only, edit-mode only. Mirrors
+              the legacy Read-page delete button: host owns the confirm
+              dialog + mutation; this only triggers the handler. */}
+          {isSettingsView && onDelete && !locked && (
+            <div className="px-5 pt-6 flex flex-col gap-2">
+              <FieldLabel>Danger zone</FieldLabel>
+              <Button
+                type="button"
+                onClick={onDelete}
+                className="self-start rounded-none bg-[var(--destructive)] text-white hover:opacity-90"
+              >
+                Delete Wiki
+              </Button>
+            </div>
+          )}
+
           <div className="pb-5" />
 
           {submitError ? (
@@ -931,32 +1003,66 @@ export default function AddWikiModal({
             </div>
           ) : null}
 
-          </div>
-          {/* /Scrollable body */}
+      </div>
+      {/* /Scrollable body */}
 
-          <div className="h-px w-full bg-[#e5e5e5] shrink-0" />
+      <div className="h-px w-full bg-[#e5e5e5] shrink-0" />
 
-          {/* Footer */}
-          <div className="flex items-center justify-end gap-3 px-5 py-4 shrink-0">
-            <Button
-              type="button"
-              onClick={handleConfirm}
-              disabled={submitting}
-              className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
-            >
-              {locked
-                ? confirmLabel
-                : isSettingsView
-                  ? submitting
-                    ? "Saving…"
-                    : "Save"
-                  : submitting
-                    ? "Creating…"
-                    : confirmLabel}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Footer: hidden when the parent opts to render the primary
+          action button outside the form (embedded Settings tab). */}
+      {!hideFooter && (
+        <div className="flex items-center justify-end gap-3 px-5 py-4 shrink-0">
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting}
+            className="rounded-none bg-[var(--wiki-link)] text-white hover:bg-[var(--wiki-link-hover)]"
+          >
+            {locked
+              ? confirmLabel
+              : isSettingsView
+                ? submitting
+                  ? "Saving…"
+                  : "Save"
+                : submitting
+                  ? "Creating…"
+                  : confirmLabel}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {embedded ? (
+        <div
+          data-slot="wiki-settings-embedded"
+          className="flex flex-col w-full"
+          style={{
+            border: "1px solid var(--wiki-card-border)",
+            borderRadius: 12,
+            background: "var(--wiki-card-bg, transparent)",
+            overflow: "hidden",
+          }}
+        >
+          {formContents}
+        </div>
+      ) : (
+        <Dialog
+          open={open}
+          onOpenChange={(next) => {
+            if (!next) onClose();
+          }}
+        >
+          <DialogContent
+            className="p-0 sm:max-w-[571px] gap-0 rounded-2xl border-black/10 flex flex-col"
+            style={{ maxHeight: "min(631px, 90vh)", overflow: "hidden" }}
+          >
+            {formContents}
+          </DialogContent>
+        </Dialog>
+      )}
 
       <Toast
         message={toastMessage}
@@ -965,4 +1071,6 @@ export default function AddWikiModal({
       />
     </>
   );
-}
+});
+
+export default AddWikiModal;

--- a/wiki/src/components/wiki/MemberFragmentsManagementTable.tsx
+++ b/wiki/src/components/wiki/MemberFragmentsManagementTable.tsx
@@ -28,11 +28,27 @@ export interface MemberFragment {
 interface MemberFragmentsManagementTableProps {
   wikiId: string;
   fragments: MemberFragment[];
+  /**
+   * When true, the Actions column (with the Un-attach button) is shown.
+   * When false, the table is read-only and the Actions column is hidden
+   * entirely so the row chrome doesn't suggest an interactive surface.
+   */
+  manageMode?: boolean;
+  /**
+   * Set of fragment IDs that appear as citations in the current wiki
+   * body. Drives the "cited" / "uncited" label in the Status column.
+   * The prior label was always "active", which carries no information
+   * since every row in this table is by definition an attached
+   * (active-edge) fragment.
+   */
+  citedFragmentIds?: Set<string>;
 }
 
 export function MemberFragmentsManagementTable({
   wikiId,
   fragments,
+  manageMode = false,
+  citedFragmentIds,
 }: MemberFragmentsManagementTableProps) {
   const detach = useDetachFragment();
   const [confirmTarget, setConfirmTarget] = useState<MemberFragment | null>(null);
@@ -68,12 +84,14 @@ export function MemberFragmentsManagementTable({
             >
               Status
             </TableHead>
-            <TableHead
-              style={{ ...T.micro, fontWeight: 600, fontFamily: FONT.SANS }}
-              className="text-right"
-            >
-              Actions
-            </TableHead>
+            {manageMode && (
+              <TableHead
+                style={{ ...T.micro, fontWeight: 600, fontFamily: FONT.SANS }}
+                className="text-right"
+              >
+                Actions
+              </TableHead>
+            )}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -109,43 +127,62 @@ export function MemberFragmentsManagementTable({
                 )}
               </TableCell>
               <TableCell>
-                <span
-                  style={{
-                    ...T.micro,
-                    color:
-                      frag.edgeStatus === "pending"
-                        ? "var(--wiki-count)"
-                        : "var(--wiki-article-text)",
-                    fontStyle:
-                      frag.edgeStatus === "pending" ? "italic" : "normal",
-                  }}
-                >
-                  {frag.edgeStatus === "pending" ? "pending" : "active"}
-                </span>
+                {(() => {
+                  // "pending" beats cited/uncited because the edge isn't
+                  // even active yet, so citation status would be misleading.
+                  if (frag.edgeStatus === "pending") {
+                    return (
+                      <span
+                        style={{
+                          ...T.micro,
+                          color: "var(--wiki-count)",
+                          fontStyle: "italic",
+                        }}
+                      >
+                        pending
+                      </span>
+                    );
+                  }
+                  const cited = citedFragmentIds?.has(frag.id) ?? false;
+                  return (
+                    <span
+                      style={{
+                        ...T.micro,
+                        color: cited
+                          ? "var(--wiki-article-text)"
+                          : "var(--wiki-count)",
+                      }}
+                    >
+                      {cited ? "cited" : "uncited"}
+                    </span>
+                  );
+                })()}
               </TableCell>
-              <TableCell className="text-right">
-                <button
-                  type="button"
-                  title="Un-attach fragment"
-                  onClick={() => setConfirmTarget(frag)}
-                  disabled={detach.isPending}
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 4,
-                    padding: "2px 8px",
-                    fontSize: 12,
-                    color: "var(--wiki-article-text)",
-                    background: "none",
-                    border: "1px solid var(--wiki-card-border)",
-                    cursor: detach.isPending ? "default" : "pointer",
-                    opacity: detach.isPending ? 0.5 : 1,
-                  }}
-                >
-                  <Unlink size={12} strokeWidth={1.5} />
-                  Un-attach
-                </button>
-              </TableCell>
+              {manageMode && (
+                <TableCell className="text-right">
+                  <button
+                    type="button"
+                    title="Un-attach fragment"
+                    onClick={() => setConfirmTarget(frag)}
+                    disabled={detach.isPending}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      padding: "2px 8px",
+                      fontSize: 12,
+                      color: "var(--wiki-article-text)",
+                      background: "none",
+                      border: "1px solid var(--wiki-card-border)",
+                      cursor: detach.isPending ? "default" : "pointer",
+                      opacity: detach.isPending ? 0.5 : 1,
+                    }}
+                  >
+                    <Unlink size={12} strokeWidth={1.5} />
+                    Un-attach
+                  </button>
+                </TableCell>
+              )}
             </TableRow>
           ))}
         </TableBody>

--- a/wiki/src/components/wiki/WikiCitationsSection.tsx
+++ b/wiki/src/components/wiki/WikiCitationsSection.tsx
@@ -86,16 +86,18 @@ export function WikiCitationsSection({
         ...style,
       }}
     >
-      <h2
-        style={{
-          fontSize: 18,
-          fontWeight: 600,
-          margin: "0 0 12px",
-          color: "var(--wiki-article-h2)",
-        }}
-      >
-        {heading}
-      </h2>
+      {heading && (
+        <h2
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            margin: "0 0 12px",
+            color: "var(--wiki-article-h2)",
+          }}
+        >
+          {heading}
+        </h2>
+      )}
       <ol
         style={{
           listStyle: "decimal",

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -6,9 +6,14 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import AddWikiModal from "@/components/layout/AddWikiModal";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import AddWikiModal, {
+  type WikiSettingsFormHandle,
+  type WikiSettingsFormMode,
+} from "@/components/layout/AddWikiModal";
 import InlineEditor from "@/components/editor/InlineEditor";
 import WikiHistoryTimeline from "@/components/wiki/WikiHistoryTimeline";
+import WikiRegenTimeline from "@/components/wiki/WikiRegenTimeline";
 import { T, FONT } from "@/lib/typography";
 import {
   EDITABLE_WIKI_TYPES,
@@ -278,6 +283,14 @@ export type WikiEntityArticleProps = {
    * Optional sections rendered after divider and before modal.
    */
   customBottomSections?: ReactNode;
+  /**
+   * Content rendered in the dedicated "Fragments" tab. Caller owns the
+   * fragment management surface (typically <MemberFragmentsManagementTable>).
+   * When this prop is provided AND the user clicks the Fragments tab, the
+   * main content area swaps to this node and Read/Edit/History content
+   * are hidden.
+   */
+  fragmentsTabContent?: ReactNode;
   /** Per-wiki Wiki Style override to prefill in settings modal (wikis.prompt). */
   promptOverride?: string;
   /** Per-wiki Wiki Format override to prefill in settings modal (wikis.structure). */
@@ -301,6 +314,21 @@ export type WikiEntityArticleProps = {
   onSave?: (data: { title: string; chipLabel: string; content: string }) => void;
   /** Custom settings click handler — when provided, the header gear calls this instead of opening AddWikiModal. */
   onSettingsClick?: () => void;
+  /**
+   * Optional delete-wiki callback. Forwarded to the Settings-tab form's
+   * Delete Wiki button. Host owns the confirm dialog + mutation; this
+   * component just triggers it when the user clicks Delete.
+   */
+  onDeleteWiki?: () => void;
+  /**
+   * Optional regenerate-wiki callback. When provided, a Regenerate button
+   * renders in the Settings tab's action row alongside Edit Wiki Settings /
+   * Save (only while fields are unlocked). The host owns the mutation; this
+   * component just triggers it.
+   */
+  onRegenerateWiki?: () => void;
+  /** Disables the Settings-tab Regenerate button + shows "Regenerating…". */
+  regenerateBusy?: boolean;
   /** Editorial state dot rendered inline with the title. */
   editorialStateDot?: EditorialStateDotProps;
   children: ReactNode;
@@ -343,6 +371,7 @@ export function WikiEntityArticle({
   infobox,
   renderCustomInfobox,
   customBottomSections,
+  fragmentsTabContent,
   promptOverride,
   structureOverride,
   description,
@@ -354,12 +383,48 @@ export function WikiEntityArticle({
   collections,
   onSave,
   onSettingsClick: onSettingsClickProp,
+  onDeleteWiki,
+  onRegenerateWiki,
+  regenerateBusy = false,
   editorialStateDot,
   children,
 }: WikiEntityArticleProps) {
   const [infoVisible, setInfoVisible] = useState(true);
-  const [wikiSettingsOpen, setWikiSettingsOpen] = useState(false);
+  // Tab and URL sync (Phase 2). ?tab=fragments / ?tab=history reflects
+  // state so the user can deep-link or refresh-with-tab-preserved. Edit
+  // isn't synced because it's a write-in-progress mode; coming back via
+  // URL would lose the draft anyway.
+  //
+  // The initial tab is read once from the URL via the useState
+  // initializer (which runs only on mount), avoiding a cascading
+  // setState in useEffect.
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  // Fragments and Settings render inline in the main content area (no modal).
+  // The modal mode of AddWikiModal is still used by the global header's
+  // "+ New" create flow; hosts can also override via `onSettingsClickProp`
+  // (e.g. preview pages) to keep their own popup.
+  const [isViewingFragments, setIsViewingFragments] = useState(
+    () => searchParams.get("tab") === "fragments",
+  );
+  const [isViewingSettings, setIsViewingSettings] = useState(
+    () => searchParams.get("tab") === "settings",
+  );
+  // Settings form: parent-rendered primary button + delete confirmation
+  // live above the embedded form panel, so we expose the form's submit
+  // via ref and track its mode for the button label.
+  const settingsFormRef = useRef<WikiSettingsFormHandle>(null);
+  const [settingsMode, setSettingsMode] = useState<WikiSettingsFormMode>("view");
   const readContentRef = useRef<HTMLDivElement | null>(null);
+
+  const updateTabInUrl = (tab: "read" | "fragments" | "history" | "settings" | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!tab || tab === "read") params.delete("tab");
+    else params.set("tab", tab);
+    const next = params.toString();
+    router.replace(next ? `${pathname}?${next}` : pathname);
+  };
 
   const { data: historyData } = useWikiEditHistory(wikiId);
   const serverRevisions = useMemo<WikiRevision[] | undefined>(() => {
@@ -431,7 +496,7 @@ export function WikiEntityArticle({
     [displayTitle, displayChipLabel, description, promptOverride, structureOverride, bouncerMode, published, publishedSlug, publishedOrigin, collections],
   );
 
-  const tabs = ["Read", "Edit", "View history"] as const;
+  const tabs = ["Read", "Edit", "Fragments", "History", "Settings"] as const;
 
   return (
     <div className="wiki-page wiki-page--article">
@@ -460,79 +525,80 @@ export function WikiEntityArticle({
               width: "100%",
             }}
           >
-            {isEditing ? (
-              wikiTypeLocked ? (
-                <div style={{ display: "inline-flex", flexDirection: "column", gap: 6 }}>
-                  <WikiTypeBadge type={displayChipLabel} icon={displayChipIcon} />
-                </div>
-              ) : (
-                <div
-                  style={{
-                    display: "inline-flex",
-                    flexDirection: "column",
-                    gap: 0,
-                    alignItems: "flex-start",
-                  }}
-                >
-                  <Combobox
-                    value={draftChipLabel}
-                    items={EDITABLE_WIKI_TYPES}
-                    filter={null}
-                    onValueChange={(value) => setDraftChipLabel(String(value))}
+            {/* Top metadata row: collections on the left, Wiki Type badge +
+                editorial-state dot + Private indicator on the right. Type
+                change is owned by Settings only (not Edit). */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  flexWrap: "wrap",
+                }}
+              >
+                {(collections ?? []).map((c) => (
+                  <span
+                    key={c.id}
+                    data-slot="wiki-collection-chip"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 6,
+                      padding: "2px 8px",
+                      ...T.micro,
+                      fontFamily: FONT.SANS,
+                      color: "var(--wiki-article-text)",
+                      border: "1px solid var(--wiki-card-border)",
+                      whiteSpace: "nowrap",
+                    }}
                   >
-                    <ComboboxTrigger
-                      className="inline-flex w-fit items-center gap-1 rounded-sm border border-border bg-white text-xs [&>svg]:text-black"
-                      render={<button type="button" />}
+                    <span
                       style={{
-                        paddingLeft: 6,
-                        paddingRight: 6,
-                        paddingTop: 3,
-                        paddingBottom: 3,
+                        display: "inline-block",
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        backgroundColor: c.color || "var(--wiki-count)",
                       }}
-                    >
-                      <span
-                        style={{
-                          display: "inline-flex",
-                          alignItems: "center",
-                          gap: 4,
-                          backgroundColor: draftChipColors.bg,
-                          color: "var(--foreground)",
-                          borderColor: draftChipColors.border,
-                          borderWidth: 1,
-                          borderStyle: "solid",
-                          borderRadius: 2,
-                          padding: "2px 8px",
-                          lineHeight: "16px",
-                        }}
-                      >
-                        {(() => {
-                          const DraftIcon = getWikiTypeIcon(draftChipLabel);
-                          return DraftIcon ? <DraftIcon /> : null;
-                        })()}
-                        <ComboboxValue />
-                      </span>
-                    </ComboboxTrigger>
-                    <ComboboxContent className="rounded-none px-2 py-1">
-                      <ComboboxEmpty>No wiki type found.</ComboboxEmpty>
-                      <ComboboxList>
-                        <ComboboxCollection>
-                          {(item) => {
-                            const type = item as WikiType;
-                            return (
-                              <ComboboxItem value={type}>
-                                <WikiTypeBadge type={type} />
-                              </ComboboxItem>
-                            );
-                          }}
-                        </ComboboxCollection>
-                      </ComboboxList>
-                    </ComboboxContent>
-                  </Combobox>
-                </div>
-              )
-            ) : (
-              <WikiTypeBadge type={displayChipLabel} icon={displayChipIcon ?? ChipIcon} />
-            )}
+                      aria-hidden
+                    />
+                    {c.name}
+                  </span>
+                ))}
+              </div>
+              <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <WikiTypeBadge type={displayChipLabel} icon={displayChipIcon ?? ChipIcon} />
+                {editorialStateDot && <EditorialStateDot {...editorialStateDot} />}
+                {/* Private badge renders identically across all 5 sub-pages
+                    alongside the Type badge and editorial-state dot. */}
+                {published === false && (
+                  <span
+                    data-testid="wiki-private-badge"
+                    aria-label="Private"
+                    style={{
+                      ...T.micro,
+                      color: "var(--wiki-infobox-text)",
+                      opacity: 0.7,
+                      fontFamily: FONT.SANS,
+                      whiteSpace: "nowrap",
+                      flexShrink: 0,
+                    }}
+                  >
+                    Private
+                  </span>
+                )}
+              </div>
+            </div>
 
             <div
               style={{
@@ -547,138 +613,61 @@ export function WikiEntityArticle({
                 className="wiki-article-title-wrap"
                 style={{
                   display: "flex",
-                  alignItems: "flex-end",
-                  justifyContent: "space-between",
+                  flexDirection: "column",
+                  alignItems: "stretch",
+                  gap: 8,
                   width: "100%",
                   borderBottom: showTitleUnderline
                     ? "1px solid var(--wiki-search-section-line)"
                     : "none",
                 }}
               >
-                {isEditing ? (
-                  <input
-                    value={draftTitle}
-                    onChange={(event) => setDraftTitle(event.target.value)}
-                    aria-label="Wiki title"
-                    style={{
-                      margin: 0,
-                      paddingBottom: 8,
-                      ...T.h1,
-                      fontFamily: FONT.SERIF,
-                      color: "var(--wiki-title)",
-                      minWidth: 0,
-                      flex: 1,
-                      border: "none",
-                      outline: "none",
-                      background: "transparent",
-                    }}
-                  />
-                ) : (
-                  <h1
-                    className="wiki-article-h1"
-                    style={{
-                      margin: 0,
-                      paddingBottom: 8,
-                      ...T.h1,
-                      fontFamily: FONT.SERIF,
-                      color: "var(--wiki-title)",
-                      overflow: titleEllipsis ? "hidden" : undefined,
-                      textOverflow: titleEllipsis ? "ellipsis" : undefined,
-                      whiteSpace: titleEllipsis ? "nowrap" : undefined,
-                      minWidth: 0,
-                      flex: 1,
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: 8,
-                    }}
-                  >
-                    {displayTitle}
-                    {editorialStateDot && (
-                      <EditorialStateDot {...editorialStateDot} />
-                    )}
-                  </h1>
-                )}
-                {/* Private badge — visible whenever the wiki is unpublished.
-                    Tells the operator at a glance that nobody else can read
-                    this surface. Suppressed in edit mode to keep the editor
-                    chrome calm. Caller wires `published` from the wiki row
-                    (defaults to false at the schema layer per #277). */}
-                {!isEditing && published === false && (
-                  <span
-                    data-testid="wiki-private-badge"
-                    aria-label="Private"
-                    style={{
-                      ...T.micro,
-                      color: "var(--wiki-infobox-text)",
-                      opacity: 0.7,
-                      fontFamily: FONT.SANS,
-                      paddingBottom: 10,
-                      whiteSpace: "nowrap",
-                      flexShrink: 0,
-                      marginRight: 12,
-                    }}
-                  >
-                    Private
-                  </span>
-                )}
+                {/* Title is identical across all modes (Read / Edit / Fragments /
+                    History / Settings). Title rename lives in Settings (along
+                    with type change). */}
+                <h1
+                  className="wiki-article-h1"
+                  style={{
+                    margin: 0,
+                    paddingBottom: 8,
+                    ...T.h1,
+                    fontFamily: FONT.SERIF,
+                    color: "var(--wiki-title)",
+                    overflow: titleEllipsis ? "hidden" : undefined,
+                    textOverflow: titleEllipsis ? "ellipsis" : undefined,
+                    whiteSpace: titleEllipsis ? "nowrap" : undefined,
+                    minWidth: 0,
+                    flex: 1,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  {displayTitle}
+                </h1>
+                {/* Phase 2: editorial-state dot + Private badge moved up
+                    next to the Wiki Type badge so the title has the full
+                    horizontal lane. */}
                 <div
                   className="wiki-article-tabs"
                   style={{
                     display: "flex",
                     alignItems: "flex-end",
+                    justifyContent: "flex-end",
                     gap: 12,
                     flexShrink: 0,
+                    flexWrap: "wrap",
                   }}
                 >
-                  {isEditing ? (
-                    <>
-                      <button
-                        type="button"
-                        className="wiki-article-tab"
-                        onClick={() => {
-                          handleSave();
-                          onSave?.({ title: draftTitle || title, chipLabel: draftChipLabel || chipLabel, content: draftContent });
-                        }}
-                        style={{
-                          background: "none",
-                          borderTop: "none",
-                          borderLeft: "none",
-                          borderRight: "none",
-                          cursor: "pointer",
-                          ...T.bodySmall,
-                          fontFamily: FONT.SANS,
-                          lineHeight: "20px",
-                          paddingBottom: 8,
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        Save
-                      </button>
-                      <button
-                        type="button"
-                        className="wiki-article-tab-muted"
-                        onClick={handleCancel}
-                        style={{
-                          background: "none",
-                          borderTop: "none",
-                          borderLeft: "none",
-                          borderRight: "none",
-                          cursor: "pointer",
-                          ...T.bodySmall,
-                          fontFamily: FONT.SANS,
-                          lineHeight: "20px",
-                          paddingBottom: 8,
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    tabs.map((tab) => {
+                  {/* Tabs render identically across all modes. Save / Cancel
+                      for Edit live inline below the editor, not in the tab bar. */}
+                  {tabs.map((tab) => {
                       const active =
-                        (tab === "Read" && !isViewingHistory) ||
-                        (tab === "View history" && isViewingHistory);
+                        (tab === "Read" && !isEditing && !isViewingHistory && !isViewingFragments && !isViewingSettings) ||
+                        (tab === "Edit" && isEditing) ||
+                        (tab === "Fragments" && isViewingFragments) ||
+                        (tab === "History" && isViewingHistory) ||
+                        (tab === "Settings" && isViewingSettings);
                       return (
                         <button
                           key={tab}
@@ -689,20 +678,13 @@ export function WikiEntityArticle({
                               : "wiki-article-tab"
                           }
                           onClick={() => {
-                            // Scope the read-mode HTML capture to the `[data-wiki-body]`
-                            // subtree so sidebar chrome (Member Fragments,
-                            // Mentioned People, citations, etc.) never leaks
-                            // into the Tiptap draft and gets baked into
-                            // `wikis.content` on save (#241). Fall back to the
-                            // wrapper innerHTML for callers that haven't opted
-                            // in yet (e.g. the People page).
-                            //
-                            // Within the body, strip `[data-slot]` affordances
-                            // (the inline `[edit]` link rendered by
-                            // `WikiEditLink`, citation superscripts, etc.) —
-                            // they are interactive UI, not author content, and
-                            // round-tripping them turns live affordances into
-                            // inert markup permanently baked into the body.
+                            // Scope the read-mode HTML capture to the
+                            // `[data-wiki-body]` subtree so sidebar chrome
+                            // (Member Fragments, Mentioned People, citations,
+                            // etc.) never leaks into the Tiptap draft.
+                            // Strip [data-slot] affordances (edit-link,
+                            // references, see-also, citation chips) since
+                            // they are interactive UI, not author content.
                             let bodyHtml = "";
                             const bodyEl = readContentRef.current?.querySelector("[data-wiki-body]");
                             if (bodyEl) {
@@ -713,19 +695,48 @@ export function WikiEntityArticle({
                               bodyHtml = readContentRef.current?.innerHTML ?? "";
                             }
                             if (tab === "Edit") {
+                              setIsViewingFragments(false);
+                              setIsViewingSettings(false);
                               enterEditMode({
                                 currentHtml: bodyHtml,
                                 currentTitle: displayTitle,
                                 currentChipLabel: displayChipLabel,
                               });
-                            } else if (tab === "View history") {
+                              updateTabInUrl(null);
+                            } else if (tab === "Fragments") {
+                              if (isViewingHistory) closeHistory();
+                              setIsViewingSettings(false);
+                              setIsViewingFragments(true);
+                              setInfoVisible(false);
+                              updateTabInUrl("fragments");
+                            } else if (tab === "History") {
+                              setIsViewingFragments(false);
+                              setIsViewingSettings(false);
                               openHistory({
                                 currentHtml: bodyHtml,
                                 currentTitle: displayTitle,
                                 currentChipLabel: displayChipLabel,
                               });
+                              updateTabInUrl("history");
+                            } else if (tab === "Settings") {
+                              // Settings renders inline as its own page now.
+                              // The legacy modal path (onSettingsClickProp) is
+                              // still respected for hosts that wire their own
+                              // handler, e.g. preview / prototype pages.
+                              if (onSettingsClickProp) {
+                                onSettingsClickProp();
+                              } else {
+                                if (isViewingHistory) closeHistory();
+                                setIsViewingFragments(false);
+                                setInfoVisible(false);
+                                setIsViewingSettings(true);
+                              }
+                              updateTabInUrl("settings");
                             } else if (tab === "Read") {
+                              setIsViewingFragments(false);
+                              setIsViewingSettings(false);
                               if (isViewingHistory) closeHistory();
+                              updateTabInUrl(null);
                             }
                           }}
                           style={{
@@ -744,9 +755,8 @@ export function WikiEntityArticle({
                           {tab}
                         </button>
                       );
-                    })
-                  )}
-                  {showInfobox && !isEditing && !isViewingHistory ? (
+                    })}
+                  {showInfobox && !isEditing && !isViewingHistory && !isViewingFragments && !isViewingSettings ? (
                     <button
                       type="button"
                       title={infoVisible ? "Hide infobox" : "Show infobox"}
@@ -765,29 +775,125 @@ export function WikiEntityArticle({
                       {infoVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}
                     </button>
                   ) : null}
-                  {showSettings && !isEditing && !isViewingHistory ? (
-                    <button
-                      type="button"
-                      title="Wiki settings"
-                      onClick={() => onSettingsClickProp ? onSettingsClickProp() : setWikiSettingsOpen(true)}
-                      style={{
-                        background: "none",
-                        border: "none",
-                        cursor: "pointer",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        width: 24,
-                        paddingBottom: 12,
-                      }}
-                    >
-                      <SettingsIcon />
-                    </button>
-                  ) : null}
+                  {/* Settings gear icon removed; Settings is now a tab. */}
                 </div>
               </div>
             </div>
           </div>
+
+          {/* Page-action row: sits below the tab bar, above the content
+              box. Hosts mode-specific buttons:
+                - Edit mode → Save / Cancel
+                - Settings tab → Edit Wiki Settings / Save (label tracks
+                  the embedded form's mode via WikiSettingsFormHandle).
+              Right-aligned to match the tab bar. */}
+          {isEditing && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: 8,
+                paddingTop: 12,
+                paddingBottom: 12,
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  handleSave();
+                  onSave?.({
+                    title: draftTitle || title,
+                    chipLabel: draftChipLabel || chipLabel,
+                    content: draftContent,
+                  });
+                }}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 13,
+                  fontFamily: FONT.SANS,
+                  color: "#fff",
+                  background: "var(--wiki-link)",
+                  border: "1px solid var(--wiki-link)",
+                  cursor: "pointer",
+                }}
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={handleCancel}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 13,
+                  fontFamily: FONT.SANS,
+                  color: "var(--wiki-article-text)",
+                  background: "none",
+                  border: "1px solid var(--wiki-card-border)",
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+          {isViewingSettings && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: 8,
+                paddingTop: 12,
+                paddingBottom: 12,
+              }}
+            >
+              {/* Regenerate lives in the Settings action row too, so it's
+                  surfaceable from somewhere other than the Fragments tab
+                  (which is easy to miss). Only shows once the form is
+                  unlocked, mirroring the Delete Wiki button's gating
+                  (destructive / heavyweight actions require entering edit
+                  mode first). */}
+              {settingsMode === "edit" && onRegenerateWiki && (
+                <button
+                  type="button"
+                  onClick={() => onRegenerateWiki()}
+                  disabled={regenerateBusy}
+                  style={{
+                    padding: "6px 16px",
+                    fontSize: 13,
+                    fontFamily: FONT.SANS,
+                    color: "var(--wiki-article-text)",
+                    background: "none",
+                    border: "1px solid var(--wiki-card-border)",
+                    cursor: regenerateBusy ? "default" : "pointer",
+                    opacity: regenerateBusy ? 0.6 : 1,
+                  }}
+                >
+                  {regenerateBusy ? "Regenerating…" : "Regenerate"}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => settingsFormRef.current?.submit()}
+                disabled={settingsMode === "submitting"}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 13,
+                  fontFamily: FONT.SANS,
+                  color: "#fff",
+                  background: "var(--wiki-link)",
+                  border: "1px solid var(--wiki-link)",
+                  cursor: settingsMode === "submitting" ? "default" : "pointer",
+                  opacity: settingsMode === "submitting" ? 0.6 : 1,
+                }}
+              >
+                {settingsMode === "submitting"
+                  ? "Saving…"
+                  : settingsMode === "edit"
+                    ? "Save"
+                    : "Edit Wiki Settings"}
+              </button>
+            </div>
+          )}
 
           {/*
             Structured `.winfo` infobox (sidecar-driven) renders inline as
@@ -817,7 +923,7 @@ export function WikiEntityArticle({
                 display: "flow-root",
               }}
             >
-              {showInfobox && infoVisible && !isEditing && !isViewingHistory && renderCustomInfobox
+              {showInfobox && infoVisible && !isEditing && !isViewingHistory && !isViewingFragments && !isViewingSettings && renderCustomInfobox
                 ? renderCustomInfobox()
                 : null}
               {isEditing ? (
@@ -827,7 +933,39 @@ export function WikiEntityArticle({
                   editable
                 />
               ) : isViewingHistory ? (
-                <WikiHistoryTimeline revisions={revisions} />
+                // Phase 2: History is the unified stream. WikiRegenTimeline
+                // already merges /history (edit revisions) + /timeline (audit
+                // events) internally, so we use it as-is. WikiHistoryTimeline
+                // (the older revision-only view) stays as a fallback when we
+                // don't have a wikiId.
+                wikiId ? <WikiRegenTimeline wikiId={wikiId} /> : <WikiHistoryTimeline revisions={revisions} />
+              ) : isViewingFragments ? (
+                fragmentsTabContent ?? (
+                  <div style={{ ...T.bodySmall, color: "var(--muted-foreground)" }}>
+                    No fragments tab content provided by this page.
+                  </div>
+                )
+              ) : isViewingSettings ? (
+                // Inline Settings tab: renders the same form the legacy gear
+                // modal used, embedded directly in the article column. The
+                // page-level title h1 + tab bar already supply chrome, so
+                // `embedded` strips the DialogHeader.
+                <AddWikiModal
+                  ref={settingsFormRef}
+                  embedded
+                  hideFooter
+                  open={false}
+                  onClose={() => {
+                    setIsViewingSettings(false);
+                    updateTabInUrl(null);
+                  }}
+                  title="Wiki Settings"
+                  confirmLabel="Edit Wiki Settings"
+                  prefill={wikiSettingsPrefill}
+                  wikiId={wikiId ?? "preview"}
+                  onDelete={onDeleteWiki}
+                  onModeChange={setSettingsMode}
+                />
               ) : (
                 <div ref={readContentRef}>
                   {savedContent ? (
@@ -842,7 +980,7 @@ export function WikiEntityArticle({
               )}
             </div>
 
-            {showInfobox && infoVisible && !isEditing && !isViewingHistory && !renderCustomInfobox
+            {showInfobox && infoVisible && !isEditing && !isViewingHistory && !isViewingFragments && !isViewingSettings && !renderCustomInfobox
               ? (
                   <div className="hidden md:block">
                     {renderInfobox(infobox)}
@@ -852,17 +990,12 @@ export function WikiEntityArticle({
           </div>
         </div>
 
-        {customBottomSections}
+        {/* customBottomSections (citations + mentioned-people + share button)
+            hide in the Fragments and Settings tabs since those tabs own the
+            entire content area. Read, Edit, History still show them. */}
+        {!isViewingFragments && !isViewingSettings && customBottomSections}
       </div>
 
-      <AddWikiModal
-        open={wikiSettingsOpen}
-        onClose={() => setWikiSettingsOpen(false)}
-        title="Wiki Settings"
-        confirmLabel="Edit Wiki Settings"
-        prefill={wikiSettingsPrefill}
-        wikiId={wikiId ?? "preview"}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Restructure the wiki detail page from a single Read view with a modal Settings popup into a five-tab model where each sub-page is a first-class surface. URL-synced via `?tab=fragments|history|settings` so the active tab survives a refresh and is deep-linkable.

- **Header chrome standardised** across all 5 sub-pages (collections left, type badge / dot / Private right, full-width title, right-aligned tab row).
- **Settings tab** replaces the gear-modal: form renders inline with action button above (Edit Wiki Settings / Save), Delete Wiki in a Danger zone, Regenerate button alongside Save.
- **Fragments tab** replaces the in-Read "Member Fragments" section with a dedicated surface: cited / uncited / pending status column, manage-mode gating for Un-attach, Regenerate in the toolbar.
- **History tab** unifies revisions + audit timeline into a single stream.

**Note:** stacks on #402. The per-section `[edit]` removal there is a precondition — the tab-level Edit is the canonical edit entry point now. Will need a rebase once #402 lands.

## Why

The wiki page was carrying too much weight: a Read view with per-section edit links, plus a gear-icon-triggered modal for Settings, plus a "Member Fragments" section near the bottom, plus a History view that only surfaced via a separate route. Each surface was a different mental model. The 5-tab model gives each a dedicated, URL-addressable home and lets the shared chrome (title, type badge, tab bar) stay stable as the user moves between them.

### Header

The pre-tab layout had the title swap to an editable input when Edit was active, the type chip jump positions depending on mode, and the Private label only appear in certain views. Three modes had three subtly different headers. Now: the title is always a full-width `<h1>`; the type badge + editorial-state dot + Private label always sit on a metadata row above it; collections chips sit on that same row, left-aligned. Identical chrome across all 5 tabs. Title rename moves to the Settings tab.

### Settings

The modal popup was an accident of "where Settings lives" — it was the only writeable surface other than per-section edit, so it earned a dialog. With Edit promoted to a first-class tab, Settings can be a tab too. The form contents are unchanged; what's new is:

- `AddWikiModal` converted to `forwardRef` exposing `WikiSettingsFormHandle.submit()`. Lets the primary action button render *outside* the form panel so the user sees Edit Wiki Settings / Save right under the tab bar, not at the bottom of a scrolling form.
- New `hideFooter` prop and `onModeChange` callback let the parent host the button + track lock/submit state.
- Delete Wiki sits in a "Danger zone" group at the bottom of the form, visible only when the form is unlocked.
- Regenerate sits beside Save in the action row when unlocked.
- The unwired Fragment Review Mode toggle is hidden — state + prefill + save path stay in place so re-enabling is a one-line UI restore once the backend lands.

### Fragments

Was a section near the bottom of Read mode. Now its own tab with three meaningful changes:

- **Status column derived from citations.** Was always "active" (carrying no information — every row in the table is by definition active). Now reports `cited` / `uncited` from `sidecarSections[].citations[]` against the current body, or `pending` if the edge is still pending. Tells the user which attached fragments are doing work in this wiki and which are dormant.
- **Manage mode.** Default read view drops the entire Actions column — no Un-attach button rendered, not just disabled. Click Manage Fragments to enter write mode; Un-attach + Regenerate become available.
- **Restyled buttons.** Manage / Done / Regenerate now match the page-action button aesthetic (Save / Cancel / Edit Wiki Settings).

### History

Unified into `WikiRegenTimeline` which merges edit revisions (`/history`) and audit events (`/timeline`) into one chronological stream. Pre-tab there was a separate revision-only route and an audit-events surface; users had to know which to look at for which question.

## Files

- `wiki/src/components/wiki/WikiEntityArticle.tsx` — the shell. Tab scaffold, header standardisation, action row, all tab branches
- `wiki/src/components/layout/AddWikiModal.tsx` — forwardRef refactor + `hideFooter` + `onModeChange` + `onDelete` prop + new `WikiSettingsFormHandle` type
- `wiki/src/app/(shell)/wiki/[id]/page.tsx` — props plumbing, fragmentsTabContent, DestructiveConfirmDialog hoist
- `wiki/src/components/wiki/MemberFragmentsManagementTable.tsx` — manage-mode gating + cited/uncited status
- `wiki/src/components/wiki/WikiCitationsSection.tsx` — heading made conditional so the Fragments tab can omit it

## Test plan

### Tab navigation
- [ ] Five tabs visible: Read / Edit / Fragments / History / Settings
- [ ] Active-state underline tracks the current tab in all five modes
- [ ] URL updates to `?tab=fragments` / `?tab=history` / `?tab=settings` as appropriate
- [ ] Refresh on `?tab=fragments` lands you back on Fragments
- [ ] Edit tab works as before (this PR doesn't change editor behavior; that's a follow-up)

### Header
- [ ] Type badge, editorial-state dot, Private label render identically across all 5 tabs
- [ ] Collections chips render top-left, one per collection, side-by-side when multiple
- [ ] Title is a full-width `<h1>`, identical across tabs

### Settings tab
- [ ] Clicking Settings tab opens the inline form panel (no popup)
- [ ] Form is read-only by default; clicking Edit Wiki Settings unlocks fields
- [ ] Save button in the action row above the panel; label tracks form state
- [ ] Delete Wiki red button appears in Danger zone when unlocked; click → confirm dialog requiring wiki name; confirm → wiki deleted + routed back to `/wiki`
- [ ] Regenerate button beside Save when unlocked; click → regen runs, button shows "Regenerating…"
- [ ] Fragment Review Mode row not visible

### Fragments tab
- [ ] Shows the attached-fragments table with three columns: Fragment / Status / (Actions only in manage mode)
- [ ] Status reports `cited` for fragments that appear in `[[fragment:slug]]` tokens in the current body, `uncited` for attached fragments not yet cited, `pending` for pending edges
- [ ] Manage Fragments button → enters manage mode → Un-attach column appears + Regenerate appears in toolbar
- [ ] Done button → exits manage mode → Un-attach column disappears

### History tab
- [ ] Single timeline showing both regen events and edit revisions interleaved by timestamp

### General
- [ ] `pnpm --filter @robin/wiki typecheck` passes
- [ ] Existing wikis open without errors on any tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
