### PR TITLE
perf(regen): fire batch every 12h instead of midnight-only; raise BATCH_LIMIT 5 → 50

### DIFF
--- a/core/src/queue/regen-worker.ts
+++ b/core/src/queue/regen-worker.ts
@@ -12,8 +12,16 @@ import { enqueueWikiRegen, filterDebouncedWikiKeys, regenDebounceMs } from './re
 
 const log = logger.child({ component: 'regen-worker' })
 
-/** Max wikis to process in a single batch job */
-const BATCH_LIMIT = 5
+/**
+ * Max wikis to process in a single batch job.
+ *
+ * The batch scheduler fires every 12 hours (see scheduler.ts). Each
+ * firing can enqueue up to BATCH_LIMIT regen jobs. At 50, an instance
+ * can clear up to 100 dirty wikis/day via the auto path before users
+ * hit manual-trigger territory. Sized for heavy-ingest scenarios
+ * (e.g. fresh KB builds) without spiking per-tick LLM cost too far.
+ */
+const BATCH_LIMIT = 50
 
 /** Stale threshold removed — wikis only regen when they have new fragments or are stuck */
 

--- a/core/src/queue/scheduler.ts
+++ b/core/src/queue/scheduler.ts
@@ -4,7 +4,10 @@ import { logger } from '../lib/logger.js'
 const log = logger.child({ component: 'scheduler' })
 
 /**
- * Set up the midnight regen batch scheduler using BullMQ's upsertJobScheduler.
+ * Set up the regen batch scheduler using BullMQ's upsertJobScheduler.
+ * Fires every 12 hours (midnight and noon UTC). The scheduler name
+ * 'midnight-regen' is retained for back-compat with existing BullMQ
+ * persistence: renaming would orphan the previously-registered job.
  * If ENABLE_BATCH_REGEN is explicitly 'false', this is a no-op.
  */
 export async function setupRegenScheduler(queue: Queue): Promise<void> {
@@ -15,7 +18,7 @@ export async function setupRegenScheduler(queue: Queue): Promise<void> {
 
   await queue.upsertJobScheduler(
     'midnight-regen',
-    { pattern: '0 0 * * *' },
+    { pattern: '0 */12 * * *' },
     {
       name: 'regen-batch',
       // SEC-H6: scheduler-emitted jobs flow through the same signed-payload
@@ -31,7 +34,7 @@ export async function setupRegenScheduler(queue: Queue): Promise<void> {
     }
   )
 
-  log.info('midnight regen batch scheduler registered')
+  log.info('regen batch scheduler registered (every 12 hours)')
 }
 
 /**


### PR DESCRIPTION
## Summary

The regen auto-path's throughput today is capped at ~5 wikis/day:

- `core/src/queue/scheduler.ts` registers the batch sweep with `pattern: '0 0 * * *'` — fires **once a day at midnight UTC**.
- `core/src/queue/regen-worker.ts` defines `BATCH_LIMIT = 5` — caps each firing at **5 wikis enqueued**.

Combined effect: at most 5 dirty wikis get auto-regenerated per day. In heavy-ingest scenarios (operator dumps 30+ entries when seeding a new KB; per-wiki rebuild after a Quill voice/prompt change; reorganisation work), 25+ wikis sit dirty for *days* unless the operator manually clicks Regenerate Now on each one.

## Change

Two one-line tuning changes:

1. **Cron from once-a-day to every 12 hours.** `'0 0 * * *'` → `'0 */12 * * *'`. Fires at midnight and noon UTC.
2. **BATCH_LIMIT from 5 to 50.** Each firing can enqueue up to 50 regens.

Combined: up to 100 wikis/day cleared via the auto path, vs 5/day today.

## Cost / load implications

- **Per-tick LLM cost ceiling rises ~10×.** Today: ~5 × $0.05 ≈ $0.25 per midnight firing (worst case). After: ~50 × $0.05 ≈ $2.50 per firing × 2 firings/day = ~$5/day worst case if every wiki in the system is dirty at both firings. In practice most firings have fewer than 50 candidates, so the actual ceiling is rarely hit.
- **OpenRouter rate-limit pressure** is the main practical risk. The existing regen worker serialises via `wikiRegenLock` (one regen at a time per process), so 50 wikis still process sequentially rather than in parallel. Spreading across 12-hour windows further reduces burst pressure vs a single midnight spike.
- **Manual `Regenerate Now`** continues to work as today — operators retain immediate per-wiki control when they don't want to wait.

## What's not changed

- `wikiRegenLock` (serialisation guarantee).
- `REGEN_DEBOUNCE_MS` (5-minute quiet-window filter for Reasons 1 + 2).
- Reasons 3 + 4 (stuck / learning) continue to bypass the debounce.
- `ENABLE_BATCH_REGEN=false` no-op behaviour.
- The BullMQ scheduler name `midnight-regen` (retained for back-compat with existing persistence — renaming would orphan the registered job).
- Schema (no migration).

## Test plan

- [ ] On deploy, observe `[scheduler] regen batch scheduler registered (every 12 hours)` in startup logs.
- [ ] Verify the scheduler entry in Redis: BullMQ should show one repeatable job under `midnight-regen` with the new pattern.
- [ ] Dirty more than 5 wikis (set `wikis.dirty_since = now()` on a sample, with `autoregen = true`).
- [ ] Wait for the next scheduled firing OR trigger manually via BullMQ.
- [ ] Verify `pipeline_events` shows `stage='regen'` events for all dirty wikis (up to 50), not just the first 5.
- [ ] Verify completed wikis have `dirty_since = NULL` after regen.
- [ ] Confirm `Regenerate Now` still works on individual wikis during heavy batch processing (lock serialisation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
