### PR TITLE
fix(wiki-management): broken wiki link + empty people queue

### DIFF
--- a/wiki/src/app/settings/people/page.tsx
+++ b/wiki/src/app/settings/people/page.tsx
@@ -32,7 +32,7 @@ export default function SettingsPeoplePage() {
         <p style={{ ...T.bodySmall, color: "var(--destructive)" }}>
           Failed to load pending people. Try refreshing the page.
         </p>
-      ) : !data?.people?.length ? (
+      ) : !data?.persons?.length ? (
         <div
           style={{
             padding: "48px 16px",
@@ -57,7 +57,7 @@ export default function SettingsPeoplePage() {
             overflow: "hidden",
           }}
         >
-          {data.people.map((person) => (
+          {data.persons.map((person) => (
             <PersonRow
               key={person.lookupKey}
               person={person}

--- a/wiki/src/components/settings/WikiRow.tsx
+++ b/wiki/src/components/settings/WikiRow.tsx
@@ -90,7 +90,7 @@ export function WikiRow({ wiki, onRegenSuccess, onRegenError }: Props) {
     >
       <div style={{ minWidth: 0 }}>
         <Link
-          href={`/wiki/${wiki.slug}`}
+          href={`/wiki/${wiki.id}`}
           style={{
             ...T.body,
             fontWeight: 500,

--- a/wiki/src/hooks/usePendingPersons.ts
+++ b/wiki/src/hooks/usePendingPersons.ts
@@ -30,7 +30,7 @@ export interface PendingPerson {
 }
 
 interface PendingPersonsResponse {
-  people: PendingPerson[]
+  persons: PendingPerson[]
 }
 
 export function usePendingPersons() {
@@ -42,7 +42,7 @@ export function usePendingPersons() {
       })
       if (res.status === 404) {
         // Stream P not yet merged — surface as empty rather than error.
-        return { people: [] }
+        return { persons: [] }
       }
       if (!res.ok) {
         const text = await res.text().catch(() => '')


### PR DESCRIPTION
## Summary

Two small contract bugs in the existing `/settings` admin surfaces that mean any deployment with pending people, or any operator clicking through to a wiki from the settings row, sees broken UI.

### 1. `/settings/people` always renders the empty state

`GET /admin/people?status=pending` returns `{ persons: [...], total }` (matching the field name used by the table and by the `list_pending_persons` MCP tool). The frontend hook expected `{ people: [...] }`, so `data.people` was permanently `undefined` and the page always rendered the "no pending people" empty state even when the queue had rows.

Fix: rename the hook's response field to `persons`.

### 2. `/settings/wikis` row link 404s

The wiki row in `WikiRow.tsx` linked to `/wiki/${wiki.slug}`. The wiki detail route resolves by `lookupKey` (exposed on the list response as `id`), so the slug-based URL 404s. Every other call site in the codebase (Sidebar, BrowseByType, RecentlyUpdated, FeaturedArticle, CollectionsHome) already uses `id`/`lookupKey` — this was a one-off mistake.

Fix: link by `wiki.id`.

## Test plan

- [ ] On a deployment with a verified-disabled person sitting in the queue (`auto_accept_persons = false`), navigate to `/settings/people` — pending rows render with Approve / Reject controls.
- [ ] On `/settings/wikis`, click any wiki name — lands on `/wiki/<id>` instead of 404.

Pure wiki-workspace changes, no Core touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
