### PR TITLE
fix(sidecar): resolve [[kind:slug]] tokens that appear only in infobox rows

### DIFF
--- a/core/src/lib/wikiSidecar.test.ts
+++ b/core/src/lib/wikiSidecar.test.ts
@@ -153,4 +153,33 @@ describe('buildSidecar', () => {
     })
     expect(result.infobox).toBeNull()
   })
+
+  it('resolves [[wiki:slug]] tokens that appear only inside infobox row values', async () => {
+    // Regression: a wiki whose body never references a sibling wiki but whose
+    // infobox does (e.g. a "Contradicts" row) used to render the raw token
+    // because resolveRefs only walked input.content. The infobox tokens now
+    // contribute to the refs map alongside body tokens.
+    const deps = makeDeps({
+      resolveRef: vi.fn(async (kind, slug) =>
+        kind === 'wiki' && slug === 'other-belief' ? wikiRef('other-belief') : null
+      ),
+    })
+    const infobox: WikiInfobox = {
+      rows: [
+        { label: 'Strength', value: 'provisional', valueKind: 'text' },
+        {
+          label: 'Contradicts',
+          value: '[[wiki:other-belief]]',
+          valueKind: 'ref',
+        },
+      ],
+    }
+    const result = await buildSidecar({
+      content: '# Body with no cross-refs',
+      deps,
+      metadata: { infobox },
+    })
+    expect(result.refs).toEqual({ 'wiki:other-belief': wikiRef('other-belief') })
+    expect(deps.resolveRef).toHaveBeenCalledWith('wiki', 'other-belief')
+  })
 })

--- a/core/src/lib/wikiSidecar.ts
+++ b/core/src/lib/wikiSidecar.ts
@@ -90,12 +90,22 @@ function parseSections(content: string): WikiSection[] {
 /**
  * Resolve every parsed token to a WikiRef, deduplicated on `${kind}:${slug}`.
  * Unknown slugs drop silently — render-side falls back to raw token text.
+ *
+ * Scans both the wiki body content and any infobox row values, so an
+ * infobox-only ref (e.g. a `Contradicts: [[wiki:other-belief]]` row whose
+ * token never appears in the body) still resolves into the refs map. Without
+ * this, the renderer's fallback prints the raw `[[wiki:slug]]` token to
+ * users.
  */
 async function resolveRefs(
   content: string,
+  infobox: WikiInfobox | null,
   deps: SidecarDeps
 ): Promise<Record<string, WikiRef>> {
-  const parsed = parseWikiLinks(content)
+  const infoboxText = infobox
+    ? '\n' + infobox.rows.map((row) => row.value).join('\n')
+    : ''
+  const parsed = parseWikiLinks(content + infoboxText)
   const refs: Record<string, WikiRef> = {}
   const seen = new Set<string>()
 
@@ -151,12 +161,12 @@ function pickInfobox(input: SidecarInputs): WikiInfobox | null {
 }
 
 export async function buildSidecar(input: SidecarInputs): Promise<SidecarOutputs> {
-  const refs = await resolveRefs(input.content, input.deps)
+  const infobox = pickInfobox(input)
+  const refs = await resolveRefs(input.content, infobox, input.deps)
   const sections = await attachCitations(
     parseSections(input.content),
     input.citationDeclarations,
     input.deps
   )
-  const infobox = pickInfobox(input)
   return { refs, sections, infobox }
 }


### PR DESCRIPTION
## Summary

`buildSidecar`'s `resolveRefs` walked only the wiki body content (`input.content`), so a `[[kind:slug]]` token that appeared solely inside an infobox row value — e.g. a `Contradicts: [[wiki:other-belief]]` row whose target is never cited in the body — never made it into the resolved `refs` map. The frontend's `renderInfoboxValue` fell through to its raw-text branch and printed the literal `[[wiki:slug]]` to users.

### Symptom

Authenticated wiki page on a two-host Robin deployment, infobox `Contradicts` row rendering verbatim:

```
Contradicts: [[wiki:the-realistic-ai-scenario-for-gbs-is-jobs-changing]]
```

instead of a clickable chip.

### Root cause

`core/src/lib/wikiSidecar.ts:154` (pre-fix):

```ts
const refs = await resolveRefs(input.content, input.deps)
```

`resolveRefs` parsed tokens only from `input.content`. Any token living exclusively inside `input.metadata?.infobox?.rows[*].value` was invisible to the resolver. The frontend renderer correctly handed each row to `renderInfoboxValue`, which correctly looked up the token in the refs map, missed, and returned the raw value.

### Fix

`resolveRefs` now takes the resolved `infobox` alongside `content`, concatenates the row values into the token-parse input, and otherwise behaves identically (same deduplication, same kind-scoping, same silent drop on unknown slugs). `buildSidecar` resolves the infobox first so it can pass it through.

Tokens that *do* appear in the body keep working unchanged — they get parsed once, deduped by `${kind}:${slug}`, and resolved once.

## Test plan

- [x] New regression test in `wikiSidecar.test.ts`: wiki with no body cross-refs but an infobox row value `[[wiki:other-belief]]` now resolves into the refs map.
- [x] All existing `wikiSidecar.test.ts` tests pass (12 total).
- [x] `core/` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
