### PR TITLE
structured authorship attribution for entries and fragments

### DIFF
--- a/.claude/skills/log-to-robin/SKILL.md
+++ b/.claude/skills/log-to-robin/SKILL.md
@@ -262,8 +262,11 @@ Do not gatekeep — the user decides. But make sure it's a conscious decision.
 
 Call whichever you chose during the mode-specific path:
 
-- **`Robin:log_entry`** — pass the structured content string and `source: "mcp"`. Robin handles fragmentation and cross-wiki routing.
-- **`Robin:log_fragment`** — pass the content and the target wiki's `threadSlug` (still called `threadSlug` even though Robin renamed thread → wiki everywhere else). Lands directly in that wiki, no routing.
+- **`Robin:log_entry`** — pass `content`, `source: "mcp"`, and structured metadata:
+  - `type` — infer from content: `article` for written pieces with a byline, `transcript` for multi-speaker conversations, `email` for messages with a From header, `document` for uploaded files, `thought` for personal reflections (default).
+  - `authors` — extract from attribution: pass as an array of names (e.g. `["Sarah Mwangi", "Barzan Mozafari"]`). Do NOT put attribution only in the content text — pass it as this parameter so Robin can create structured authorship edges.
+  - Robin handles fragmentation and cross-wiki routing.
+- **`Robin:log_fragment`** — pass the content, the target wiki's `threadSlug`, and optionally `authors`. Lands directly in that wiki, no routing.
 
 The decision was made in **Quick · Step C** or implicitly during Mining curation. If you got here without making it, go back and make it — don't pick by default mid-call.
 

--- a/core/src/lib/authorship.ts
+++ b/core/src/lib/authorship.ts
@@ -1,0 +1,251 @@
+import { eq } from 'drizzle-orm'
+import { makeLookupKey } from '@robin/shared'
+import type { DB } from '../db/client.js'
+import { edges, people } from '../db/schema.js'
+import { insertExtractedPerson } from './people-settings.js'
+
+type AuthorshipRole = 'byline' | 'quoted'
+
+interface AuthorEdgeAttrs {
+  role: AuthorshipRole
+  evidence: string | null
+  extractionMethod: 'deterministic' | 'llm' | 'inherited' | 'regex'
+  confidence: number
+}
+
+async function insertAuthorEdge(
+  db: DB,
+  params: {
+    srcType: 'raw_source' | 'fragment'
+    srcId: string
+    personKey: string
+    attrs: AuthorEdgeAttrs
+  }
+): Promise<void> {
+  const edgeType =
+    params.srcType === 'raw_source' ? 'ENTRY_AUTHORED_BY_PERSON' : 'FRAGMENT_AUTHORED_BY_PERSON'
+  await db
+    .insert(edges)
+    .values({
+      id: crypto.randomUUID(),
+      srcType: params.srcType,
+      srcId: params.srcId,
+      dstType: 'person',
+      dstId: params.personKey,
+      edgeType,
+      attrs: params.attrs as unknown as Record<string, unknown>,
+    })
+    .onConflictDoNothing()
+}
+
+async function loadOwnerPersonKey(db: DB): Promise<string | null> {
+  const [row] = await db
+    .select({ lookupKey: people.lookupKey })
+    .from(people)
+    .where(eq(people.isOwner, true))
+    .limit(1)
+  return row?.lookupKey ?? null
+}
+
+/**
+ * Explicitly-provided authors at capture time (e.g. from MCP `authors` param).
+ * Finds or creates a pending Person row for each name, then writes
+ * ENTRY_AUTHORED_BY_PERSON edges. Called synchronously before the extraction
+ * job is enqueued so attribution is immediate.
+ */
+export async function applyExplicitAuthors(
+  db: DB,
+  srcType: 'raw_source' | 'fragment',
+  srcId: string,
+  authorNames: string[]
+): Promise<void> {
+  for (const name of authorNames) {
+    const trimmed = name.trim()
+    if (!trimmed) continue
+
+    const [existing] = await db
+      .select({ lookupKey: people.lookupKey })
+      .from(people)
+      .where(eq(people.canonicalName, trimmed))
+      .limit(1)
+
+    const personKey = existing?.lookupKey ?? makeLookupKey('person')
+
+    if (!existing) {
+      await insertExtractedPerson(db, {
+        lookupKey: personKey,
+        canonicalName: trimmed,
+        status: 'pending',
+        createdVia: 'extractor_pending',
+        extractedFromFragmentId: srcType === 'fragment' ? srcId : null,
+      })
+    }
+
+    await insertAuthorEdge(db, {
+      srcType,
+      srcId,
+      personKey,
+      attrs: { role: 'byline', evidence: null, extractionMethod: 'deterministic', confidence: 1.0 },
+    })
+  }
+}
+
+/**
+ * `thought` entries: owner is the sole author.
+ * Creates ENTRY_AUTHORED_BY_PERSON + inherited FRAGMENT_AUTHORED_BY_PERSON for all fragments.
+ */
+export async function applyThoughtAuthorship(
+  db: DB,
+  entryKey: string,
+  fragmentKeys: string[]
+): Promise<void> {
+  const ownerKey = await loadOwnerPersonKey(db)
+  if (!ownerKey) return
+
+  await insertAuthorEdge(db, {
+    srcType: 'raw_source',
+    srcId: entryKey,
+    personKey: ownerKey,
+    attrs: { role: 'byline', evidence: null, extractionMethod: 'deterministic', confidence: 1.0 },
+  })
+
+  for (const fragKey of fragmentKeys) {
+    await insertAuthorEdge(db, {
+      srcType: 'fragment',
+      srcId: fragKey,
+      personKey: ownerKey,
+      attrs: { role: 'byline', evidence: null, extractionMethod: 'inherited', confidence: 1.0 },
+    })
+  }
+}
+
+/**
+ * Parse the From: header out of raw email content.
+ * Returns the best-guess display name, or null if no header found.
+ */
+export function parseFromHeader(content: string): string | null {
+  const match = content.match(/^From:\s*(?:"?([^"<\r\n]+?)"?\s+)?<?([^>\r\n]+@[^>\r\n]+)>?/mi)
+  if (!match) return null
+  const name = match[1]?.trim()
+  const email = match[2]?.trim()
+  if (name && name.length > 0) return name
+  if (email) return email.split('@')[0] ?? null
+  return null
+}
+
+/**
+ * `email` entries: sender from the From: header is the author.
+ * Creates a pending Person row if the sender isn't already in the graph.
+ */
+export async function applyEmailAuthorship(
+  db: DB,
+  entryKey: string,
+  content: string,
+  fragmentKeys: string[]
+): Promise<void> {
+  const senderName = parseFromHeader(content)
+  if (!senderName) return
+
+  const [existing] = await db
+    .select({ lookupKey: people.lookupKey })
+    .from(people)
+    .where(eq(people.canonicalName, senderName))
+    .limit(1)
+
+  const personKey = existing?.lookupKey ?? makeLookupKey('person')
+
+  if (!existing) {
+    await insertExtractedPerson(db, {
+      lookupKey: personKey,
+      canonicalName: senderName,
+      status: 'pending',
+      createdVia: 'extractor_pending',
+      extractedFromFragmentId: null,
+    })
+  }
+
+  await insertAuthorEdge(db, {
+    srcType: 'raw_source',
+    srcId: entryKey,
+    personKey,
+    attrs: { role: 'byline', evidence: null, extractionMethod: 'regex', confidence: 0.9 },
+  })
+
+  for (const fragKey of fragmentKeys) {
+    await insertAuthorEdge(db, {
+      srcType: 'fragment',
+      srcId: fragKey,
+      personKey,
+      attrs: { role: 'byline', evidence: null, extractionMethod: 'inherited', confidence: 0.9 },
+    })
+  }
+}
+
+/**
+ * `article` / `transcript` / `document` entries: Elfie-detected authorship.
+ *
+ * - byline mentions  → ENTRY_AUTHORED_BY_PERSON
+ * - quoted mentions  → FRAGMENT_AUTHORED_BY_PERSON for the fragment whose
+ *                      content contains the source span
+ * - unmatched frags  → if 1 byline: inherit; if 2+ bylines: apply ALL authors;
+ *                      if 0 bylines: no edges (blank is fine)
+ */
+export async function applyElfieAuthorship(
+  db: DB,
+  entryKey: string,
+  authorshipMentions: Array<{ personKey: string; role: 'byline' | 'quoted'; sourceSpan: string; mention: string }>,
+  fragmentContents: Array<{ key: string; content: string }>
+): Promise<void> {
+  if (authorshipMentions.length === 0) return
+
+  const bylines = authorshipMentions.filter((m) => m.role === 'byline')
+  const quotes = authorshipMentions.filter((m) => m.role === 'quoted')
+
+  for (const b of bylines) {
+    await insertAuthorEdge(db, {
+      srcType: 'raw_source',
+      srcId: entryKey,
+      personKey: b.personKey,
+      attrs: { role: 'byline', evidence: b.sourceSpan, extractionMethod: 'llm', confidence: 1.0 },
+    })
+  }
+
+  const attributedFragKeys = new Set<string>()
+
+  for (const q of quotes) {
+    for (const frag of fragmentContents) {
+      if (frag.content.includes(q.sourceSpan) || frag.content.includes(q.mention)) {
+        await insertAuthorEdge(db, {
+          srcType: 'fragment',
+          srcId: frag.key,
+          personKey: q.personKey,
+          attrs: { role: 'quoted', evidence: q.sourceSpan, extractionMethod: 'llm', confidence: 1.0 },
+        })
+        attributedFragKeys.add(frag.key)
+        break
+      }
+    }
+  }
+
+  for (const frag of fragmentContents) {
+    if (attributedFragKeys.has(frag.key)) continue
+
+    if (bylines.length === 1) {
+      await insertAuthorEdge(db, {
+        srcType: 'fragment',
+        srcId: frag.key,
+        personKey: bylines[0].personKey,
+        attrs: { role: 'byline', evidence: null, extractionMethod: 'inherited', confidence: 1.0 },
+      })
+    } else if (bylines.length > 1) {
+      for (const b of bylines) {
+        await insertAuthorEdge(db, {
+          srcType: 'fragment',
+          srcId: frag.key,
+          personKey: b.personKey,
+          attrs: { role: 'byline', evidence: null, extractionMethod: 'inherited', confidence: 1.0 },
+        })
+      }
+    }
+  }
+}

--- a/core/src/mcp/handlers.ts
+++ b/core/src/mcp/handlers.ts
@@ -36,6 +36,7 @@ import type { PeopleExtractionOutput } from '@robin/shared'
 import { resolveOrDrop } from '@robin/agent'
 import { loadAutoAcceptPersons } from '../lib/people-settings.js'
 import { loadPendingPeople } from '../lib/people-settings.js'
+import { applyExplicitAuthors } from '../lib/authorship.js'
 import type { BullMQProducer, ExtractionJob } from '@robin/queue'
 import { resolveEntrySlug, resolveFragmentSlug, resolveWikiSlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateEntry, findDuplicateFragment } from '../db/dedup.js'
@@ -159,6 +160,10 @@ export async function handleLogEntry(
   input: {
     content: string
     source?: 'mcp' | 'api' | 'web'
+    type?: 'thought' | 'article' | 'transcript' | 'email' | 'document'
+    /** Names of people who wrote or said this content. Creates pending Person
+     *  rows and ENTRY_AUTHORED_BY_PERSON edges immediately at capture time. */
+    authors?: string[]
     /**
      * MCP `clientInfo` payload (Stream C / C2). Persisted to
      * `entries.source_client` jsonb. NULL when the caller is the legacy
@@ -205,10 +210,14 @@ export async function handleLogEntry(
       title,
       content: trimmed,
       dedupHash: hash,
-      type: 'thought',
+      type: input.type ?? 'thought',
       source: entrySource,
       sourceClient: input.sourceClient ?? null,
     })
+
+    if (input.authors && input.authors.length > 0) {
+      await applyExplicitAuthors(deps.db, 'raw_source', entryKey, input.authors)
+    }
 
     const job: ExtractionJob = {
       type: 'extraction',
@@ -272,6 +281,9 @@ export async function handleLogFragment(
     threadSlug: string
     title?: string
     tags?: string[]
+    /** Names of people who wrote or said this fragment. Creates pending Person
+     *  rows and FRAGMENT_AUTHORED_BY_PERSON edges immediately at capture time. */
+    authors?: string[]
     /**
      * MCP `clientInfo` payload (Stream C / C2). After Stream V the
      * fragments table carries its own `source_client text` column
@@ -487,6 +499,10 @@ export async function handleLogFragment(
           attrs,
         })
         .onConflictDoNothing()
+    }
+
+    if (input.authors && input.authors.length > 0) {
+      await applyExplicitAuthors(deps.db, 'fragment', fragKey, input.authors)
     }
 
     // Stream P: new persons are inserted by `resolveOrDrop` via the

--- a/core/src/mcp/server.ts
+++ b/core/src/mcp/server.ts
@@ -100,12 +100,14 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
       inputSchema: {
         content: z.string().describe('The text content to log'),
         source: z.enum(['mcp', 'api', 'web']).optional().describe('Origin of the entry'),
+        type: z.enum(['thought', 'article', 'transcript', 'email', 'document']).optional().describe('Content type — defaults to thought'),
+        authors: z.array(z.string()).optional().describe('Names of the people who wrote or said this content (e.g. ["Sarah Mwangi", "Chris Okoth"])'),
       },
     },
-    async ({ content, source }, extra) => {
+    async ({ content, source, type, authors }, extra) => {
       return handleLogEntry(
         deps,
-        { content, source, sourceClient: (deps.getClientInfo?.() as { [key: string]: unknown; name: string; version?: string } | undefined) ?? null },
+        { content, source, type, authors, sourceClient: (deps.getClientInfo?.() as { [key: string]: unknown; name: string; version?: string } | undefined) ?? null },
         extra.authInfo?.clientId as string
       )
     }
@@ -125,12 +127,13 @@ export function createMcpServer(deps: McpServerDeps): McpServer {
           .describe('Exact wiki slug to attach to (from list_wikis or get_wiki)'),
         title: z.string().optional().describe('Fragment title (derived from content if omitted)'),
         tags: z.array(z.string()).optional().describe('Optional tags'),
+        authors: z.array(z.string()).optional().describe('Names of the people who wrote or said this (e.g. ["Sarah Mwangi"])'),
       },
     },
-    async ({ content, threadSlug, title, tags }, extra) => {
+    async ({ content, threadSlug, title, tags, authors }, extra) => {
       return handleLogFragment(
         deps,
-        { content, threadSlug, title, tags, sourceClient: (deps.getClientInfo?.() as { [key: string]: unknown; name: string; version?: string } | undefined) ?? null },
+        { content, threadSlug, title, tags, authors, sourceClient: (deps.getClientInfo?.() as { [key: string]: unknown; name: string; version?: string } | undefined) ?? null },
         extra.authInfo?.clientId as string
       )
     }

--- a/core/src/queue/worker.ts
+++ b/core/src/queue/worker.ts
@@ -61,6 +61,11 @@ import {
   loadAutoAcceptPersons,
   insertExtractedPerson,
 } from '../lib/people-settings.js'
+import {
+  applyThoughtAuthorship,
+  applyEmailAuthorship,
+  applyElfieAuthorship,
+} from '../lib/authorship.js'
 import { producer } from './producer.js'
 import { processRegenJob, processRegenBatchJob } from './regen-worker.js'
 import { processEmbeddingRetryJob } from './embedding-retry-worker.js'
@@ -435,13 +440,37 @@ async function processExtractionJob(job: ExtractionJob): Promise<JobResult> {
     },
   }
 
+  // Look up entry type from DB — the entry is pre-created by the route/MCP
+  // handler before the job is enqueued, so this is always safe.
+  const [entryRow] = await db
+    .select({ type: entries.type })
+    .from(entries)
+    .where(eq(entries.lookupKey, job.entryKey))
+    .limit(1)
+  const entryType = entryRow?.type ?? 'thought'
+
   try {
     const result = await runExtraction(deps, {
       entryKey: job.entryKey,
       content: job.content,
       source: job.source,
       jobId: job.jobId,
+      entryType,
     })
+
+    // Authorship edges — fail-open so a broken authorship lookup never
+    // poisons an otherwise-successful extraction job.
+    try {
+      if (entryType === 'thought') {
+        await applyThoughtAuthorship(db, job.entryKey, result.fragmentKeys)
+      } else if (entryType === 'email') {
+        await applyEmailAuthorship(db, job.entryKey, job.content, result.fragmentKeys)
+      } else {
+        await applyElfieAuthorship(db, job.entryKey, result.authorshipMentions, result.fragmentContents)
+      }
+    } catch (authorshipErr) {
+      log.warn({ jobId: job.jobId, entryKey: job.entryKey, err: authorshipErr }, 'authorship edge creation failed (non-fatal)')
+    }
 
     await db
       .update(entries)

--- a/core/src/routes/entries.ts
+++ b/core/src/routes/entries.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono'
-import { eq, and, desc, isNull } from 'drizzle-orm'
+import { eq, and, desc, isNull, inArray } from 'drizzle-orm'
 import { zValidator } from '@hono/zod-validator'
 import { sessionMiddleware } from '../middleware/session.js'
 import { producer } from '../queue/producer.js'
 import { db } from '../db/client.js'
-import { entries as entriesTable, fragments } from '../db/schema.js'
+import { entries as entriesTable, fragments, edges, people } from '../db/schema.js'
 import { makeLookupKey, parseLookupKey, generateSlug } from '@robin/shared'
 import { resolveEntrySlug } from '../db/slug.js'
 import { computeContentHash, findDuplicateEntry } from '../db/dedup.js'
@@ -137,12 +137,36 @@ entries.get('/:id', async (c) => {
     derivedInfobox: null,
   })
 
+  const authorEdges = await db
+    .select({ dstId: edges.dstId, attrs: edges.attrs })
+    .from(edges)
+    .where(and(eq(edges.srcId, id), eq(edges.edgeType, 'ENTRY_AUTHORED_BY_PERSON'), isNull(edges.deletedAt)))
+
+  const authors: { personKey: string; name: string; role: string }[] = []
+  if (authorEdges.length > 0) {
+    const personKeys = authorEdges.map((e) => e.dstId)
+    const personRows = await db
+      .select({ lookupKey: people.lookupKey, name: people.name })
+      .from(people)
+      .where(inArray(people.lookupKey, personKeys))
+    const personMap = new Map(personRows.map((p) => [p.lookupKey, p.name]))
+    for (const e of authorEdges) {
+      const attrs = e.attrs as Record<string, unknown> | null
+      authors.push({
+        personKey: e.dstId,
+        name: personMap.get(e.dstId) ?? e.dstId,
+        role: typeof attrs?.role === 'string' ? attrs.role : 'byline',
+      })
+    }
+  }
+
   return c.json(
     entryResponseSchema.parse({
       ...entry,
       id: entry.lookupKey,
       refs: sidecar.refs,
       sections: sidecar.sections,
+      authors,
     })
   )
 })

--- a/core/src/routes/fragments.ts
+++ b/core/src/routes/fragments.ts
@@ -166,6 +166,30 @@ fragmentsRouter.get('/:id', async (c) => {
     relatedFragments.sort((a, b) => b.similarity - a.similarity)
   }
 
+  // Resolve FRAGMENT_AUTHORED_BY_PERSON edges
+  const authorEdges = await db
+    .select({ dstId: edges.dstId, attrs: edges.attrs })
+    .from(edges)
+    .where(and(eq(edges.srcId, id), eq(edges.edgeType, 'FRAGMENT_AUTHORED_BY_PERSON'), isNull(edges.deletedAt)))
+
+  const authors: { personKey: string; name: string; role: string }[] = []
+  if (authorEdges.length > 0) {
+    const personKeys = authorEdges.map((e) => e.dstId)
+    const personRows = await db
+      .select({ lookupKey: people.lookupKey, name: people.name })
+      .from(people)
+      .where(inArray(people.lookupKey, personKeys))
+    const personMap = new Map(personRows.map((p) => [p.lookupKey, p.name]))
+    for (const e of authorEdges) {
+      const attrs = e.attrs as Record<string, unknown> | null
+      authors.push({
+        personKey: e.dstId,
+        name: personMap.get(e.dstId) ?? e.dstId,
+        role: typeof attrs?.role === 'string' ? attrs.role : 'byline',
+      })
+    }
+  }
+
   return c.json(
     fragmentDetailResponseSchema.parse({
       ...fragment,
@@ -173,6 +197,7 @@ fragmentsRouter.get('/:id', async (c) => {
       content: fragment.content ?? '',
       backlinks,
       relatedFragments,
+      authors,
     })
   )
 })

--- a/core/src/schemas/entries.schema.ts
+++ b/core/src/schemas/entries.schema.ts
@@ -17,6 +17,9 @@ export const entryResponseSchema = z.object({
   attemptCount: z.number().optional(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
+  authors: z.array(
+    z.object({ personKey: z.string(), name: z.string(), role: z.string() })
+  ).default([]),
 })
 
 export const entryCreatedResponseSchema = entryResponseSchema.extend({

--- a/core/src/schemas/fragments.schema.ts
+++ b/core/src/schemas/fragments.schema.ts
@@ -38,6 +38,13 @@ export const fragmentDetailResponseSchema = fragmentWithContentResponseSchema.ex
       similarity: z.number(),
     })
   ).default([]),
+  authors: z.array(
+    z.object({
+      personKey: z.string(),
+      name: z.string(),
+      role: z.string(),
+    })
+  ).default([]),
 })
 
 export const fragmentListResponseSchema = z.object({

--- a/packages/agent/src/stages/entity-extract.ts
+++ b/packages/agent/src/stages/entity-extract.ts
@@ -121,6 +121,7 @@ interface EntityExtractInput {
   content: string
   entryKey: string
   jobId: string
+  entryType?: string
 }
 
 export async function entityExtract(
@@ -158,6 +159,7 @@ export async function entityExtract(
   const spec = loadPeopleExtractionSpec({
     content: input.content,
     knownPeople: knownPeopleJson,
+    entryType: input.entryType,
   })
 
   // 4. Call LLM (returns Zod-validated output, accepts both v3 buckets
@@ -264,6 +266,29 @@ export async function entityExtract(
     }
   }
 
+  // Build authorshipMentions by correlating resolved outcomes back to bucket roles.
+  const mentionToRole = new Map<string, 'byline' | 'quoted' | 'mentioned'>()
+  for (const m of buckets.matched) {
+    if (m.authorshipRole) mentionToRole.set(m.mention, m.authorshipRole)
+  }
+  for (const c of buckets.candidates) {
+    if (c.authorshipRole) mentionToRole.set(c.mention, c.authorshipRole)
+  }
+
+  const authorshipMentions: EntityExtractResult['authorshipMentions'] = []
+  for (const outcome of outcomes) {
+    if (outcome.kind === 'dropped') continue
+    const role = mentionToRole.get(outcome.mention)
+    if (role === 'byline' || role === 'quoted') {
+      authorshipMentions.push({
+        personKey: outcome.lookupKey,
+        role,
+        sourceSpan: outcome.sourceSpan.text,
+        mention: outcome.mention,
+      })
+    }
+  }
+
   const denominator = rawMentionsSeen
   const dropRatePct =
     denominator > 0
@@ -297,6 +322,7 @@ export async function entityExtract(
       newAliases,
       extractions: matchedExtractions,
       newPeople,
+      authorshipMentions,
     },
     durationMs: Date.now() - start,
   }

--- a/packages/agent/src/stages/index.ts
+++ b/packages/agent/src/stages/index.ts
@@ -37,6 +37,13 @@ export interface ExtractionResult {
   entryKey: string
   fragmentKeys: string[]
   personKeys: string[]
+  authorshipMentions: Array<{
+    personKey: string
+    role: 'byline' | 'quoted'
+    sourceSpan: string
+    mention: string
+  }>
+  fragmentContents: Array<{ key: string; content: string }>
 }
 
 /**
@@ -110,6 +117,7 @@ export async function runExtraction(
           content: input.content,
           entryKey: input.entryKey,
           jobId: input.jobId,
+          entryType: input.entryType,
         }),
       ])
 
@@ -174,6 +182,11 @@ export async function runExtraction(
         entryKey: input.entryKey,
         fragmentKeys: persistResult.data.fragmentKeys,
         personKeys: entityResult ? Array.from(entityResult.peopleMap.values()) : [],
+        authorshipMentions: entityResult?.authorshipMentions ?? [],
+        fragmentContents: persistResult.data.fragmentKeys.map((key, i) => ({
+          key,
+          content: fragResult.data.fragments[i]?.content ?? '',
+        })),
       }
     }
   )

--- a/packages/agent/src/stages/types.ts
+++ b/packages/agent/src/stages/types.ts
@@ -21,6 +21,7 @@ export interface ExtractionInput {
   entryKey: string
   source: string
   jobId: string
+  entryType?: string
 }
 
 export interface LinkingInput {
@@ -239,5 +240,13 @@ export interface EntityExtractResult {
     verified: boolean
     /** Stream P quarantine status, surfaced for telemetry only. */
     status?: 'verified' | 'pending'
+  }>
+  /** Elfie-detected byline and quoted mentions. Worker uses these to create
+   *  ENTRY_AUTHORED_BY_PERSON (byline) and FRAGMENT_AUTHORED_BY_PERSON (quoted) edges. */
+  authorshipMentions: Array<{
+    personKey: string
+    role: 'byline' | 'quoted'
+    sourceSpan: string
+    mention: string
   }>
 }

--- a/packages/shared/src/prompts/loaders/people-extraction.ts
+++ b/packages/shared/src/prompts/loaders/people-extraction.ts
@@ -6,11 +6,13 @@ import type { PromptResult } from '../types.js'
 const inputSchema = z.object({
   content: z.string(),
   knownPeople: z.string().optional(),
+  entryType: z.string().optional(),
 })
 
 export function loadPeopleExtractionSpec(vars: {
   content: string
   knownPeople?: string
+  entryType?: string
 }): PromptResult {
   const validated = inputSchema.parse(vars)
   const spec = loadSpec('people-extraction.yaml')

--- a/packages/shared/src/prompts/specs/people-extraction.schema.ts
+++ b/packages/shared/src/prompts/specs/people-extraction.schema.ts
@@ -14,12 +14,15 @@ import { z } from 'zod'
  * passthrough is filled in by code on top of the schema, not the
  * schema itself, to keep input and output types matching.
  */
+const authorshipRoleSchema = z.enum(['byline', 'quoted', 'mentioned']).optional()
+
 const matchedMentionSchema = z.object({
   mention: z.string(),
   inferredName: z.string(),
   matchedKey: z.string(),
   confidence: z.number(),
   sourceSpan: z.string(),
+  authorshipRole: authorshipRoleSchema,
 })
 
 const candidateMentionSchema = z.object({
@@ -27,6 +30,7 @@ const candidateMentionSchema = z.object({
   inferredName: z.string(),
   confidence: z.number(),
   sourceSpan: z.string(),
+  authorshipRole: authorshipRoleSchema,
 })
 
 const legacyMentionSchema = z.object({

--- a/packages/shared/src/prompts/specs/people-extraction.yaml
+++ b/packages/shared/src/prompts/specs/people-extraction.yaml
@@ -64,8 +64,25 @@ template: |
   7. Do NOT match organizations, teams, or groups, only individuals.
   8. Generic references ("someone", "people", "they" without
      antecedent) are NOT person-like and should be skipped.
-  9. Authorship for first-person pronouns is handled downstream by
-     the classifier's [AUTHORSHIP] block, leave I/me/my alone.
+  9. Leave I/me/my alone. Authorship for first-person pronouns is
+     handled downstream — never resolve them here.
+  10. For each mention, set authorshipRole if the context makes it
+      unambiguous:
+      - byline: the person wrote or authored this whole piece (appears
+        in a byline, "by [Name]", or clear authorship credit).
+      - quoted: the person is explicitly attributed as the speaker of
+        this passage ("said", "told", "stated", "according to",
+        "claims", or a speaker label like "Chris:").
+      - mentioned: appears in the text but neither author nor speaker.
+      Omit authorshipRole when context does not clearly indicate a
+      role — silence beats a wrong assignment.
+
+  {{#if entryType}}
+  [ENTRY TYPE HINT]
+  This content is a {{entryType}}. Use this to inform authorshipRole
+  detection: look for byline patterns in articles, speaker labels in
+  transcripts.
+  {{/if}}
 
   [REINFORCEMENT]
   Remember: you are Elfie the surfacer. Spurious matches corrupt the
@@ -83,6 +100,8 @@ template: |
     without explicit text-side evidence linking them.
   - Returning the author/owner via first-person pronouns; that is
     handled downstream.
+  - Setting authorshipRole when context is ambiguous. Omit it rather
+    than guessing.
 
   [TEXT TO PROCESS]
   {{content}}
@@ -97,6 +116,11 @@ input_variables:
     description: >
       JSON array of known people with key, canonicalName, and aliases
       for matching. Empty when no people exist yet.
+    required: false
+  - name: entryType
+    description: >
+      Optional content type hint (thought/email/article/transcript/document)
+      to guide authorshipRole detection.
     required: false
 
 output:
@@ -134,3 +158,17 @@ few_shot_examples:
       knownPeople: '[]'
     output: >
       {"matched": [], "candidates": []}
+  - input: >
+      content: "By Sarah Mwangi. Professor Doe stated inflation will hit 5%."
+      knownPeople: '[]'
+      entryType: "article"
+    output: >
+      {"matched": [], "candidates": [
+        {"mention": "Sarah Mwangi", "inferredName": "Sarah Mwangi",
+         "confidence": 0.9, "sourceSpan": "By Sarah Mwangi",
+         "authorshipRole": "byline"},
+        {"mention": "Professor Doe", "inferredName": "Professor Doe",
+         "confidence": 0.8,
+         "sourceSpan": "Professor Doe stated inflation will hit 5%",
+         "authorshipRole": "quoted"}
+      ]}

--- a/wiki/src/app/(shell)/entries/[id]/page.tsx
+++ b/wiki/src/app/(shell)/entries/[id]/page.tsx
@@ -118,6 +118,7 @@ export default function EntryPage() {
         type: entry.type,
         source: entry.source,
         createdAt: formatDate(entry.createdAt),
+        authors: (entry as unknown as { authors?: Array<{ personKey: string; name: string; role: string }> }).authors,
       }}
       body={
         <MarkdownContent

--- a/wiki/src/app/(shell)/fragments/[id]/page.tsx
+++ b/wiki/src/app/(shell)/fragments/[id]/page.tsx
@@ -24,6 +24,7 @@ type FragmentData = Omit<FragmentWithContentResponseSchema, "entryId"> & {
   entryId: string | null;
   backlinks?: Array<{ id: string; name: string; type: string; bouncerMode?: string }>;
   relatedFragments?: Array<{ id: string; slug: string; title: string; similarity: number }>;
+  authors?: Array<{ personKey: string; name: string; role: string }>;
 };
 
 function formatDate(iso: string) {
@@ -68,6 +69,13 @@ function FragmentInfobox({ fragment }: { fragment: FragmentData }) {
         alignSelf: "flex-start",
       }}
     >
+      {fragment.authors && fragment.authors.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <p style={label}>Authors</p>
+          <p style={body}>{fragment.authors.map((a) => a.name).join(", ")}</p>
+        </div>
+      )}
+
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <p style={label}>Type</p>
         <p style={body}>{fragment.type}</p>
@@ -399,6 +407,7 @@ function FragmentReviewActions({ fragmentId, backlinks }: { fragmentId: string; 
 export default function FragmentPage() {
   const { id } = useParams<{ id: string }>();
   const { data: fragment, isLoading, error } = useFragment(id);
+  const queryClient = useQueryClient();
 
   const bodyStyle = {
     ...T.bodySmall,
@@ -427,7 +436,6 @@ export default function FragmentPage() {
 
   const frag = fragment as FragmentData;
   const backlinks = frag.backlinks ?? [];
-  const queryClient = useQueryClient();
 
   const handleSaveToApi = async (data: { title: string; chipLabel: string; content: string }) => {
     try {

--- a/wiki/src/components/wiki/EntryArticle.tsx
+++ b/wiki/src/components/wiki/EntryArticle.tsx
@@ -54,10 +54,14 @@ export type EntryInfoboxProps = {
   type: string;
   source: string;
   createdAt: string;
+  authors?: Array<{ personKey: string; name: string; role: string }>;
 };
 
-export function EntryInfobox({ type, source, createdAt }: EntryInfoboxProps) {
+export function EntryInfobox({ type, source, createdAt, authors }: EntryInfoboxProps) {
   const rows: { label: string; value: string }[] = [
+    ...(authors && authors.length > 0
+      ? [{ label: "Authors", value: authors.map((a) => a.name).join(", ") }]
+      : []),
     { label: "Type", value: type },
     { label: "Source", value: source },
     { label: "Created", value: createdAt },


### PR DESCRIPTION
- Elfie (ElfieTheExtractor) gains rule 10: authorshipRole field on every mention,
  optional entryType hint for better byline/quoted detection in articles and
  transcripts; first-person pronouns left alone at extraction time (speaker
  labels and bylines are the reliable signal)
- New authorship.ts module handles three deterministic paths: thought (owner),
  email (From header), and Elfie-detected (articles/transcripts) with multi-author apply-all for fragments where the speaker is ambiguous
- ENTRY_AUTHORED_BY_PERSON and FRAGMENT_AUTHORED_BY_PERSON edge types wired
  through the extraction worker; fragment inheritance and quoted-speaker matching by source span
- log_entry and log_fragment MCP tools accept authors (array) and type params;
  explicit authors create edges synchronously at capture time before the extraction job queues
- Fragment and entry API endpoints return resolved author names; entry and
  fragment detail pages show an Authors row in the metadata box
- Fix hooks-order violation in FragmentPage (useQueryClient hoisted before
  early returns)

## Summary

<!--
Lead with user impact. The PR title and this body double as release notes,
so write them as if a user is skimming the changelog. Screenshots or short
clips are welcome for UI changes.
-->

## Related issues

<!--
Link any related GitHub issues. Use "closes #<n>", "fixes #<n>", or
"resolves #<n>" to auto-close on merge.
-->

## How to test

<!--
Steps a reviewer can follow locally. Note any env vars, migrations, or
seed data required.
-->

## Checklist

- [ ] I have run and reviewed this code locally.
- [ ] `pnpm typecheck` passes.
- [ ] `pnpm lint` passes.
- [ ] Tests added or updated where applicable, and `pnpm test` passes.
- [ ] Database migrations included if the schema changed.
- [ ] Screenshots or recordings attached for UI changes.
- [ ] PR title follows the conventional-commit style and reads as a release note.
