### PR TITLE
chore: remove deprecated baseUrl option from tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "paths": {
       "@robin/agent": ["packages/agent/src/index.ts"],
       "@robin/graph": ["packages/graph/src/index.ts"],


### PR DESCRIPTION
## Summary

baseUrl is not required in TypeScript 5+. paths resolves correctly without it.

<!--
Lead with user impact. The PR title and this body double as release notes,
so write them as if a user is skimming the changelog. Screenshots or short
clips are welcome for UI changes.
-->

## Related issues

<!--
Link any related GitHub issues. Use "closes #<n>", "fixes #<n>", or
"resolves #<n>" to auto-close on merge.
-->

## How to test

<!--
Steps a reviewer can follow locally. Note any env vars, migrations, or
seed data required.
-->

## Checklist

- [x] I have run and reviewed this code locally.
- [x] `pnpm typecheck` passes.
- [ ] `pnpm lint` passes.
- [ ] Tests added or updated where applicable, and `pnpm test` passes.
- [ ] Database migrations included if the schema changed.
- [ ] Screenshots or recordings attached for UI changes.
- [x] PR title follows the conventional-commit style and reads as a release note.
