### PR TITLE
fix: add schema qualifier to drizzle migrations count queries

### DIFF
--- a/core/src/bootstrap/run-migrations.ts
+++ b/core/src/bootstrap/run-migrations.ts
@@ -110,11 +110,11 @@ export async function runMigrations(): Promise<void> {
   let appliedBefore = 0
   try {
     const rows = await db.execute<{ created_at: number }>(
-      /* sql */ `SELECT created_at FROM "__drizzle_migrations" ORDER BY created_at`
+      /* sql */ `SELECT created_at FROM "drizzle"."__drizzle_migrations" ORDER BY created_at`
     )
     appliedBefore = Array.isArray(rows) ? rows.length : 0
-  } catch {
-    // Table doesn't exist yet — first run, zero applied
+  } catch (err) {
+    log.warn({ err }, 'could not count pre-migrate rows — assuming first run')
     appliedBefore = 0
   }
 
@@ -125,10 +125,11 @@ export async function runMigrations(): Promise<void> {
   let appliedAfter = 0
   try {
     const rows = await db.execute<{ created_at: number }>(
-      /* sql */ `SELECT created_at FROM "__drizzle_migrations" ORDER BY created_at`
+      /* sql */ `SELECT created_at FROM "drizzle"."__drizzle_migrations" ORDER BY created_at`
     )
     appliedAfter = Array.isArray(rows) ? rows.length : 0
-  } catch {
+  } catch (err) {
+    log.warn({ err }, 'could not count post-migrate rows — newCount will be unreliable')
     appliedAfter = appliedBefore
   }
 


### PR DESCRIPTION
The __drizzle_migrations table lives in the drizzle schema, not public. Without the qualifier the queries failed silently, newCount was always 0,
updateJournalSha() never ran, and the drift check fired on every deploy after new migrations were applied.

## Summary

<!--
Lead with user impact. The PR title and this body double as release notes,
so write them as if a user is skimming the changelog. Screenshots or short
clips are welcome for UI changes.
-->

## Related issues

<!--
Link any related GitHub issues. Use "closes #<n>", "fixes #<n>", or
"resolves #<n>" to auto-close on merge.
-->

## How to test

<!--
Steps a reviewer can follow locally. Note any env vars, migrations, or
seed data required.
-->

## Checklist

- [x] I have run and reviewed this code locally.
- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes.
- [ ] Tests added or updated where applicable, and `pnpm test` passes.
- [ ] Database migrations included if the schema changed.
- [ ] Screenshots or recordings attached for UI changes.
- [x] PR title follows the conventional-commit style and reads as a release note.
