### PR TITLE
fix(wiki): open collapsed <details> on Safari when an inline citation is clicked

### DIFF
--- a/wiki/src/app/(shell)/wiki/[id]/page.tsx
+++ b/wiki/src/app/(shell)/wiki/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useWiki } from "@/hooks/useWiki";
 import { useRegenerateWiki } from "@/hooks/useRegenerateWiki";
 import { useDeleteWiki } from "@/hooks/useDeleteWiki";
+import { useDetailsAnchorOpener } from "@/lib/useDetailsAnchorOpener";
 import { useQueryClient } from "@tanstack/react-query";
 import DestructiveConfirmDialog from "@/components/prompts/DestructiveConfirmDialog";
 import SectionEditor from "@/components/editor/SectionEditor";
@@ -173,6 +174,11 @@ function HtmlWikiBody({
 export default function WikiDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
+  // Open any collapsed <details> (Citations, Mentioned People) when a
+  // #fragment-<lookupKey> hash targets a row inside one. Safari does
+  // not auto-open <details> on internal-anchor navigation; without
+  // this, clicking a citation footnote silently fails on Safari.
+  useDetailsAnchorOpener();
   const { data: _wiki, isLoading, error } = useWiki(id);
   // Extend generated type with fields added in #128 (bouncerMode, edgeStatus)
   // until the OpenAPI codegen picks them up from the live spec

--- a/wiki/src/lib/useDetailsAnchorOpener.ts
+++ b/wiki/src/lib/useDetailsAnchorOpener.ts
@@ -36,15 +36,28 @@ export function useDetailsAnchorOpener(): void {
       const target = document.getElementById(id)
       if (!target) return
 
-      // Walk up through every ancestor <details>, opening each. The
-      // direct `closest('details')` handles the one-level case; the
-      // loop handles deeper nesting in case a future surface wraps
-      // a citation row inside more than one collapsible.
+      // Walk up through every ancestor <details>, opening any that are
+      // currently closed. The direct `closest('details')` handles the
+      // one-level case; the loop handles deeper nesting.
+      //
+      // Track whether we actually opened anything. If every ancestor
+      // was already open, the browser has already handled this anchor
+      // navigation natively (Chrome / Edge / newer Firefox), so we
+      // skip the explicit scroll to avoid a flicker on top of the
+      // browser's native scroll. We only intervene when there was a
+      // closed disclosure hiding the target — which is the Safari
+      // case this hook exists for.
+      let openedAny = false
       let cursor: HTMLElement | null = target.closest('details')
       while (cursor instanceof HTMLDetailsElement) {
-        cursor.open = true
+        if (!cursor.open) {
+          cursor.open = true
+          openedAny = true
+        }
         cursor = cursor.parentElement?.closest('details') ?? null
       }
+
+      if (!openedAny) return
 
       requestAnimationFrame(() => {
         target.scrollIntoView({ behavior: 'smooth', block: 'start' })

--- a/wiki/src/lib/useDetailsAnchorOpener.ts
+++ b/wiki/src/lib/useDetailsAnchorOpener.ts
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Open any ancestor `<details>` elements when an anchor target inside
+ * them is referenced via `window.location.hash`.
+ *
+ * Why this exists: the wiki detail page renders its Citations list
+ * inside a collapsed `<details>` (so the footnote section doesn't
+ * dominate the chrome). Each `<li>` carries `id="fragment-{lookupKey}"`
+ * so the `[N]` superscript anchors in the body can jump to the row.
+ *
+ * Chrome auto-opens an enclosing `<details>` when an anchor inside it
+ * is targeted via hash navigation. **Safari does not.** The result:
+ * clicking a citation footnote on Safari changes the URL hash but the
+ * page does nothing — the target `<li>` is hidden inside the closed
+ * `<details>`, so there's nothing to scroll to.
+ *
+ * The hook runs:
+ *  - Once on mount, so deep-linking to `/wiki/abc#fragment-xyz` works.
+ *  - On every `hashchange` event, so in-page citation clicks work.
+ *
+ * After opening the details, scroll is deferred one animation frame so
+ * the layout shift from the now-expanded section settles before
+ * `scrollIntoView` measures.
+ */
+export function useDetailsAnchorOpener(): void {
+  useEffect(() => {
+    function openAndScrollToHash() {
+      if (typeof window === 'undefined') return
+      const hash = window.location.hash
+      if (!hash || hash.length < 2) return
+
+      const id = hash.slice(1)
+      const target = document.getElementById(id)
+      if (!target) return
+
+      // Walk up through every ancestor <details>, opening each. The
+      // direct `closest('details')` handles the one-level case; the
+      // loop handles deeper nesting in case a future surface wraps
+      // a citation row inside more than one collapsible.
+      let cursor: HTMLElement | null = target.closest('details')
+      while (cursor instanceof HTMLDetailsElement) {
+        cursor.open = true
+        cursor = cursor.parentElement?.closest('details') ?? null
+      }
+
+      requestAnimationFrame(() => {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    }
+
+    openAndScrollToHash()
+    window.addEventListener('hashchange', openAndScrollToHash)
+    return () => window.removeEventListener('hashchange', openAndScrollToHash)
+  }, [])
+}


### PR DESCRIPTION
## Summary

Builds on PR #417 (which fixed the Safari click-target hit-test for `sup.cite`). With that landed, clicks on `[N]` superscripts in Safari now register and the URL hash changes — but the page **still doesn't scroll**.

Reason: the wiki detail page wraps its Citations list in a collapsed `<details>`. The `<li id="fragment-{lookupKey}">` rows live *inside* that closed disclosure.

- **Chrome** auto-opens an enclosing `<details>` when an anchor inside it is targeted via hash navigation. It expands, then scrolls.
- **Safari does not.** The target is hidden, so there's nothing to scroll to and nothing visible happens.

### Symptom

Wiki body has inline citation superscripts like `[3]`. Click in Safari:
1. URL hash updates to `#fragment-frag01KT23VA2KDH4NDM462VZFRF0T`
2. Page does not scroll
3. Citations section stays collapsed
4. User has no visual feedback that anything happened

### Repro

Open any published wiki on Safari, click a `[N]` superscript in the body. Chrome behaves correctly on the same page.

### Root cause

`wiki/src/app/(shell)/wiki/[id]/page.tsx:608-630` renders the Citations list inside `<details>`. The default-collapsed state hides every `<li id="fragment-...">`. Safari's anchor-scroll behaviour does not auto-expand `<details>`; Chrome's does.

### Fix

A small `useDetailsAnchorOpener` hook in `wiki/src/lib/`. On mount and on every `hashchange` event:

1. Read the current hash, look up `document.getElementById(hash.slice(1))`.
2. Walk ancestor `<details>` from the target and set `open = true` on each.
3. `requestAnimationFrame(() => target.scrollIntoView(...))` so the layout shift from expansion settles before measuring.

Called once at the top of `WikiDetailPage`. Browser-agnostic — Chrome already does this natively, so the hook is a no-op there. Safari now matches Chrome's behaviour.

## Test plan

- [ ] On Safari: open a wiki with citations, click any `[N]` superscript in the body. Citations section expands; page scrolls to the matching footnote.
- [ ] On Chrome: same flow still works (no regression).
- [ ] Deep link directly to `/wiki/<id>#fragment-<lookupKey>` in Safari: page mounts, Citations expands, scrolls to the row. (Tests the on-mount path, not just hashchange.)
- [ ] Click the same citation footnote again: no-op (already open and in view).

Wiki-workspace only, no Core changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
