### PR TITLE
fix regen when type is change

### DIFF
--- a/core/src/routes/wikis.agent-schema-loop.test.ts
+++ b/core/src/routes/wikis.agent-schema-loop.test.ts
@@ -361,6 +361,9 @@ describe('PUT /wikis/:id — agent_schema refresh on description change (#69 D6,
 // take the cached-partition path (regen.ts) and short-circuit on an empty
 // diff, leaving the old type's content in place. Clearing lastRebuiltAt
 // routes the next regen through the first-regen full-synthesis path instead.
+// dirtySince is stamped alongside it so editorialStateOf reads 'learning'
+// (new content awaiting regen) rather than 'empty' (never regenned) while
+// the old content is still on display.
 
 describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt', () => {
   beforeEach(() => {
@@ -388,6 +391,7 @@ describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt',
     expect(setArg.type).toBe('log')
     expect(setArg.state).toBe('PENDING')
     expect(setArg.lastRebuiltAt).toBeNull()
+    expect(setArg.dirtySince).toBeInstanceOf(Date)
   })
 
   it('marks PENDING and clears lastRebuiltAt when prompt changes', async () => {
@@ -408,6 +412,7 @@ describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt',
     const setArg = updateChain.set.mock.calls[0][0]
     expect(setArg.state).toBe('PENDING')
     expect(setArg.lastRebuiltAt).toBeNull()
+    expect(setArg.dirtySince).toBeInstanceOf(Date)
   })
 
   it('marks PENDING and clears lastRebuiltAt when structure changes', async () => {
@@ -428,9 +433,10 @@ describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt',
     const setArg = updateChain.set.mock.calls[0][0]
     expect(setArg.state).toBe('PENDING')
     expect(setArg.lastRebuiltAt).toBeNull()
+    expect(setArg.dirtySince).toBeInstanceOf(Date)
   })
 
-  it('does not touch state or lastRebuiltAt when type is set to its current value', async () => {
+  it('does not touch state, lastRebuiltAt, or dirtySince when type is set to its current value', async () => {
     const existing = makeWiki({ type: 'log', lastRebuiltAt: new Date() })
     const updated = makeWiki({ type: 'log' })
     mockDbSelect
@@ -450,5 +456,6 @@ describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt',
     const setArg = updateChain.set.mock.calls[0][0]
     expect(setArg.state).toBeUndefined()
     expect(setArg.lastRebuiltAt).toBeUndefined()
+    expect(setArg.dirtySince).toBeUndefined()
   })
 })

--- a/core/src/routes/wikis.agent-schema-loop.test.ts
+++ b/core/src/routes/wikis.agent-schema-loop.test.ts
@@ -353,3 +353,102 @@ describe('PUT /wikis/:id — agent_schema refresh on description change (#69 D6,
     expect(optionsArg.alsoStaleHyde).toBe(true)
   })
 })
+
+// ── PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt ─────
+//
+// A type/prompt/structure change marks the wiki PENDING so the next regen
+// rebuilds it. Without also clearing lastRebuiltAt, that regen would still
+// take the cached-partition path (regen.ts) and short-circuit on an empty
+// diff, leaving the old type's content in place. Clearing lastRebuiltAt
+// routes the next regen through the first-regen full-synthesis path instead.
+
+describe('PUT /wikis/:id — type/prompt/structure changes reset lastRebuiltAt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks PENDING and clears lastRebuiltAt when type changes', async () => {
+    const existing = makeWiki({ type: 'decision', lastRebuiltAt: new Date() })
+    const updated = makeWiki({ type: 'log', state: 'PENDING', lastRebuiltAt: null })
+    mockDbSelect
+      .mockReturnValueOnce(selectChainMock([existing]))
+      .mockReturnValueOnce(selectChainMock([{ slug: 'log' }]))
+    const updateChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'log' }),
+    })
+
+    expect(res.status).toBe(200)
+    const setArg = updateChain.set.mock.calls[0][0]
+    expect(setArg.type).toBe('log')
+    expect(setArg.state).toBe('PENDING')
+    expect(setArg.lastRebuiltAt).toBeNull()
+  })
+
+  it('marks PENDING and clears lastRebuiltAt when prompt changes', async () => {
+    const existing = makeWiki({ prompt: 'old prompt', lastRebuiltAt: new Date() })
+    const updated = makeWiki({ prompt: 'new prompt', state: 'PENDING', lastRebuiltAt: null })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([existing]))
+    const updateChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'new prompt' }),
+    })
+
+    expect(res.status).toBe(200)
+    const setArg = updateChain.set.mock.calls[0][0]
+    expect(setArg.state).toBe('PENDING')
+    expect(setArg.lastRebuiltAt).toBeNull()
+  })
+
+  it('marks PENDING and clears lastRebuiltAt when structure changes', async () => {
+    const existing = makeWiki({ structure: 'old skeleton', lastRebuiltAt: new Date() })
+    const updated = makeWiki({ structure: 'new skeleton', state: 'PENDING', lastRebuiltAt: null })
+    mockDbSelect.mockReturnValueOnce(selectChainMock([existing]))
+    const updateChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ structure: 'new skeleton' }),
+    })
+
+    expect(res.status).toBe(200)
+    const setArg = updateChain.set.mock.calls[0][0]
+    expect(setArg.state).toBe('PENDING')
+    expect(setArg.lastRebuiltAt).toBeNull()
+  })
+
+  it('does not touch state or lastRebuiltAt when type is set to its current value', async () => {
+    const existing = makeWiki({ type: 'log', lastRebuiltAt: new Date() })
+    const updated = makeWiki({ type: 'log' })
+    mockDbSelect
+      .mockReturnValueOnce(selectChainMock([existing]))
+      .mockReturnValueOnce(selectChainMock([{ slug: 'log' }]))
+    const updateChain = updateChainMock([updated])
+    mockDbUpdate.mockReturnValueOnce(updateChain)
+
+    const app = createApp()
+    const res = await app.request('/wikis/wiki01TEST', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'log' }),
+    })
+
+    expect(res.status).toBe(200)
+    const setArg = updateChain.set.mock.calls[0][0]
+    expect(setArg.state).toBeUndefined()
+    expect(setArg.lastRebuiltAt).toBeUndefined()
+  })
+})

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -586,19 +586,34 @@ wikisRouter.put('/:id', zValidator('json', updateWikiBodySchema, validationHook)
   if (body.description != null) updates.description = body.description
   if (body.type != null) {
     updates.type = body.type
-    // Type change affects wiki generation — mark PENDING so regen rebuilds with new type's prompt
-    if (body.type !== existing.type) updates.state = 'PENDING'
+    // Type change affects wiki generation — mark PENDING and clear
+    // lastRebuiltAt so the next regen takes the first-regen full-synthesis
+    // path (regen.ts) instead of the empty-partition short-circuit, which
+    // would otherwise leave the old type's content in place untouched.
+    if (body.type !== existing.type) {
+      updates.state = 'PENDING'
+      updates.lastRebuiltAt = null
+    }
   }
   if (body.prompt != null) {
     updates.prompt = body.prompt
-    // Prompt change affects wiki generation — mark PENDING so regen rebuilds with new prompt
-    if (body.prompt !== existing.prompt) updates.state = 'PENDING'
+    // Prompt change affects wiki generation — mark PENDING and clear
+    // lastRebuiltAt so the next regen rebuilds with the new prompt via
+    // full synthesis (see type-change comment above).
+    if (body.prompt !== existing.prompt) {
+      updates.state = 'PENDING'
+      updates.lastRebuiltAt = null
+    }
   }
   // Document-structure override (#244). Sibling of `prompt`; same PENDING
-  // semantics on change so the next regen rebuilds against the new skeleton.
+  // + lastRebuiltAt-reset semantics on change so the next regen rebuilds
+  // against the new skeleton via full synthesis.
   if (body.structure != null) {
     updates.structure = body.structure
-    if (body.structure !== existing.structure) updates.state = 'PENDING'
+    if (body.structure !== existing.structure) {
+      updates.state = 'PENDING'
+      updates.lastRebuiltAt = null
+    }
   }
   // T4-bundle (v0.2.2): autoregen flag now editable via the unified PUT body.
   if (body.autoregen != null) updates.autoregen = body.autoregen

--- a/core/src/routes/wikis.ts
+++ b/core/src/routes/wikis.ts
@@ -590,9 +590,13 @@ wikisRouter.put('/:id', zValidator('json', updateWikiBodySchema, validationHook)
     // lastRebuiltAt so the next regen takes the first-regen full-synthesis
     // path (regen.ts) instead of the empty-partition short-circuit, which
     // would otherwise leave the old type's content in place untouched.
+    // Also stamp dirtySince so editorialStateOf reads 'learning' (new
+    // content awaiting regen) rather than 'empty' (never regenned) while
+    // the old content is still on display.
     if (body.type !== existing.type) {
       updates.state = 'PENDING'
       updates.lastRebuiltAt = null
+      updates.dirtySince = new Date()
     }
   }
   if (body.prompt != null) {
@@ -603,6 +607,7 @@ wikisRouter.put('/:id', zValidator('json', updateWikiBodySchema, validationHook)
     if (body.prompt !== existing.prompt) {
       updates.state = 'PENDING'
       updates.lastRebuiltAt = null
+      updates.dirtySince = new Date()
     }
   }
   // Document-structure override (#244). Sibling of `prompt`; same PENDING
@@ -613,6 +618,7 @@ wikisRouter.put('/:id', zValidator('json', updateWikiBodySchema, validationHook)
     if (body.structure !== existing.structure) {
       updates.state = 'PENDING'
       updates.lastRebuiltAt = null
+      updates.dirtySince = new Date()
     }
   }
   // T4-bundle (v0.2.2): autoregen flag now editable via the unified PUT body.


### PR DESCRIPTION
- set lastRebuiltAt to null when the type of wiki is changed so a wiki is regenerated as the new type instead of persisting the existing data

## Summary

<!--
Lead with user impact. The PR title and this body double as release notes,
so write them as if a user is skimming the changelog. Screenshots or short
clips are welcome for UI changes.
-->

## Related issues

<!--
Link any related GitHub issues. Use "closes #<n>", "fixes #<n>", or
"resolves #<n>" to auto-close on merge.
-->

## How to test

<!--
Steps a reviewer can follow locally. Note any env vars, migrations, or
seed data required.
-->

## Checklist

- [x] I have run and reviewed this code locally.
- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes.
- [x] Tests added or updated where applicable, and `pnpm test` passes.
- [ ] Database migrations included if the schema changed.
- [ ] Screenshots or recordings attached for UI changes.
- [x] PR title follows the conventional-commit style and reads as a release note.
