### PR TITLE
fix(wiki): restore Safari click target on inline citation superscripts

### DIFF
--- a/wiki/src/app/globals.css
+++ b/wiki/src/app/globals.css
@@ -1214,6 +1214,7 @@ input:focus {
 
 /* ─── Citations (.cite) ────────────────────────────────────── */
 sup.cite {
+  position: relative; /* Safari: aligns hit-test box with visual position for super-offset elements */
   font-size: 11px;
   line-height: 0;
   vertical-align: super;


### PR DESCRIPTION
position: relative aligns Safari's hit-test box with the visual position of super-offset elements — without it the [1][2] links are visually present but not clickable in Safari.

## Summary

<!--
Lead with user impact. The PR title and this body double as release notes,
so write them as if a user is skimming the changelog. Screenshots or short
clips are welcome for UI changes.
-->

## Related issues

<!--
Link any related GitHub issues. Use "closes #<n>", "fixes #<n>", or
"resolves #<n>" to auto-close on merge.
-->

## How to test

<!--
Steps a reviewer can follow locally. Note any env vars, migrations, or
seed data required.
-->

## Checklist

- [ ] I have run and reviewed this code locally.
- [ ] `pnpm typecheck` passes.
- [ ] `pnpm lint` passes.
- [ ] Tests added or updated where applicable, and `pnpm test` passes.
- [ ] Database migrations included if the schema changed.
- [ ] Screenshots or recordings attached for UI changes.
- [ ] PR title follows the conventional-commit style and reads as a release note.
