### PR TITLE
feat(wiki-edit): preserve citation tokens on Tiptap save + diff preview + dirty gating

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -41,6 +41,7 @@
     "jose": "^6.1.3",
     "js-yaml": "^4.1.1",
     "nanoid": "^5.0.0",
+    "node-html-parser": "^7.1.0",
     "pino": "^10.3.1",
     "postgres": "^3.4.0",
     "zod": "3.25.76"

--- a/core/src/lib/htmlToWikiMarkdown.test.ts
+++ b/core/src/lib/htmlToWikiMarkdown.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToWikiMarkdown } from './htmlToWikiMarkdown.js'
+
+describe('htmlToWikiMarkdown', () => {
+  describe('passthrough', () => {
+    it('returns empty string for empty input', () => {
+      expect(htmlToWikiMarkdown('')).toBe('')
+      expect(htmlToWikiMarkdown('   ')).toBe('')
+    })
+
+    it('returns markdown unchanged when input has no tags', () => {
+      // Regen output round-tripping through the editor sometimes lands
+      // here, and the converter must not corrupt already-canonical bodies.
+      expect(htmlToWikiMarkdown('Plain markdown content.')).toBe(
+        'Plain markdown content.\n',
+      )
+    })
+
+    it('does not treat & as the start of HTML', () => {
+      // URL query strings contain `&` but the input is still markdown,
+      // so the parser shouldn't try to decode entities here.
+      expect(htmlToWikiMarkdown('See https://x?a=1&b=2')).toBe(
+        'See https://x?a=1&b=2\n',
+      )
+    })
+
+    it('passthrough matches parser-path trailing-newline form', () => {
+      // Idempotency: a save of identical content shouldn't log a spurious
+      // edit row. The two output paths must agree on trailing whitespace.
+      const md = '## Heading\n\nBody.\n'
+      const out = htmlToWikiMarkdown(md)
+      expect(out).toBe(md)
+    })
+  })
+
+  describe('block structure', () => {
+    it('converts headings h1-h6', () => {
+      expect(htmlToWikiMarkdown('<h1>Top</h1>')).toBe('# Top\n')
+      expect(htmlToWikiMarkdown('<h2>Mid</h2>')).toBe('## Mid\n')
+      expect(htmlToWikiMarkdown('<h6>Tiny</h6>')).toBe('###### Tiny\n')
+    })
+
+    it('preserves inline emphasis inside headings', () => {
+      // Mirrors the broken-Gatsby form `<h2><strong>The Position</strong></h2>`.
+      expect(
+        htmlToWikiMarkdown('<h2><strong>The Position</strong></h2>'),
+      ).toBe('## **The Position**\n')
+    })
+
+    it('separates paragraphs with a blank line', () => {
+      const html = '<p>First.</p><p>Second.</p>'
+      expect(htmlToWikiMarkdown(html)).toBe('First.\n\nSecond.\n')
+    })
+
+    it('renders hr as a horizontal rule', () => {
+      expect(htmlToWikiMarkdown('<p>A</p><hr><p>B</p>')).toBe(
+        'A\n\n---\n\nB\n',
+      )
+    })
+
+    it('drops empty paragraphs the editor inserts', () => {
+      // Tiptap routinely appends a trailing <p></p> or <p><br></p> on
+      // every transaction; they would round-trip as blank lines forever
+      // if we didn't filter them.
+      expect(htmlToWikiMarkdown('<p>real</p><p></p>')).toBe('real\n')
+      expect(htmlToWikiMarkdown('<p>real</p><p><br></p>')).toBe('real\n')
+    })
+
+    it('drops empty headings', () => {
+      // `<h2></h2>` has no semantic meaning and parseSections rejects it
+      // anyway. Don't emit a stray `## ` line.
+      expect(htmlToWikiMarkdown('<h2></h2><p>body</p>')).toBe('body\n')
+    })
+  })
+
+  describe('inline marks', () => {
+    it('wraps strong/em/strike correctly', () => {
+      expect(
+        htmlToWikiMarkdown('<p><strong>bold</strong> and <em>em</em></p>'),
+      ).toBe('**bold** and *em*\n')
+      expect(
+        htmlToWikiMarkdown('<p>A <s>retracted</s> claim.</p>'),
+      ).toBe('A ~~retracted~~ claim.\n')
+    })
+
+    it('renders inline code', () => {
+      expect(htmlToWikiMarkdown('<p>Use <code>foo()</code>.</p>')).toBe(
+        'Use `foo()`.\n',
+      )
+    })
+
+    it('renders fenced code blocks', () => {
+      const html = '<pre><code>line1\nline2</code></pre>'
+      expect(htmlToWikiMarkdown(html)).toBe('```\nline1\nline2\n```\n')
+    })
+
+    it('converts links', () => {
+      expect(
+        htmlToWikiMarkdown('<p>See <a href="https://x">x</a>.</p>'),
+      ).toBe('See [x](https://x).\n')
+    })
+
+    it('collapses bare URLs to autolinks', () => {
+      // [https://x](https://x) is noisier than <https://x>, so emit
+      // the CommonMark autolink form.
+      expect(
+        htmlToWikiMarkdown('<p><a href="https://x">https://x</a></p>'),
+      ).toBe('<https://x>\n')
+    })
+  })
+
+  describe('lists', () => {
+    it('renders unordered lists', () => {
+      expect(
+        htmlToWikiMarkdown('<ul><li>one</li><li>two</li></ul>'),
+      ).toBe('- one\n- two\n')
+    })
+
+    it('renders ordered lists with incremented numbers', () => {
+      expect(
+        htmlToWikiMarkdown('<ol><li>one</li><li>two</li></ol>'),
+      ).toBe('1. one\n2. two\n')
+    })
+
+    it('nests sub-lists with two-space indent', () => {
+      const html =
+        '<ul><li>outer<ul><li>inner</li></ul></li><li>next</li></ul>'
+      expect(htmlToWikiMarkdown(html)).toBe(
+        '- outer\n  - inner\n- next\n',
+      )
+    })
+
+    it('keeps inline formatting inside list items', () => {
+      expect(
+        htmlToWikiMarkdown(
+          '<ul><li><strong>bold</strong> point</li></ul>',
+        ),
+      ).toBe('- **bold** point\n')
+    })
+  })
+
+  describe('blockquote', () => {
+    it('prefixes every line with > ', () => {
+      const html = '<blockquote><p>First.</p><p>Second.</p></blockquote>'
+      expect(htmlToWikiMarkdown(html)).toBe('> First.\n>\n> Second.\n')
+    })
+  })
+
+  describe('token preservation (the load-bearing case)', () => {
+    it('keeps inline [[fragment:slug]] text verbatim', () => {
+      // Client-side extraction already replaces citation chips with this
+      // text form before Tiptap sees the body. Round-trip must not mangle.
+      const html =
+        '<p>Some claim. [[fragment:my-frag]] More text.</p>'
+      expect(htmlToWikiMarkdown(html)).toBe(
+        'Some claim. [[fragment:my-frag]] More text.\n',
+      )
+    })
+
+    it('keeps inline [[wiki:slug]] text verbatim', () => {
+      const html = '<p>See [[wiki:related-belief]] for context.</p>'
+      expect(htmlToWikiMarkdown(html)).toBe(
+        'See [[wiki:related-belief]] for context.\n',
+      )
+    })
+
+    it('round-trips a citation <sup> chip from its data-fragment-slug attr', () => {
+      // If a chip survives to the server (edit extraction missed it, or
+      // the chip was pasted from another rendered surface), recover the
+      // token from the round-trip attribute so the canonical body still
+      // points at the right fragment.
+      const html =
+        '<p>A claim.<sup data-slot="wiki-citation" data-fragment-slug="my-frag">[1]</sup></p>'
+      expect(htmlToWikiMarkdown(html)).toBe(
+        'A claim.[[fragment:my-frag]]\n',
+      )
+    })
+
+    it('round-trips a cross-reference <a> chip from data-token-* attrs', () => {
+      const html =
+        '<p>See <a data-slot="wiki-chip" data-token-kind="wiki" data-token-slug="other" href="/wiki/other">Other</a>.</p>'
+      expect(htmlToWikiMarkdown(html)).toBe('See [[wiki:other]].\n')
+    })
+
+    it('falls back to link text when chip is missing token attrs', () => {
+      // Legacy rendered bodies don't carry data-token-*. Render as a
+      // standard link rather than dropping it.
+      const html =
+        '<p>See <a data-slot="wiki-chip" href="/wiki/other">Other</a>.</p>'
+      expect(htmlToWikiMarkdown(html)).toBe('See [Other](/wiki/other).\n')
+    })
+  })
+
+  describe('the broken-Gatsby shape end-to-end', () => {
+    it('converts a realistic Tiptap-saved wiki body into parseable markdown', () => {
+      // Modeled on the rural-water-services wiki the user tested with on
+      // 2026-05-24: HTML headings with bold inner text, paragraphs with
+      // multiple inline fragment tokens, lists in the body.
+      const html = [
+        '<h2><strong>The Position</strong></h2>',
+        '<p>Water utilities that demonstrate strong governance.</p>',
+        '<h2><strong>Evidence and Reasoning</strong></h2>',
+        '<p>Kenya loses $1.5B/year. [[fragment:kenya-water-loss]] Coverage is 57%. [[fragment:kenya-water-coverage]]</p>',
+        '<ul><li>One model is affermage. [[fragment:rwanda-affermage]]</li><li>Another is co-management.</li></ul>',
+      ].join('')
+
+      const md = htmlToWikiMarkdown(html)
+      expect(md).toContain('## **The Position**')
+      expect(md).toContain('## **Evidence and Reasoning**')
+      expect(md).toContain('[[fragment:kenya-water-loss]]')
+      expect(md).toContain('[[fragment:kenya-water-coverage]]')
+      expect(md).toContain('- One model is affermage. [[fragment:rwanda-affermage]]')
+    })
+  })
+})

--- a/core/src/lib/htmlToWikiMarkdown.ts
+++ b/core/src/lib/htmlToWikiMarkdown.ts
@@ -1,0 +1,306 @@
+/**
+ * Server-side HTML → markdown converter for wiki bodies saved through the
+ * inline Tiptap editor.
+ *
+ * Background: the read pipeline expects `wikis.content` to be markdown so
+ * `parseSections` / `deriveCitationDeclarations` / the remark plugins all
+ * fire. Tiptap, however, emits HTML on save. Without normalization the body
+ * ends up in HTML form, sections become unparseable, the citation map
+ * collapses, and inline citations fall back to slug-initial labels ([k] [l]
+ * instead of [1] [2]). See the 2026-05-24 Gatsby audit.
+ *
+ * The converter is intentionally narrow: it handles only the tag set the
+ * Tiptap StarterKit emits, plus a couple of post-render affordances (the
+ * `<sup data-slot="wiki-citation*">` chips and the `<a data-slot="wiki-chip">`
+ * cross-reference chips) that we sometimes leave in the DOM when the edit
+ * extraction can read their data-* round-trip attributes. Everything outside
+ * that set falls back to plain text content. No new dependencies beyond
+ * node-html-parser.
+ *
+ * Round-trip contract:
+ *   text  → markdown                preserved verbatim, including any
+ *                                   [[fragment:slug]] / [[kind:slug]] tokens
+ *                                   the edit extraction already inlined
+ *   <p>                  → `\n\n`-separated paragraph
+ *   <h1>..<h6>           → `#`..`######` heading
+ *   <strong>             → `**…**`
+ *   <em>                 → `*…*`
+ *   <s>                  → `~~…~~`             (GFM)
+ *   <code> (inline)      → `` `…` ``
+ *   <pre><code>          → ```\n…\n```         (fenced)
+ *   <a href>             → `[text](href)`
+ *   <br>                 → hard line break (`  \n` inside paragraph)
+ *   <hr>                 → `---`
+ *   <ul>/<ol> + <li>     → `- ` / `1. ` lists (with nesting + indentation)
+ *   <blockquote>         → `> …` prefix on every line
+ *   <sup data-slot="wiki-citation*">      → `[[fragment:<data-fragment-slug>]]`
+ *   <a data-slot="wiki-chip">             → `[[<data-token-kind>:<data-token-slug>]]`
+ *
+ * Anything else is unwrapped: the converter recurses into its children but
+ * emits no surrounding markdown. That keeps unexpected tags from corrupting
+ * the output while still preserving their text content.
+ */
+
+import { parse, HTMLElement, Node, NodeType, TextNode } from 'node-html-parser'
+
+/**
+ * Public entry point. Parses the input HTML and returns canonical markdown
+ * that the read pipeline can consume. Idempotent on already-markdown input:
+ * if the input contains no HTML tags, it's returned trimmed but otherwise
+ * unchanged.
+ */
+export function htmlToWikiMarkdown(html: string): string {
+  const trimmed = html?.trim() ?? ''
+  if (trimmed.length === 0) return ''
+
+  // Fast path: input has no tags. Nothing to convert; caller is probably
+  // re-saving content that was already markdown (e.g. our own regen output
+  // round-tripping through the editor). Treat as opaque, but ensure a
+  // trailing newline so the body matches the canonical form the parser
+  // path emits (otherwise the next save logs a no-op edit row).
+  if (!/<[a-zA-Z!\/]/.test(trimmed)) return trimmed.endsWith('\n') ? trimmed : trimmed + '\n'
+
+  // parse() wraps the input in a synthetic root; childNodes are the
+  // top-level blocks the editor emitted.
+  const root = parse(trimmed, { lowerCaseTagName: false, comment: false })
+
+  const out: string[] = []
+  for (const child of root.childNodes) {
+    const block = renderBlock(child, 0)
+    if (block.length > 0) out.push(block)
+  }
+
+  // Single trailing newline. parseSections is tolerant of either, but a
+  // canonical form keeps round-trips stable across edits.
+  return out.join('\n\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}
+
+// ── Block-level rendering ─────────────────────────────────────────────────
+
+/**
+ * Convert a block-level node to its markdown form. `depth` carries indentation
+ * state into nested lists/blockquotes.
+ */
+function renderBlock(node: Node, depth: number): string {
+  if (node.nodeType === NodeType.TEXT_NODE) {
+    // Top-level loose text: wrap as a paragraph so it doesn't collide with
+    // an adjacent block. (Tiptap shouldn't emit loose text at the document
+    // root, but be defensive.)
+    const text = (node as TextNode).text.trim()
+    return text
+  }
+  if (node.nodeType !== NodeType.ELEMENT_NODE) return ''
+
+  const el = node as HTMLElement
+  const tag = el.tagName?.toLowerCase()
+
+  switch (tag) {
+    case 'p':
+      return renderInline(el).trim()
+
+    case 'h1':
+    case 'h2':
+    case 'h3':
+    case 'h4':
+    case 'h5':
+    case 'h6': {
+      const level = Number(tag[1])
+      const inner = renderInline(el).trim()
+      // Drop empty headings: parseSections rejects them anyway, and
+      // emitting `## ` with no text creates a stray line that has no
+      // semantic meaning in the read pipeline.
+      if (inner.length === 0) return ''
+      return `${'#'.repeat(level)} ${inner}`
+    }
+
+    case 'ul':
+    case 'ol':
+      return renderList(el, depth)
+
+    case 'blockquote':
+      return renderBlockquote(el, depth)
+
+    case 'pre':
+      return renderPreCode(el)
+
+    case 'hr':
+      return '---'
+
+    case 'br':
+      // A bare <br> at block level is unusual but possible (e.g. between
+      // paragraphs the editor inserted). Treat as nothing.
+      return ''
+
+    default:
+      // Unknown block-level element. Recurse so we don't drop the prose
+      // inside; emit each child as its own block.
+      return el.childNodes
+        .map((c) => renderBlock(c, depth))
+        .filter((s) => s.length > 0)
+        .join('\n\n')
+  }
+}
+
+function renderList(el: HTMLElement, depth: number): string {
+  const ordered = el.tagName.toLowerCase() === 'ol'
+  const indent = '  '.repeat(depth)
+  const items: string[] = []
+  let counter = 1
+
+  for (const child of el.childNodes) {
+    if (child.nodeType !== NodeType.ELEMENT_NODE) continue
+    const li = child as HTMLElement
+    if (li.tagName?.toLowerCase() !== 'li') continue
+
+    const marker = ordered ? `${counter}. ` : '- '
+    counter++
+
+    // An <li> may contain inline text directly, or nested block elements
+    // (paragraphs, sub-lists, blockquotes). Separate the two.
+    const inlineParts: string[] = []
+    const blockParts: string[] = []
+    for (const grand of li.childNodes) {
+      if (grand.nodeType === NodeType.ELEMENT_NODE) {
+        const gel = grand as HTMLElement
+        const gtag = gel.tagName?.toLowerCase()
+        if (gtag === 'ul' || gtag === 'ol') {
+          blockParts.push(renderList(gel, depth + 1))
+          continue
+        }
+        if (gtag === 'p') {
+          // First <p> joins the item line; later <p>s become block parts so
+          // multi-paragraph list items round-trip.
+          if (inlineParts.length === 0 && blockParts.length === 0) {
+            inlineParts.push(renderInline(gel).trim())
+          } else {
+            blockParts.push(`${indent}  ${renderInline(gel).trim()}`)
+          }
+          continue
+        }
+        if (gtag === 'blockquote') {
+          blockParts.push(renderBlockquote(gel, depth + 1))
+          continue
+        }
+      }
+      // Plain inline content (text node, <strong>, <em>, etc).
+      inlineParts.push(renderInlineNode(grand))
+    }
+
+    const head = `${indent}${marker}${inlineParts.join('').trim()}`
+    if (blockParts.length === 0) {
+      items.push(head)
+    } else {
+      items.push([head, ...blockParts].join('\n'))
+    }
+  }
+
+  return items.join('\n')
+}
+
+function renderBlockquote(el: HTMLElement, depth: number): string {
+  const body = el.childNodes
+    .map((c) => renderBlock(c, depth))
+    .filter((s) => s.length > 0)
+    .join('\n\n')
+  return body
+    .split('\n')
+    .map((line) => (line.length === 0 ? '>' : `> ${line}`))
+    .join('\n')
+}
+
+function renderPreCode(el: HTMLElement): string {
+  // Tiptap CodeBlock renders <pre><code>…</code></pre>. node-html-parser
+  // treats <pre> contents as opaque raw text by default, so the inner <code>
+  // tag arrives as part of the text node, not as a child element. Strip
+  // the wrapper if present and use whatever's inside as the code body.
+  let code = el.text
+  const wrapped = code.match(/^\s*<code[^>]*>([\s\S]*?)<\/code>\s*$/)
+  if (wrapped) code = wrapped[1]
+  return '```\n' + code.replace(/\n+$/, '') + '\n```'
+}
+
+// ── Inline rendering ──────────────────────────────────────────────────────
+
+/**
+ * Render an element's children as inline markdown. Used inside block tags
+ * where we don't need surrounding structure (`<p>`, headings, list items).
+ */
+function renderInline(el: HTMLElement): string {
+  return el.childNodes.map(renderInlineNode).join('')
+}
+
+function renderInlineNode(node: Node): string {
+  if (node.nodeType === NodeType.TEXT_NODE) {
+    // Preserve text verbatim, including any `[[fragment:slug]]` /
+    // `[[kind:slug]]` tokens the client-side edit extraction inlined.
+    // We deliberately don't escape `[` / `]` here: doing so would break
+    // wiki-link tokens. Markdown emphasis chars (`*`, `_`, `` ` ``) are
+    // not currently escaped either, since Tiptap can't emit literal `*foo*`
+    // text without wrapping it in <em>, so the round-trip is safe.
+    return (node as TextNode).text
+  }
+  if (node.nodeType !== NodeType.ELEMENT_NODE) return ''
+
+  const el = node as HTMLElement
+  const tag = el.tagName?.toLowerCase()
+
+  switch (tag) {
+    case 'strong':
+    case 'b':
+      return `**${renderInline(el)}**`
+
+    case 'em':
+    case 'i':
+      return `*${renderInline(el)}*`
+
+    case 's':
+    case 'del':
+    case 'strike':
+      return `~~${renderInline(el)}~~`
+
+    case 'code':
+      // Inline code. Avoid double-backticks if the content has a backtick.
+      return `\`${el.text}\``
+
+    case 'br':
+      // Hard line break: two trailing spaces + newline is the CommonMark form.
+      return '  \n'
+
+    case 'sup': {
+      // Citation chip the read renderer may leave in the DOM. If it carries
+      // our round-trip slug, emit the markdown token form so the next regen
+      // / read can rebuild the chip from the canonical source.
+      const slot = el.getAttribute('data-slot')
+      if (slot === 'wiki-citation' || slot === 'wiki-citation-inline') {
+        const slug = el.getAttribute('data-fragment-slug')
+        if (slug) return `[[fragment:${slug}]]`
+      }
+      // Otherwise treat as inline text.
+      return renderInline(el)
+    }
+
+    case 'a': {
+      const slot = el.getAttribute('data-slot')
+      if (slot === 'wiki-chip') {
+        const kind = el.getAttribute('data-token-kind')
+        const slug = el.getAttribute('data-token-slug')
+        if (kind && slug) return `[[${kind}:${slug}]]`
+      }
+      const href = el.getAttribute('href') ?? ''
+      const text = renderInline(el).trim()
+      // Bare URL with matching text: collapse to autolink form `<url>` so
+      // the canonical markdown is shorter (`http://x` rather than `[x](x)`).
+      if (href && text === href) return `<${href}>`
+      return `[${text}](${href})`
+    }
+
+    case 'span':
+      // Tiptap doesn't emit bare `<span>`s but the editor sometimes leaves
+      // remnants from pasted content. Unwrap.
+      return renderInline(el)
+
+    default:
+      // Unknown inline element: drop the wrapper, keep the text.
+      return renderInline(el)
+  }
+}

--- a/core/src/routes/content.ts
+++ b/core/src/routes/content.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono'
-import { eq } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { sessionMiddleware } from '../middleware/session.js'
 import { db } from '../db/client.js'
-import { entries, fragments, wikis, people, edits } from '../db/schema.js'
+import { entries, fragments, wikis, people, edits, edges } from '../db/schema.js'
 import { VALID_TYPES, WRITE_SCHEMAS, type ContentType } from '../lib/content-schemas.js'
 import {
   contentRawResponseSchema,
@@ -12,6 +12,8 @@ import { okResponseSchema } from '../schemas/base.schema.js'
 import { logger } from '../lib/logger.js'
 import { nanoid } from '../lib/id.js'
 import { emitAuditEvent } from '../db/audit.js'
+import { htmlToWikiMarkdown } from '../lib/htmlToWikiMarkdown.js'
+import { deriveCitationDeclarations, type FragmentSlugMap } from '../lib/citations-from-markdown.js'
 
 const log = logger.child({ component: 'content' })
 
@@ -150,18 +152,82 @@ contentRoutes.put('/:type/:key', async (c) => {
       .limit(1)
     const previousContent = currentWiki?.content ?? ''
 
+    // The inline editor (Tiptap) emits HTML; the read pipeline expects
+    // canonical markdown so parseSections / deriveCitationDeclarations /
+    // remark plugins all fire. Normalize on save so wikis.content stays
+    // in one canonical form. htmlToWikiMarkdown is idempotent on
+    // markdown input (no-tag passthrough), so regen output round-
+    // tripping through here doesn't get re-converted.
+    //
+    // Defensive: a converter throw must not 500 the user's save. If the
+    // walker hits something it can't handle, log it and fall back to the
+    // raw HTML body. User keeps their edit; downstream rendering is
+    // degraded (slug-initial citation fallback) until the next regen
+    // restores canonical markdown. Worst case is the pre-fix status quo.
+    let normalizedBody = body
+    try {
+      normalizedBody = htmlToWikiMarkdown(body)
+    } catch (err) {
+      log.warn(
+        {
+          wikiKey: key,
+          err: err instanceof Error ? { name: err.name, message: err.message } : err,
+        },
+        'htmlToWikiMarkdown failed; storing raw body, next regen will recover',
+      )
+    }
+
+    // Re-derive citation declarations from the new body so the read-time
+    // sidecar reflects what the user just wrote, not what regen last cached.
+    // Without this, an edit that drops a `[[fragment:slug]]` reference
+    // leaves the bottom Citations list + the Fragments-tab cited/uncited
+    // status pointing at the pre-edit declarations.
+    //
+    // The wiki's attached fragment edges give us the slug↔lookupKey map
+    // deriveCitationDeclarations needs; tokens that don't resolve to an
+    // attached fragment are silently skipped (same contract as regen).
+    const attachedFragments = await db
+      .select({ lookupKey: fragments.lookupKey, slug: fragments.slug })
+      .from(fragments)
+      .innerJoin(
+        edges,
+        and(
+          eq(edges.srcId, fragments.lookupKey),
+          eq(edges.dstId, key),
+          eq(edges.edgeType, 'FRAGMENT_IN_WIKI'),
+          isNull(edges.deletedAt),
+        ),
+      )
+      .where(isNull(fragments.deletedAt))
+    const fragmentSlugMap: FragmentSlugMap = {
+      slugToKey: new Map(attachedFragments.map((f) => [f.slug, f.lookupKey])),
+      keySet: new Set(attachedFragments.map((f) => f.lookupKey)),
+    }
+    const derivedCitationDeclarations = deriveCitationDeclarations(
+      normalizedBody,
+      fragmentSlugMap,
+    )
+
     await db
       .update(wikis)
       .set({
         name: data.frontmatter.name as string,
         type: (data.frontmatter.type as string) ?? 'log',
         prompt: (data.frontmatter.prompt as string) ?? '',
-        content: body,
+        content: normalizedBody,
+        citationDeclarations: derivedCitationDeclarations,
+        // Stamp dirty_since so the editorial-state dot flips to
+        // "learning" (amber) and reflects that the wiki has unintegrated
+        // changes. The next autoregen pass hits the empty-partition
+        // skip path (no fragment edges changed), clears dirty_since,
+        // and the dot returns to green, body untouched. Without this
+        // stamp, hand edits leave no visible signal on the dot at all.
+        dirtySince: now,
         updatedAt: now,
       })
       .where(eq(wikis.lookupKey, key))
 
-    if (body && body !== previousContent) {
+    if (normalizedBody && normalizedBody !== previousContent) {
       await db.insert(edits).values({
         id: nanoid(),
         objectType: 'wiki',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       nanoid:
         specifier: ^5.0.0
         version: 5.1.7
+      node-html-parser:
+        specifier: ^7.1.0
+        version: 7.1.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -3132,6 +3135,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -3407,9 +3413,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -3576,8 +3589,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3740,6 +3766,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -4329,6 +4359,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
@@ -5330,6 +5364,9 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  node-html-parser@7.1.0:
+    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
@@ -5344,6 +5381,9 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -9497,6 +9537,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -9779,10 +9821,20 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -9906,9 +9958,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.6.1: {}
 
@@ -9978,6 +10048,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
 
   entities@8.0.0: {}
 
@@ -10164,7 +10236,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -10197,7 +10269,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10212,7 +10284,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10889,6 +10961,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  he@1.2.0: {}
 
   headers-polyfill@5.0.1:
     dependencies:
@@ -12088,6 +12162,11 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  node-html-parser@7.1.0:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-releases@2.0.37: {}
 
   normalize-path@3.0.0: {}
@@ -12100,6 +12179,10 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 

--- a/wiki/src/app/(shell)/people/[id]/page.tsx
+++ b/wiki/src/app/(shell)/people/[id]/page.tsx
@@ -69,7 +69,14 @@ function renderInfoboxValue(
       const [, kind, slug] = match;
       const ref = refs[`${kind}:${slug}`];
       if (ref) {
-        return <WikiChip label={ref.label} href={hrefForRef(ref)} />;
+        return (
+          <WikiChip
+            label={ref.label}
+            href={hrefForRef(ref)}
+            tokenKind={ref.kind}
+            tokenSlug={ref.slug}
+          />
+        );
       }
     }
     // Unresolved ref — fall back to the raw string so the user still sees

--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -94,7 +94,14 @@ function renderInfoboxValue(
   if (singleMatch) {
     const [, kind, slug] = singleMatch;
     const ref = refs[`${kind}:${slug}`];
-    if (ref) return <WikiChip label={ref.label} href={hrefForRef(ref)} />;
+    if (ref) return (
+      <WikiChip
+        label={ref.label}
+        href={hrefForRef(ref)}
+        tokenKind={ref.kind}
+        tokenSlug={ref.slug}
+      />
+    );
     return row.value;
   }
 
@@ -115,7 +122,15 @@ function renderInfoboxValue(
     }
     const ref = refs[`${kind}:${slug}`];
     if (ref) {
-      parts.push(<WikiChip key={parts.length} label={ref.label} href={hrefForRef(ref)} />);
+      parts.push(
+        <WikiChip
+          key={parts.length}
+          label={ref.label}
+          href={hrefForRef(ref)}
+          tokenKind={ref.kind}
+          tokenSlug={ref.slug}
+        />,
+      );
     } else {
       parts.push(whole);
     }

--- a/wiki/src/components/editor/InlineEditor.tsx
+++ b/wiki/src/components/editor/InlineEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import Placeholder from "@tiptap/extension-placeholder";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -10,6 +10,16 @@ type InlineEditorProps = {
   onChange: (html: string) => void;
   editable?: boolean;
   placeholder?: string;
+  /**
+   * Fired once when the editor has mounted and produced its first
+   * round-tripped HTML. The caller should reseat any "baseline" copy
+   * of the content to this value, because Tiptap normalizes input on
+   * load (StarterKit strips unknown tags, reformats whitespace, etc.)
+   * so the raw HTML we passed in does not match what the editor will
+   * report on subsequent updates. Without this, isDirty fires as soon
+   * as the editor mounts.
+   */
+  onReady?: (initialHtml: string) => void;
 };
 
 /**
@@ -24,7 +34,13 @@ export default function InlineEditor({
   onChange,
   editable = true,
   placeholder = "Write something...",
+  onReady,
 }: InlineEditorProps) {
+  // Keep the latest onReady in a ref so we can fire it from onCreate
+  // without rebuilding the editor every time the prop reference changes.
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -33,6 +49,9 @@ export default function InlineEditor({
     content,
     editable,
     immediatelyRender: false,
+    onCreate: ({ editor: instance }) => {
+      onReadyRef.current?.(instance.getHTML());
+    },
     onUpdate: ({ editor: instance }) => {
       onChange(instance.getHTML());
     },

--- a/wiki/src/components/wiki/MarkdownContent.tsx
+++ b/wiki/src/components/wiki/MarkdownContent.tsx
@@ -86,14 +86,27 @@ function buildComponents(
         : `[${ref.slug?.charAt(0) ?? "?"}]`;
       const href = fragmentCitationHref(ref.id);
       return (
-        <sup data-slot="wiki-citation-inline" className="cite">
+        <sup
+          data-slot="wiki-citation-inline"
+          data-fragment-slug={ref.slug}
+          className="cite"
+        >
           <a href={href} title={ref.label}>{label}</a>
         </sup>
       );
     }
 
     // Q2: single chip style — pass label + href only, no kind variant.
-    return <WikiChip label={ref.label} href={refToHref(ref)} />;
+    // Pass tokenKind/tokenSlug so the Edit-tab DOM extraction can
+    // round-trip the chip back to its `[[kind:slug]]` token.
+    return (
+      <WikiChip
+        label={ref.label}
+        href={refToHref(ref)}
+        tokenKind={ref.kind}
+        tokenSlug={ref.slug}
+      />
+    );
   };
 
   return {

--- a/wiki/src/components/wiki/WikiChip.tsx
+++ b/wiki/src/components/wiki/WikiChip.tsx
@@ -4,21 +4,35 @@ interface WikiChipProps {
   label: string
   href?: string
   className?: string
+  /**
+   * Underlying ref kind ("person" | "wiki" | "entry"). Combined with
+   * `tokenSlug`, renders `data-token-kind` and `data-token-slug` so the
+   * Edit-tab DOM extraction can round-trip the chip back to its
+   * `[[kind:slug]]` text token instead of destroying it. Required for
+   * any chip emitted from a `[[kind:slug]]` source so the round-trip
+   * survives a manual edit + save.
+   */
+  tokenKind?: string
+  tokenSlug?: string
 }
 
-function WikiChip({ label, href, className }: WikiChipProps) {
+function WikiChip({ label, href, className, tokenKind, tokenSlug }: WikiChipProps) {
   const classes = cn("wchip", className)
+  const tokenAttrs =
+    tokenKind && tokenSlug
+      ? { "data-token-kind": tokenKind, "data-token-slug": tokenSlug }
+      : undefined
 
   if (href) {
     return (
-      <a data-slot="wiki-chip" href={href} className={classes}>
+      <a data-slot="wiki-chip" href={href} className={classes} {...tokenAttrs}>
         {label}
       </a>
     )
   }
 
   return (
-    <span data-slot="wiki-chip" className={classes}>
+    <span data-slot="wiki-chip" className={classes} {...tokenAttrs}>
       {label}
     </span>
   )

--- a/wiki/src/components/wiki/WikiCitations.tsx
+++ b/wiki/src/components/wiki/WikiCitations.tsx
@@ -73,7 +73,11 @@ function CitationSuperscript({ citation, index }: CitationSuperscriptProps) {
   // so hover reveals the quote+capturedAt card.
   return (
     <Tooltip content={tooltipContent}>
-      <sup data-slot="wiki-citation" className="cite">
+      <sup
+        data-slot="wiki-citation"
+        data-fragment-slug={citation.fragmentSlug}
+        className="cite"
+      >
         <a href={href} title={citation.quote ?? undefined}>
           [{index}]
         </a>

--- a/wiki/src/components/wiki/WikiDiffInline.tsx
+++ b/wiki/src/components/wiki/WikiDiffInline.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useMemo } from "react";
+import { diffArrays, diffWordsWithSpace } from "diff";
+import { sanitizeWikiHtml } from "@/lib/sanitizeWikiHtml";
+
+/**
+ * Block-level HTML diff renderer.
+ *
+ * Splits the before/after HTML into top-level block elements
+ * (paragraphs, headings, lists, etc.), aligns matching blocks by text
+ * content, and renders unchanged blocks as-is. Added blocks gain a
+ * green background; removed blocks gain a red background + line-through.
+ *
+ * The output is wrapped in `.wiki-richtext-rendered` so it inherits the
+ * exact same typography (heading scale, paragraph spacing, list bullets)
+ * the Read mode uses, so the diff reads like the wiki, not like raw text.
+ *
+ * For pairs of removed+added blocks that share the same tag, a word-level
+ * diff runs inside them so a typo fix doesn't show as "whole paragraph
+ * gone + whole paragraph added".
+ */
+
+interface Block {
+  tag: string;
+  html: string;
+  text: string;
+}
+
+function splitBlocks(html: string): Block[] {
+  if (!html) return [];
+
+  // Server-side fallback: regex split on opening block tags. Less
+  // accurate than DOMParser but enough for SSR.
+  if (typeof window === "undefined") {
+    const parts = html.split(
+      /(?=<(?:h[1-6]|p|ul|ol|blockquote|pre|hr|table)\b)/i,
+    );
+    return parts
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => {
+        const m = s.match(/^<([a-z][a-z0-9]*)\b/i);
+        const tag = m ? m[1].toLowerCase() : "p";
+        return {
+          tag,
+          html: s,
+          text: s.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim(),
+        };
+      });
+  }
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const blocks: Block[] = [];
+  doc.body.childNodes.forEach((node) => {
+    if (node.nodeType !== 1) return;
+    const el = node as Element;
+    blocks.push({
+      tag: el.tagName.toLowerCase(),
+      html: el.outerHTML,
+      text: (el.textContent ?? "").replace(/\s+/g, " ").trim(),
+    });
+  });
+  return blocks;
+}
+
+const baseBlockStyle = {
+  borderRadius: 4,
+  padding: "2px 6px",
+  margin: "0 -6px",
+} as const;
+
+const addedStyle = {
+  ...baseBlockStyle,
+  backgroundColor: "var(--diff-added-bg)",
+};
+
+const removedStyle = {
+  ...baseBlockStyle,
+  backgroundColor: "var(--diff-removed-bg)",
+  textDecoration: "line-through",
+  textDecorationColor: "var(--diff-removed-text)",
+};
+
+const inlineAdded = {
+  backgroundColor: "var(--diff-added-bg)",
+  color: "var(--diff-added-text)",
+  padding: "0 1px",
+  borderRadius: 2,
+} as const;
+
+const inlineRemoved = {
+  backgroundColor: "var(--diff-removed-bg)",
+  color: "var(--diff-removed-text)",
+  textDecoration: "line-through",
+  padding: "0 1px",
+  borderRadius: 2,
+} as const;
+
+/**
+ * Render a word-level diff between two plain-text strings, preserving
+ * any HTML wrapper tag (h2, h3, p, etc.) so heading-vs-paragraph
+ * typography survives the diff.
+ */
+function WordLevelBlock({
+  tag,
+  before,
+  after,
+}: {
+  tag: string;
+  before: string;
+  after: string;
+}) {
+  const parts = diffWordsWithSpace(before, after);
+  const Tag = tag as keyof React.JSX.IntrinsicElements;
+  return (
+    <Tag>
+      {parts.map((p, i) => {
+        if (p.added) return <span key={i} style={inlineAdded}>{p.value}</span>;
+        if (p.removed) return <span key={i} style={inlineRemoved}>{p.value}</span>;
+        return <span key={i}>{p.value}</span>;
+      })}
+    </Tag>
+  );
+}
+
+type RenderItem =
+  | { kind: "equal"; block: Block }
+  | { kind: "added"; block: Block }
+  | { kind: "removed"; block: Block }
+  | { kind: "modified"; tag: string; before: string; after: string };
+
+/**
+ * Walk the diff output and coalesce same-tag remove+add pairs into a
+ * single "modified" item so identical-tag rewrites (a typo fix in a
+ * heading, a paragraph edit) render as a single word-diffed line
+ * instead of a strikethrough block followed by a green block.
+ */
+function buildRenderPlan(blocks: Array<{
+  value: Block[];
+  added?: boolean;
+  removed?: boolean;
+}>): RenderItem[] {
+  const out: RenderItem[] = [];
+  // Flatten array entries into one item per block so we can look at
+  // adjacent removed/added pairs.
+  const flat: Array<{ kind: "equal" | "added" | "removed"; block: Block }> = [];
+  for (const entry of blocks) {
+    const kind: "equal" | "added" | "removed" = entry.added
+      ? "added"
+      : entry.removed
+        ? "removed"
+        : "equal";
+    for (const block of entry.value) flat.push({ kind, block });
+  }
+
+  let i = 0;
+  while (i < flat.length) {
+    const curr = flat[i];
+    const next = flat[i + 1];
+    // Only coalesce same-tag remove+add pairs into a word-diffed line
+    // when the tag is a simple text container. Lists / tables / pre
+    // blocks expect specific child elements (`<li>`, `<tr>`) and would
+    // render invalid HTML if we put raw `<span>`s inside them.
+    const wordDiffableTags = new Set([
+      "p", "h1", "h2", "h3", "h4", "h5", "h6", "blockquote",
+    ]);
+    if (
+      curr.kind === "removed" &&
+      next &&
+      next.kind === "added" &&
+      curr.block.tag === next.block.tag &&
+      wordDiffableTags.has(curr.block.tag)
+    ) {
+      out.push({
+        kind: "modified",
+        tag: curr.block.tag,
+        before: curr.block.text,
+        after: next.block.text,
+      });
+      i += 2;
+      continue;
+    }
+    out.push(curr);
+    i += 1;
+  }
+  return out;
+}
+
+export interface WikiDiffInlineProps {
+  /** HTML snapshot at the start of editing, i.e. the "before" side. */
+  beforeHtml: string;
+  /** Live HTML from the editor, i.e. the "after" side. */
+  afterHtml: string;
+}
+
+export function WikiDiffInline({ beforeHtml, afterHtml }: WikiDiffInlineProps) {
+  const renderPlan = useMemo<RenderItem[]>(() => {
+    const before = splitBlocks(beforeHtml);
+    const after = splitBlocks(afterHtml);
+    const diff = diffArrays<Block>(before, after, {
+      comparator: (a, b) => a.text === b.text,
+    });
+    return buildRenderPlan(diff);
+  }, [beforeHtml, afterHtml]);
+
+  return (
+    <div className="wiki-richtext-rendered">
+      {renderPlan.map((item, i) => {
+        if (item.kind === "modified") {
+          return (
+            <WordLevelBlock
+              key={i}
+              tag={item.tag}
+              before={item.before}
+              after={item.after}
+            />
+          );
+        }
+        const style =
+          item.kind === "added"
+            ? addedStyle
+            : item.kind === "removed"
+              ? removedStyle
+              : undefined;
+        return (
+          <div
+            key={i}
+            style={style}
+            dangerouslySetInnerHTML={{ __html: sanitizeWikiHtml(item.block.html) }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/wiki/src/components/wiki/WikiEntityArticle.tsx
+++ b/wiki/src/components/wiki/WikiEntityArticle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -12,6 +13,7 @@ import AddWikiModal, {
   type WikiSettingsFormMode,
 } from "@/components/layout/AddWikiModal";
 import InlineEditor from "@/components/editor/InlineEditor";
+import { WikiDiffInline } from "@/components/wiki/WikiDiffInline";
 import WikiHistoryTimeline from "@/components/wiki/WikiHistoryTimeline";
 import WikiRegenTimeline from "@/components/wiki/WikiRegenTimeline";
 import { T, FONT } from "@/lib/typography";
@@ -416,6 +418,18 @@ export function WikiEntityArticle({
   // via ref and track its mode for the button label.
   const settingsFormRef = useRef<WikiSettingsFormHandle>(null);
   const [settingsMode, setSettingsMode] = useState<WikiSettingsFormMode>("view");
+  // Edit-mode diff toggle: when on, swap the InlineEditor for a
+  // read-only word-diff view in the same column space. Off by default
+  // so editing is the primary state; user opts in to "see what
+  // changed" when they want it. Effect below resets it on edit-mode
+  // exit so re-entering Edit always lands in the editor view.
+  const [showEditDiff, setShowEditDiff] = useState(false);
+  // True once the InlineEditor has mounted and reseated the baseline for
+  // the current Edit session. Subsequent editor mounts (e.g. after
+  // toggling Show changes off) must NOT re-anchor the baseline, or
+  // user-typed edits get re-classified as pristine and Save / Cancel
+  // disappear mid-edit. Reset in the effect that runs on isEditing=false.
+  const baselineAnchoredRef = useRef(false);
   const readContentRef = useRef<HTMLDivElement | null>(null);
 
   const updateTabInUrl = (tab: "read" | "fragments" | "history" | "settings" | null) => {
@@ -442,9 +456,11 @@ export function WikiEntityArticle({
 
   const {
     isEditing,
+    isDirty,
     isViewingHistory,
     draftContent,
     savedContent,
+    baselineContent,
     draftTitle,
     savedTitle,
     draftChipLabel,
@@ -453,6 +469,7 @@ export function WikiEntityArticle({
     setDraftContent,
     setDraftTitle,
     setDraftChipLabel,
+    setBaselineContent,
     enterEditMode,
     openHistory,
     closeHistory,
@@ -463,6 +480,18 @@ export function WikiEntityArticle({
     setInfoVisible,
     serverRevisions,
   });
+
+  // Reset Edit-session ephemera when isEditing flips off:
+  //  - diff toggle so re-entering Edit lands in the editor
+  //  - baseline-anchored flag so the NEXT Edit session reseats baseline
+  //    from a fresh Tiptap normalization (the one for the new editor
+  //    instance, not the one we cached last session).
+  useEffect(() => {
+    if (!isEditing) {
+      setShowEditDiff(false);
+      baselineAnchoredRef.current = false;
+    }
+  }, [isEditing]);
 
   const displayTitle = savedTitle ?? title;
   const displayChipLabel = savedChipLabel ?? chipLabel;
@@ -678,21 +707,94 @@ export function WikiEntityArticle({
                               : "wiki-article-tab"
                           }
                           onClick={() => {
-                            // Scope the read-mode HTML capture to the
-                            // `[data-wiki-body]` subtree so sidebar chrome
-                            // (Member Fragments, Mentioned People, citations,
-                            // etc.) never leaks into the Tiptap draft.
-                            // Strip [data-slot] affordances (edit-link,
-                            // references, see-also, citation chips) since
-                            // they are interactive UI, not author content.
+                            // Scope the read-mode HTML capture to the `[data-wiki-body]`
+                            // subtree so sidebar chrome (Member Fragments,
+                            // Mentioned People, citations, etc.) never leaks
+                            // into the Tiptap draft and gets baked into
+                            // `wikis.content` on save (#241). Fall back to the
+                            // wrapper innerHTML for callers that haven't opted
+                            // in yet (e.g. the People page).
+                            //
+                            // Within the body, three passes so citation
+                            // tokens roundtrip cleanly through Tiptap:
+                            //  1. Replace inline citation chips
+                            //     (wiki-citation / wiki-citation-inline)
+                            //     with plain-text `[[fragment:slug]]`
+                            //     tokens. Read-mode's
+                            //     useWikiTokenSubstitution will swap them
+                            //     back to numbered chips at render time.
+                            //  2. Unwrap the citations wrapper span
+                            //     (wiki-citations): keep its now-text
+                            //     children, drop the wrapper. Otherwise
+                            //     pass 3 would remove the wrapper AND
+                            //     the text tokens inside it.
+                            //  3. Strip remaining [data-slot] affordances
+                            //     (edit-link, references, see-also, hint,
+                            //     citations-section, etc.) which are interactive
+                            //     UI, not author content.
                             let bodyHtml = "";
                             const bodyEl = readContentRef.current?.querySelector("[data-wiki-body]");
                             if (bodyEl) {
                               const clone = bodyEl.cloneNode(true) as HTMLElement;
+                              clone
+                                .querySelectorAll(
+                                  '[data-slot="wiki-citation"], [data-slot="wiki-citation-inline"]',
+                                )
+                                .forEach((n) => {
+                                  const slug = (n as HTMLElement).dataset.fragmentSlug;
+                                  if (slug) {
+                                    n.replaceWith(
+                                      document.createTextNode(`[[fragment:${slug}]]`),
+                                    );
+                                  } else {
+                                    n.remove();
+                                  }
+                                });
+                              // Cross-reference chips (`[[kind:slug]]` for
+                              // person / wiki / entry) round-trip back
+                              // to their text-token form using the
+                              // data-token-* attributes baked into the
+                              // rendered chip by WikiChip + the runtime
+                              // walker. Skip if either attr is missing
+                              // (legacy chips without the round-trip
+                              // metadata fall through to the strip pass).
+                              clone
+                                .querySelectorAll('[data-slot="wiki-chip"]')
+                                .forEach((n) => {
+                                  const el = n as HTMLElement;
+                                  const kind = el.dataset.tokenKind;
+                                  const slug = el.dataset.tokenSlug;
+                                  if (kind && slug) {
+                                    n.replaceWith(
+                                      document.createTextNode(`[[${kind}:${slug}]]`),
+                                    );
+                                  } else {
+                                    n.remove();
+                                  }
+                                });
+                              clone
+                                .querySelectorAll('[data-slot="wiki-citations"]')
+                                .forEach((n) => {
+                                  const parent = n.parentNode;
+                                  if (!parent) return;
+                                  while (n.firstChild) parent.insertBefore(n.firstChild, n);
+                                  parent.removeChild(n);
+                                });
                               clone.querySelectorAll("[data-slot]").forEach((n) => n.remove());
                               bodyHtml = clone.innerHTML;
                             } else {
                               bodyHtml = readContentRef.current?.innerHTML ?? "";
+                            }
+                            // Edit mode is exclusive: the editor branch
+                            // wins the content render, so any other tab
+                            // click is a no-op visually until edit mode
+                            // exits. Auto-exit when pristine (nothing
+                            // to lose). When dirty, block the nav, since
+                            // Save / Cancel are visible above to resolve
+                            // explicitly.
+                            if (tab !== "Edit" && isEditing) {
+                              if (isDirty) return;
+                              handleCancel();
                             }
                             if (tab === "Edit") {
                               setIsViewingFragments(false);
@@ -783,11 +885,12 @@ export function WikiEntityArticle({
 
           {/* Page-action row: sits below the tab bar, above the content
               box. Hosts mode-specific buttons:
-                - Edit mode → Save / Cancel
+                - Edit mode: Save / Cancel (only while isDirty, since no point
+                  saving or bailing out before anything's changed)
                 - Settings tab → Edit Wiki Settings / Save (label tracks
                   the embedded form's mode via WikiSettingsFormHandle).
               Right-aligned to match the tab bar. */}
-          {isEditing && (
+          {isEditing && isDirty && (
             <div
               style={{
                 display: "flex",
@@ -797,6 +900,21 @@ export function WikiEntityArticle({
                 paddingBottom: 12,
               }}
             >
+              <button
+                type="button"
+                onClick={() => setShowEditDiff((v) => !v)}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 13,
+                  fontFamily: FONT.SANS,
+                  color: "var(--wiki-article-text)",
+                  background: "none",
+                  border: "1px solid var(--wiki-card-border)",
+                  cursor: "pointer",
+                }}
+              >
+                {showEditDiff ? "Hide changes" : "Show changes"}
+              </button>
               <button
                 type="button"
                 onClick={() => {
@@ -927,11 +1045,36 @@ export function WikiEntityArticle({
                 ? renderCustomInfobox()
                 : null}
               {isEditing ? (
-                <InlineEditor
-                  content={draftContent}
-                  onChange={setDraftContent}
-                  editable
-                />
+                // Show-changes toggle swaps the editor for a read-only
+                // word-diff view in the same column slot. Same green-add
+                // / red-strikethrough treatment as the History tab.
+                showEditDiff && isDirty ? (
+                  <WikiDiffInline
+                    beforeHtml={baselineContent}
+                    afterHtml={draftContent}
+                  />
+                ) : (
+                  <InlineEditor
+                    content={draftContent}
+                    onChange={setDraftContent}
+                    editable
+                    onReady={(normalized) => {
+                      // Tiptap reformats the input on mount: citations,
+                      // unknown attrs, etc. get stripped. Reseat both
+                      // baseline and draft to that normalized snapshot
+                      // so a pristine editor reads as !isDirty.
+                      //
+                      // Only do this ONCE per Edit session. The editor
+                      // re-mounts when the user toggles Show changes
+                      // on/off, and re-anchoring there would wipe
+                      // isDirty mid-edit and disappear Save / Cancel.
+                      if (baselineAnchoredRef.current) return;
+                      baselineAnchoredRef.current = true;
+                      setBaselineContent(normalized);
+                      setDraftContent(normalized);
+                    }}
+                  />
+                )
               ) : isViewingHistory ? (
                 // Phase 2: History is the unified stream. WikiRegenTimeline
                 // already merges /history (edit revisions) + /timeline (audit

--- a/wiki/src/components/wiki/useWikiEntityEditMode.ts
+++ b/wiki/src/components/wiki/useWikiEntityEditMode.ts
@@ -25,6 +25,8 @@ export type WikiEntityEditMode = {
   isDirty: boolean;
   draftContent: string;
   savedContent: string | null;
+  /** Snapshot of body HTML at the moment enterEditMode() ran. */
+  baselineContent: string;
   draftTitle: string;
   savedTitle: string | null;
   draftChipLabel: string;
@@ -33,6 +35,13 @@ export type WikiEntityEditMode = {
   setDraftContent: (value: string) => void;
   setDraftTitle: (value: string) => void;
   setDraftChipLabel: (value: string) => void;
+  /** Reseat the baseline used by isDirty + the diff preview. The
+   *  editor normalizes HTML on mount (StarterKit strips unknown tags,
+   *  reformats attribute order, etc.), so the raw HTML we passed into
+   *  enterEditMode doesn't match what Tiptap produces. Once the editor
+   *  emits its post-mount snapshot, callers reseat baseline + draft to
+   *  that snapshot so a pristine editor reads as !isDirty. */
+  setBaselineContent: (value: string) => void;
   enterEditMode: (args: {
     currentHtml: string;
     currentTitle: string;
@@ -273,6 +282,10 @@ export function useWikiEntityEditMode({
     isDirty,
     draftContent,
     savedContent,
+    /** Snapshot taken when enterEditMode() ran; drives the diff
+     *  preview in WikiEntityArticle so "before" stays the version the
+     *  user started editing from, not the most recently saved one. */
+    baselineContent,
     draftTitle,
     savedTitle,
     draftChipLabel,
@@ -281,6 +294,7 @@ export function useWikiEntityEditMode({
     setDraftContent,
     setDraftTitle,
     setDraftChipLabel,
+    setBaselineContent,
     enterEditMode,
     openHistory,
     closeHistory,

--- a/wiki/src/lib/htmlTokenSubstitute.ts
+++ b/wiki/src/lib/htmlTokenSubstitute.ts
@@ -96,6 +96,7 @@ function tokenReplacementFragment(
           : `[${ref.slug?.charAt(0) ?? '?'}]`
         const sup = doc.createElement('sup')
         sup.setAttribute('data-slot', 'wiki-citation-inline')
+        sup.setAttribute('data-fragment-slug', ref.slug ?? slug)
         sup.className = 'cite'
         const anchor = doc.createElement('a')
         anchor.setAttribute('href', `#fragment-${ref.id}`)
@@ -107,6 +108,11 @@ function tokenReplacementFragment(
         const anchor = doc.createElement('a')
         anchor.className = 'wchip'
         anchor.setAttribute('data-slot', 'wiki-chip')
+        // Round-trip data: edit-tab extraction reads these to
+        // reconstruct `[[kind:slug]]` text tokens instead of
+        // destroying the chip on a manual edit + save.
+        anchor.setAttribute('data-token-kind', ref.kind)
+        anchor.setAttribute('data-token-slug', ref.slug ?? slug)
         anchor.setAttribute('href', refToHref(ref))
         anchor.textContent = ref.label
         frag.appendChild(anchor)


### PR DESCRIPTION
## Summary

End-to-end fix for the citation-loss-on-manual-edit bug: tokens inside the wiki body now survive a Tiptap edit round-trip, the saved body lands as canonical markdown (not HTML), and the editor surface gains a dirty gate, a baseline-anchored diff preview, and pristine-tab auto-exit.

- **Token round-trip safety**: citation chips + cross-reference chips → text tokens during DOM extraction → survive Tiptap → server converts HTML to markdown before storing.
- **Editor UX**: Save / Cancel / Show changes only render when the draft is dirty; baseline reseats to Tiptap's normalised snapshot once per session; word-level diff preview in the same column slot as the editor.
- **Adjacent fixes**: re-derive citation declarations on user edit so the bottom Citations list stays current; stamp `dirty_since` on user edit so the editorial-state dot reflects unintegrated changes.

**Stacks on #403** (tabbed sub-pages). Merge that first.

## Why

Pre-fix, opening Edit → typing → saving destroyed every `[[fragment:slug]]` / `[[kind:slug]]` token in the body. Two mechanisms collaborated to lose them:

1. The Edit-tab DOM extraction did a blanket-strip of every `[data-slot]` element before feeding the body to Tiptap. Citation chips and cross-reference chips got dropped — their text-token equivalents were destroyed.
2. Tiptap saves HTML. The pipeline expected markdown. `parseSections` returned an empty array for HTML bodies, the citation map collapsed, and inline citations fell back to slug-initial labels (`[k]` `[l]` instead of `[1]` `[2]`).

## The data-integrity half

### Tokens survive the round-trip

- New `data-fragment-slug` attr on every citation `<sup>` emitter (the sidecar-driven `WikiCitations`, the remark-rendered `MarkdownContent`, and the runtime walker in `htmlTokenSubstitute`).
- New `data-token-kind` + `data-token-slug` attrs on the cross-reference `<a class="wchip">` chip (via the `WikiChip` component + the runtime walker).
- Edit-tab extraction in `WikiEntityArticle` walks the cloned DOM in passes:
    1. Replace `[data-slot="wiki-citation*"]` chips with text-node `[[fragment:slug]]` tokens.
    2. Replace `[data-slot="wiki-chip"]` chips with text-node `[[kind:slug]]` tokens.
    3. Unwrap the `[data-slot="wiki-citations"]` wrapper span (keep its now-text children — otherwise the strip pass would remove the wrapper AND the text tokens inside).
    4. Blanket-strip remaining `[data-slot]` affordances (edit links, references, see-also, hint, citations-section).

### Saved body is canonical markdown

New module `core/src/lib/htmlToWikiMarkdown.ts` walks the Tiptap-emitted HTML and produces equivalent markdown. Sized specifically for the StarterKit tag set: `p`, `h1`-`h6`, `ul`/`ol`/`li`, `blockquote`, `pre`/`code`, `strong`, `em`, `s`, `code` (inline), `a`, `br`, `hr`. Unknown elements get unwrapped (children preserved as text). 26 unit tests covering each tag, token preservation, edge cases (empty paragraphs the editor inserts, nested marks, bare-URL autolink collapse, idempotency on already-markdown input).

Wired into `PUT /api/content/wiki/:id` in `core/src/routes/content.ts`. Defensive try/catch — if the converter throws on shape we haven't seen, the save falls back to storing the raw HTML body and warn-logs. Worst case is the pre-fix status quo, not a 500.

`wikis.content` is now canonical markdown end-to-end — whether the LLM (regen) or the user (inline editor) wrote it last.

### Citation declarations stay current on user edits

`buildSidecar` attaches citations from the STORED `wikis.citationDeclarations` column. Regen writes that column; hand edits did not. Without this fix, an edit that drops a `[[fragment:foo]]` reference would leave the bottom Citations list + the Fragments-tab cited/uncited status pointing at the pre-edit body's declarations.

Fix: in the same save path, re-derive citation declarations from the new body via `deriveCitationDeclarations` and write them alongside the body update. The wiki's attached fragments (FRAGMENT_IN_WIKI edges) supply the slug↔lookupKey map; tokens that don't resolve to an attached fragment are silently skipped (same contract as regen).

### Edit signal on the editorial-state dot

Hand edits now stamp `wikis.dirty_since`, flipping the dot from filed (green) to learning (amber) right after a save. The next autoregen pass hits the empty-partition skip (no fragment edges changed), clears `dirty_since`, and the dot returns to green. Body untouched throughout. Without this stamp, hand edits left zero visible signal on the dot.

## The editor-UX half

### Dirty-gated action buttons

Save / Cancel / Show changes only render when the draft actually differs from the baseline. Entering Edit no longer offers a Save button for a pristine draft; Cancel is indistinguishable from clicking the Read tab.

### Baseline-reseat on Tiptap mount

Tiptap normalises HTML on mount: StarterKit strips unknown tags and attrs, reformats whitespace. The raw HTML passed into `enterEditMode` doesn't match what Tiptap will report on subsequent updates, so the dirty check used to fire instantly (comparing raw input to Tiptap-normalised draft).

`InlineEditor` now exposes an `onReady` callback fired from Tiptap's `onCreate` with the post-mount HTML snapshot. `useWikiEntityEditMode` exposes `setBaselineContent` so the parent can reseat the baseline outside `enterEditMode`. The parent wires `onReady` to overwrite both baseline and draft with the normalised snapshot. A pristine editor now reads as `!isDirty` — no Save / Cancel / Show changes, no diff render.

A `baselineAnchoredRef` flag ensures the reseat fires **once per Edit session**. The editor remounts when the user toggles Show changes; re-anchoring there would wipe the dirty flag mid-edit and disappear Save / Cancel. The flag resets when `isEditing` flips off, so the next Edit session anchors fresh.

### Show / Hide changes toggle

When the draft is dirty, an outlined "Show changes" button appears in the action row beside Save / Cancel. Clicking it swaps the InlineEditor for a read-only word-diff view in the same column slot — same green-add / red-strikethrough treatment the History tab uses. New `WikiDiffInline` component does the diff at block level (split HTML into top-level blocks, align by text-content equality, render unchanged blocks with their HTML, mark added/removed blocks). Adjacent same-tag remove+add pairs coalesce into a word-diffed line so a typo fix in a heading doesn't render as a full-paragraph delete + insert.

The toggle resets on edit-mode exit so re-entering Edit always lands in the editor view.

### Pristine-tab nav auto-exit

Edit mode is exclusive — the editor branch wins the content render, so clicking any other tab is a no-op visually until edit mode exits. New behavior: when leaving Edit and `!isDirty`, auto-exit edit mode (no work to lose). When dirty, block the click — Save / Cancel are visible above to resolve explicitly.

## Notable caveats

- **Wikis already broken on the server** (HTML body, no tokens) do not auto-heal on this PR. They heal on the next save through the new code path, or on the next regen.
- **Edit overwrite on autoregen**: the dirty-state stamp leaves edits at risk of overwrite when a new fragment attaches to the wiki and triggers an autoregen with a non-empty partition. That's the cache contract working as designed — fragments own the body. Users can disable autoregen on a wiki to lock in their edits permanently.
- **Tiptap silently strips unknown content**: tables, footnotes, raw HTML embedded in markdown get stripped on editor load — pre-existing Tiptap limitation, not introduced here, but worth flagging because this PR makes the loss permanent (the converter produces markdown without the dropped content).

## Files

### New
- `core/src/lib/htmlToWikiMarkdown.ts` — the converter
- `core/src/lib/htmlToWikiMarkdown.test.ts` — 26 unit tests
- `wiki/src/components/wiki/WikiDiffInline.tsx` — block-level diff

### Backend (modified)
- `core/src/routes/content.ts` — wire converter, re-derive declarations, stamp `dirty_since`
- `core/package.json` + `pnpm-lock.yaml` — add `node-html-parser`

### Frontend (modified)
- `wiki/src/components/wiki/WikiEntityArticle.tsx` — edit-tab UX, DOM extraction passes, baseline reseat, dirty gate, diff toggle, pristine tab auto-exit
- `wiki/src/components/editor/InlineEditor.tsx` — `onReady`
- `wiki/src/components/wiki/useWikiEntityEditMode.ts` — `setBaselineContent` export
- `wiki/src/components/wiki/WikiCitations.tsx` — `data-fragment-slug`
- `wiki/src/components/wiki/MarkdownContent.tsx` — same + `tokenKind`/`tokenSlug` on WikiChip
- `wiki/src/components/wiki/WikiChip.tsx` — `tokenKind`/`tokenSlug` props
- `wiki/src/lib/htmlTokenSubstitute.ts` — emit `data-*` round-trip attrs on walker-generated chips
- `wiki/src/app/(shell)/wiki/[id]/page.tsx` — thread token props through infobox ref renderer
- `wiki/src/app/(shell)/people/[id]/page.tsx` — same

## Test plan

### Round-trip safety
- [ ] Open a wiki with citations → Edit → change one word → Save. Body in DB is markdown starting with `## …`, contains the original `[[fragment:slug]]` tokens.
- [ ] Same wiki on Read: inline `[N]` superscripts render with correct numbering; bottom Citations list matches.
- [ ] Cross-references: a wiki with `[[wiki:other]]` chips → Edit → Save → chip survives, body has `[[wiki:other]]` text.

### Citation re-derive
- [ ] Edit a wiki, delete a paragraph containing `[[fragment:foo]]` (where `foo` was cited only there) → Save → bottom Citations list no longer shows `foo`, Fragments-tab status for `foo` flips to `uncited`.

### Dirty gate
- [ ] Open Edit, change nothing → no Save / Cancel / Show changes buttons.
- [ ] Type a single character → all three appear.
- [ ] Toggle Show changes → diff renders in place; click Hide changes → editor returns; Save / Cancel stay visible (dirty hasn't been reset).
- [ ] Hit Cancel → returns to Read, body unchanged.

### Edit dot signal
- [ ] After a save, the editorial-state dot turns amber for ~5 minutes, then returns to green after the autoregen worker's empty-partition skip clears `dirty_since`. Body remains exactly as saved throughout.

### Pristine tab nav
- [ ] Open Edit, change nothing → click Read tab → returns to Read.
- [ ] Open Edit, type something → click Read tab → click is blocked (no nav).

### Defensive paths
- [ ] `pnpm --filter @robin/core typecheck` passes
- [ ] `pnpm --filter @robin/core test htmlToWikiMarkdown` — 26/26 pass
- [ ] `pnpm --filter @robin/wiki typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
